### PR TITLE
Require iDynTree v1.1.0 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   vcpkg_robotology_TAG: v0.0.3
   YCM_TAG: v0.11.0
   YARP_TAG: 964bb26fa4791d83d72882711ea7509306248106
-  iDynTree_TAG: v1.0.5
+  iDynTree_TAG: v1.1.0
   Catch2_TAG: v2.11.3
 
 jobs:


### PR DESCRIPTION
This PR is required to fix the windows compilation on CI. Please check [here](https://github.com/dic-iit/bipedal-locomotion-framework/runs/752263574)

Associated PR: https://github.com/robotology/idyntree/pull/672