### PR TITLE
Add FloatingBaseEstimator skeleton class 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The **BipedalLocomotionFramework** project is a _suite_ of libraries for achievi
 - [**BipedalLocomotion::ParametersHandler**](./src/ParametersHandler): Library for
   retrieving parameters from configuration files and not only
 - [**BipedalLocomotion::Estimators**](./src/Estimators): Library containing observers
+- [**BipedalLocomotion::FloatingBaseEstimators**](./src/Estimators): Library containing floating base estimators 
 - [**BipedalLocomotion::Planner**](./src/Planner): Library containing planner useful for locomotion
 
 
@@ -41,7 +42,7 @@ file. Please note that the indicated version is the the minimum required version
     - For testing:
       - [`Catch2`](https://github.com/catchorg/Catch2)
 
-- `Estimators` requires:
+- `Estimators` and `FloatingBaseEstimators` require:
     - For using it:
       - [`iDynTree`](https://github.com/robotology/idyntree) (version 0.11.105)
       - [`ParametersHandler`](./src/ParametersHandler)

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -4,10 +4,18 @@
 
 if(FRAMEWORK_COMPILE_Estimators)
 
+  set(H_PREFIX include/BipedalLocomotion/Estimators)
   add_bipedal_locomotion_library(
     NAME                   Estimators
     SOURCES                src/RecursiveLeastSquare.cpp
-    PUBLIC_HEADERS         include/BipedalLocomotion/Estimators/RecursiveLeastSquare.h
+    PUBLIC_HEADERS         ${H_PREFIX}/RecursiveLeastSquare.h
     SUBDIRECTORIES         tests
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::System Eigen3::Eigen)
+
+  add_bipedal_locomotion_library(
+    NAME                   FloatingBaseEstimators
+    SOURCES                src/FloatingBaseEstimator.cpp
+    PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h
+    PUBLIC_LINK_LIBRARIES  iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen)
+
 endif()

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimator.h
@@ -226,18 +226,6 @@ protected:
     virtual bool updateKinematics(const FloatingBaseEstimators::Measurements& meas,
                                   const double& dt) { return true; };
 
-   /**
-   * Update the states and the associated covariance using the Kalman gain and the innovations (in an EKF based implementation)
-   * @note this function should be called from within updateKinematics in an EKF base implementation, otherwise left unused
-   * @param[in] innovation innovation vector
-   * @param[in] measurement_model_jacobian discrete-time measurement model Jacobian
-   * @param[in] measurement_noise_var discrete-time measurement noise covariance matrix
-   * @return bool
-   */
-   virtual bool updateStates(const Eigen::VectorXd& innovation,
-                             const Eigen::MatrixXd& measurement_model_jacobian,
-                             const Eigen::MatrixXd& measurement_noise_var) { return true; };
-
     ModelComputations m_model_comp; /**< Model computations object */
     FloatingBaseEstimators::Options m_options; /**< Struct holding estimator options */
     FloatingBaseEstimators::Measurements m_meas; /**< Struct holding the latest measurements that were set to the estimator */

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimator.h
@@ -33,6 +33,7 @@ namespace Estimators
 class FloatingBaseEstimator : public BipedalLocomotion::System::Advanceable<FloatingBaseEstimators::Output>
 {
 public:
+    virtual ~FloatingBaseEstimator() { };
     /**
     *  iDynTree based model-specific computations class
     *  This is class is used in a required configuration step for the estimator
@@ -51,19 +52,19 @@ public:
 
         /**
         * Set base link name and name of the IMU rigidly attached to the IMU
-        * @param[in] base_link_frame name of the base link frame
-        * @param[in] imu_frame name of the IMU frame
+        * @param[in] baseLinkFrame name of the base link frame
+        * @param[in] imuFrame name of the IMU frame
         * @return True in case of success, false otherwise.
         */
-        bool setBaseLinkAndIMU(const std::string& base_link_frame, const std::string& imu_frame);
+        bool setBaseLinkAndIMU(const std::string& baseLinkFrame, const std::string& imuFrame);
 
         /**
         * Set the feet contact frames, expected to be in contact with the environment
-        * @param[in] l_foot_contact_frame left foot contact frame
-        * @param[in] r_foot_contact_frame right foot contact frame
+        * @param[in] lFootContactFrame left foot contact frame
+        * @param[in] rFootContactFrame right foot contact frame
         * @return True in case of success, false otherwise.
         */
-        bool setFeetContactFrames(const std::string& l_foot_contact_frame, const std::string& r_foot_contact_frame);
+        bool setFeetContactFrames(const std::string& lFootContactFrame, const std::string& rFootContactFrame);
 
         /**
         * Check if model is configured with the required information
@@ -97,29 +98,28 @@ public:
         /**
          * Getters
          */
-        const int& nrJoints() const { return m_nr_joints; }
-        const std::string& baseLink() const { return m_base_link; }
-        const std::string& baseLinkIMU() const { return m_base_imu_frame; }
-        const std::string& leftFootContactFrame() const { return m_l_foot_contact_frame; }
-        const std::string& rightFootContactFrame() const { return m_r_foot_contact_frame; }
+        const int& nrJoints() const { return m_nrJoints; }
+        const std::string& baseLink() const { return m_baseLink; }
+        const std::string& baseLinkIMU() const { return m_baseImuFrame; }
+        const std::string& leftFootContactFrame() const { return m_lFootContactFrame; }
+        const std::string& rightFootContactFrame() const { return m_rFootContactFrame; }
         const iDynTree::Transform& base_H_IMU() const { return m_base_H_imu; }
-        const bool& isModelSet() const { return m_model_set; }
+        const bool& isModelSet() const { return m_modelSet; }
 
     private:
-        std::string m_base_link{""}; /**< name of the floating base link*/
-        std::string m_base_imu_frame{""}; /**< name of the IMU frame rigidly attached to the floating base link*/
-        std::string m_l_foot_contact_frame{""}; /**< name of the left foot contact frame expected to be in contact with the environment*/
-        std::string m_r_foot_contact_frame{""}; /**< name of the right foot contact frame expected to be in contact with the environment*/
-        iDynTree::FrameIndex m_base_link_idx{iDynTree::FRAME_INVALID_INDEX}; /**< base link's frame index in the loaded model*/
-        iDynTree::FrameIndex m_base_imu_idx{iDynTree::FRAME_INVALID_INDEX}; /**< IMU index in the loaded model*/
-        iDynTree::FrameIndex m_l_foot_contact_idx{iDynTree::FRAME_INVALID_INDEX}; /**< Left foot contact frame index in the loaded model*/
-        iDynTree::FrameIndex m_r_foot_contact_idx{iDynTree::FRAME_INVALID_INDEX}; /**< Right foot contact freame index in the loaded model*/
+        std::string m_baseLink{""}; /**< name of the floating base link*/
+        std::string m_baseImuFrame{""}; /**< name of the IMU frame rigidly attached to the floating base link*/
+        std::string m_lFootContactFrame{""}; /**< name of the left foot contact frame expected to be in contact with the environment*/
+        std::string m_rFootContactFrame{""}; /**< name of the right foot contact frame expected to be in contact with the environment*/
+        iDynTree::FrameIndex m_baseLinkIdx{iDynTree::FRAME_INVALID_INDEX}; /**< base link's frame index in the loaded model*/
+        iDynTree::FrameIndex m_baseImuIdx{iDynTree::FRAME_INVALID_INDEX}; /**< IMU index in the loaded model*/
+        iDynTree::FrameIndex m_lFootContactIdx{iDynTree::FRAME_INVALID_INDEX}; /**< Left foot contact frame index in the loaded model*/
+        iDynTree::FrameIndex m_rFootContactIdx{iDynTree::FRAME_INVALID_INDEX}; /**< Right foot contact freame index in the loaded model*/
 
         iDynTree::KinDynComputations m_kindyn; /**< KinDynComputations object to do the model specific computations */
-        iDynTree::Model m_model; /**< Loaded reduced model */
         iDynTree::Transform m_base_H_imu; /**< Rigid body transform of IMU frame with respect to the base link frame */
-        int m_nr_joints{0}; /**< number of joints in the loaded reduced model */
-        bool m_model_set{false};
+        int m_nrJoints{0}; /**< number of joints in the loaded reduced model */
+        bool m_modelSet{false};
     };
 
 
@@ -141,30 +141,30 @@ public:
 
     /**
     * Set the polled IMU measurement
-    * @param[in] acc_meas linear accelerometer measurement expressed in the local IMU frame (m/s^2)
-    * @param[in] gyro_meas gyroscope measurement expressed in the local IMU frame (rad/s)
+    * @param[in] accMeas linear accelerometer measurement expressed in the local IMU frame (m/s^2)
+    * @param[in] gyroMeas gyroscope measurement expressed in the local IMU frame (rad/s)
     * @return True in case of success, false otherwise.
     */
-    bool setIMUMeasurement(const Eigen::Vector3d& acc_meas,
-                           const Eigen::Vector3d& gyro_meas);
+    bool setIMUMeasurement(const Eigen::Vector3d& accMeas,
+                           const Eigen::Vector3d& gyroMeas);
 
     /**
     * Set feet contact states
-    * @param[in] lf_in_contact left foot contact state [0, 1]
-    * @param[in] rf_in_contact right foot contact state [0, 1]
+    * @param[in] lfInContact left foot contact state [0, 1]
+    * @param[in] rfInContact right foot contact state [0, 1]
     * @return True in case of success, false otherwise.
     */
-    bool setContacts(const bool& lf_in_contact, const bool& rf_in_contact);
+    bool setContacts(const bool& lfInContact, const bool& rfInContact);
 
     /**
     * Set kinematic measurements
     * @note it is assumed that the order of the joints loaded in the model and the order of the measurements in these vectors match
     * @param[in] encoders joint positions measured through encoders
-    * @param[in] encoder_speeds joint velocities measured through encoders
+    * @param[in] encoderSpeeds joint velocities measured through encoders
     * @return True in case of success, false otherwise.
     */
     bool setKinematics(const Eigen::VectorXd& encoders,
-                       const Eigen::VectorXd& encoder_speeds);
+                       const Eigen::VectorXd& encoderSpeeds);
 
     /**
     * Compute one step of the estimator
@@ -182,7 +182,7 @@ public:
     * Determines the validity of the object retrieved with get()
     * @return True in case of success, false otherwise.
     */
-    virtual bool isValid() const final { return (m_estimator_state == State::Running); };
+    virtual bool isValid() const final { return (m_estimatorState == State::Running); };
 
     /**
     * Get ModelComputations object by reference
@@ -201,6 +201,14 @@ protected:
 
     /**
     * These custom parameter specifications should be specified by the derived class.
+    * - If setupOptions() is called from within customInitialization(), ensure the group "Options" exist.
+    *   Please check the documentation of setupOptions() for relevant parameters
+    * - If setupSensorDevs() is called from within customInitialization(), ensure the group "SensorsStdDev" exist.
+    *   Please check the documentation of setupSensorDevs() for relevant parameters
+    * - If setupInitialStates() is called from within customInitialization(), ensure the group "InitialStates" exist.
+    *   Please check the documentation of setupInitialStates() for relevant parameters
+    * - If setupPriorDevs() is called from within customInitialization(), ensure the group "PriorsStdDev" exist.
+    *   Please check the documentation of setupPriorDevs() for relevant parameters
     * @param[in] handler configure the custom parameters for the estimator
     * @return bool
     */
@@ -226,26 +234,94 @@ protected:
     virtual bool updateKinematics(const FloatingBaseEstimators::Measurements& meas,
                                   const double& dt) { return true; };
 
-    ModelComputations m_model_comp; /**< Model computations object */
+    /**
+    * Setup estimator options. The parameters in the Options group are,
+    * - enable_imu_bias_estimation [PARAMETER|-|Enable/disable IMU bias estimation]
+    * - enable_static_imu_bias_initialization [PARAMETER|-|Enable/disable IMU bias initialization assuming static configuration]
+    * - nr_samples_for_imu_bias_initialization [PARAMETER|REQUIRED, if staticImuBiasInitializationEnabled is set to true|Number of samples for static bias initialization]
+    * - enable_ekf_update [PARAMETER|-|Enable/disable update step of EKF (not recommended to set to false)]
+    * - acceleration_due_to_gravity [PARAMETER|-|Acceleration due to gravity, 3d vector]
+    * @note this is a recipe method that can be called by the derived class from within customInitialization()
+    * @param[in] handler parameter handler
+    * @return True in case of success, false otherwise.
+    */
+    bool setupOptions(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+    /**
+    * Setup measurement noise standard deviations The parameters in the SensorsStdDev group are,
+    * - accelerometer_measurement_noise_std_dev [PARAMETER|REQUIRED|Accelerometer measurement white noise deviation]
+    * - gyroscope_measurement_noise_std_dev [PARAMETER|REQUIRED|Gyroscope measurement white noise deviation]
+    * - accelerometer_measurement_bias_noise_std_dev [PARAMETER|REQUIRED, if imuBiasEstimationEnabled is set to true|Accelerometer measurement bias noise deviation]
+    * - gyroscope_measurement_bias_noise_std_dev [PARAMETER|REQUIRED, if imuBiasEstimationEnabled is set to true|Gyroscope measurement bias noise deviation]
+    * - contact_foot_linear_velocity_noise_std_dev [PARAMETER|REQUIRED|Linear velocity white noise deviation when foot is in contact]
+    * - contact_foot_angular_velocity_noise_std_dev [PARAMETER|REQUIRED|Angular velocity white noise deviation when foot is in contact]
+    * - swing_foot_linear_velocity_noise_std_dev [PARAMETER|REQUIRED|Linear velocity white noise deviation when foot is swinging off contact]
+    * - swing_foot_angular_velocity_noise_std_dev [PARAMETER|REQUIRED|Angular velocity white noise deviation when foot is swinging off contact]
+    * - forward_kinematic_measurement_noise_std_dev [PARAMETER|REQUIRED|White noise deviation in relative poses computed through forward kinematics]
+    * - encoders_measurement_noise_std_dev [PARAMETER|REQUIRED|Encoder measurement white noise deviation]
+    * @note this is a recipe method that can be called by the derived class from within customInitialization()
+    * @note ensure to call setupOptions() before calling setupSensorDevs() to handle bias related parameters to be configured properly
+    * @param[in] handler parameter handler
+    * @return True in case of success, false otherwise.
+    */
+    bool setupSensorDevs(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+    /**
+    * Setup initial states. The parameters in the InitialStates group are,
+    * - imu_orientation_quaternion_wxyz [PARAMETER|REQUIRED|Initial IMU orientation  wrt inertial frame, as a quaternion]
+    * - imu_position_xyz [PARAMETER|REQUIRED|Initial IMU position wrt inertial frame]
+    * - imu_linear_velocity_xyz [PARAMETER|REQUIRED|Initial IMU linear velocity wrt inertial frame, in a mixed-velocity representation]
+    * - l_contact_frame_orientation_quaternion_wxyz [PARAMETER|REQUIRED|Initial left foot contact frame orientation wrt inertial frame, as a quaternion]
+    * - l_contact_frame_position_xyz [PARAMETER|REQUIRED|Initial left foot contact frame position wrt inertial frame]
+    * - r_contact_frame_orientation_quaternion_wxyz [PARAMETER|REQUIRED|Initial right foot contact frame orientation wrt inertial frame, as a quaternion]
+    * - r_contact_frame_position_xyz [PARAMETER|REQUIRED|Initial right foot contact frame position wrt inertial frame]
+    * - accelerometer_bias [PARAMETER|REQUIRED, if imuBiasEstimationEnabled is set to true|Initial accelerometer bias expressed in IMU frame]
+    * - gyroscope_bias [PARAMETER|REQUIRED, if imuBiasEstimationEnabled is set to true|Initial gyroscope bias expressed in IMU frame]
+    * @note this is a recipe method that can be called by the derived class from within customInitialization()
+    * @note ensure to call setupOptions() before calling setupInitialStates() to handle bias related parameters to be configured properly
+    * @param[in] handler parameter handler
+    * @return True in case of success, false otherwise.
+    */
+    bool setupInitialStates(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+    /**
+    * Setup initial state standard deviations. The parameters in the PriorsStdDev group are,
+    * - imu_orientation_quaternion_wxyz [PARAMETER|REQUIRED|Initial IMU orientation as wrt inertial frame]
+    * - imu_position [PARAMETER|REQUIRED|Initial IMU position deviation wrt inertial frame]
+    * - imu_linear_velocity [PARAMETER|REQUIRED|Initial IMU linear velocity deviation wrt inertial frame, in a mixed-velocity representation]
+    * - l_contact_frame_orientation_quaternion [PARAMETER|REQUIRED|Initial left foot contact frame orientation deviation wrt inertial frame]
+    * - l_contact_frame_position [PARAMETER|REQUIRED|Initial left foot contact frame position deviation wrt inertial frame]
+    * - r_contact_frame_orientation_quaternion [PARAMETER|REQUIRED|Initial right foot contact frame orientation deviation wrt inertial frame]
+    * - r_contact_frame_position [PARAMETER|REQUIRED|Initial right foot contact frame position deviation wrt inertial frame]
+    * - accelerometer_bias [PARAMETER|REQUIRED, if imuBiasEstimationEnabled is set to true|Initial accelerometer bias devitaion expressed in IMU frame]
+    * - gyroscope_bias [PARAMETER|REQUIRED, if imuBiasEstimationEnabled is set to true|Initial gyroscope bias deviation expressed in IMU frame]
+    * @note this is a recipe method that can be called by the derived class from within customInitialization()
+    * @note ensure to call setupOptions() before calling setupPriorDevs() to handle bias related parameters to be configured properly
+    * @param[in] handler parameter handler
+    * @return True in case of success, false otherwise.
+    */
+    bool setupPriorDevs(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+    ModelComputations m_modelComp; /**< Model computations object */
     FloatingBaseEstimators::Options m_options; /**< Struct holding estimator options */
-    FloatingBaseEstimators::Measurements m_meas; /**< Struct holding the latest measurements that were set to the estimator */
-    FloatingBaseEstimators::InternalState m_state, m_state_prev; /**< Structs holding the curent and previous internal states of the estimation algorithm */
-    FloatingBaseEstimators::Output m_estimator_out; /**< Struct holding outputs of the estimator */
-    FloatingBaseEstimators::PriorsStdDev m_priors; /**< Struct holding standard deviations associated to prior state estimates */
-    FloatingBaseEstimators::SensorsStdDev m_sensors_dev; /**< Struct holding standard deviations associated to sensor measurements */
+    FloatingBaseEstimators::Measurements m_meas, m_measPrev; /**< Struct holding the latest measurements that were set to the estimator */
+    FloatingBaseEstimators::InternalState m_state, m_statePrev; /**< Structs holding the curent and previous internal states of the estimation algorithm */
+    FloatingBaseEstimators::Output m_estimatorOut; /**< Struct holding outputs of the estimator */
+    FloatingBaseEstimators::StateStdDev m_priors, m_stateStdDev; /**< Struct holding standard deviations associated to prior state estimates */
+    FloatingBaseEstimators::SensorsStdDev m_sensorsDev; /**< Struct holding standard deviations associated to sensor measurements */
 
     /**
     * Enumerator used to determine the running state of the estimator
     */
     enum class State
     {
-        NotInitialized, /**< The estimator is not initialized yet call RecursiveLeastSquare::initialze
+        NotInitialized, /**< The estimator is not initialized yet call FloatingBaseEstimator::initialze
                            method to initialize it*/
         Initialized,    /**< The estimator is initialized and ready to be used */
         Running         /**< The estimator is running */
     };
 
-    State m_estimator_state{State::NotInitialized}; /**< State of the estimator */
+    State m_estimatorState{State::NotInitialized}; /**< State of the estimator */
 
     double m_dt{0.01}; /**< Fixed time step of the estimator, in seconds */
 
@@ -258,6 +334,18 @@ private:
     */
     bool setupModelParams(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
 
+
+    /**
+     * Setup parameter vector
+     * @param[in] param parameter name
+     * @param[in] prefix print prefix
+     * @param[in] handler parameter handler
+     * @param[out] vec parameter vector
+     * @return True in case of success, false otherwise.
+     */
+    bool setupFixedVectorParamPrivate(const std::string& param, const std::string& prefix,
+                                      std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
+                                      std::vector<double>& vec);
 };
 
 

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimator.h
@@ -1,0 +1,274 @@
+/**
+ * @file FloatingBaseEstimator.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_H
+
+#include <BipedalLocomotion/System/Advanceable.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/Estimators/FloatingBaseEstimatorParams.h>
+#include <BipedalLocomotion/Estimators/FloatingBaseEstimatorIO.h>
+
+#include <iDynTree/Model/Model.h>
+#include <iDynTree/KinDynComputations.h>
+#include <iDynTree/Model/JointState.h>
+#include <iostream>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+
+/**
+*  FloatingBaseEstimator class contains the bare-bones implementation for
+*  a LeggedOdometry based or Extended Kalman Filter based floating base estimation
+*  algorithms for bipedal robots.
+*  @note it is assumed that if an IMU (primary) is specified in the inherited implementation,
+*  then this IMU is rigidly attached to the specified base link in the implementation
+*/
+class FloatingBaseEstimator : public BipedalLocomotion::System::Advanceable<FBEOutput>
+{
+public:
+    /**
+    *  iDynTree based model-specific computations class
+    *  This is class is used in a required configuration step for the estimator
+    *  All the model related kinematics and dynamics computations specific to
+    *  the floating base estimator are contained within this class.
+    */
+    class ModelComputations
+    {
+    public:
+        /**
+        * Set the reduced model
+        * @param[in] model reduced iDynTree model
+        * @return True in case of success, false otherwise.
+        */
+        bool setModel(const iDynTree::Model& model);
+
+        /**
+        * Set base link name and name of the IMU rigidly attached to the IMU
+        * @param[in] base_link_frame name of the base link frame
+        * @param[in] imu_frame name of the IMU frame
+        * @return True in case of success, false otherwise.
+        */
+        bool setBaseLinkAndIMU(const std::string& base_link_frame, const std::string& imu_frame);
+
+        /**
+        * Set the feet contact frames, expected to be in contact with the environment
+        * @param[in] l_foot_contact_frame left foot contact frame
+        * @param[in] r_foot_contact_frame right foot contact frame
+        * @return True in case of success, false otherwise.
+        */
+        bool setFeetContactFrames(const std::string& l_foot_contact_frame, const std::string& r_foot_contact_frame);
+
+        /**
+        * Check if model is configured with the required information
+        * @note this is a required step to initialize the estimator
+        * @return True in case of success, false otherwise.
+        */
+        bool checkModelInfoLoaded();
+
+        /**
+        * Get relative pose between IMU and the feet
+        * @param[in] encoders joint positions through encoder measurements
+        * @param[out] IMU_H_l_foot pose of the left foot contact frame with respect to the IMU frame
+        * @param[out] IMU_H_r_foot pose of the right foot contact frame with respect to the IMU frame
+        * @return True in case of success, false otherwise.
+        */
+        bool getIMU_H_feet(const iDynTree::JointPosDoubleArray& encoders,
+                           iDynTree::Transform& IMU_H_l_foot,
+                           iDynTree::Transform& IMU_H_r_foot);
+
+        /**
+        * Get the base link pose and velocity from the estimated IMU pose and velocity
+        * @note the input and output velocities are both specified in mixed-velocity representation
+        * @param[in] A_H_IMU pose of the IMU in the world
+        * @param[in] v_IMU mixed-trivialized velocity of the IMU in the world
+        * @param[out] A_H_B pose of the base link in the world
+        * @param[out] v_B mixed-trivialized velocity of the base link in the world
+        * @return True in case of success, false otherwise.
+        */
+        bool getBaseStateFromIMUState(const iDynTree::Transform& A_H_IMU, const iDynTree::Twist& v_IMU,
+                                      iDynTree::Transform& A_H_B, iDynTree::Twist& v_B);
+
+        /**
+         * Getters
+         */
+        const auto& nrJoints() const { return m_nr_joints; }
+        const auto& baseLink() const { return m_base_link; }
+        const auto& baseLinkIMU() const { return m_base_imu_frame; }
+        const auto& leftFootContact() const { return m_l_foot_contact_frame; }
+        const auto& rightFootContact() const { return m_r_foot_contact_frame; }
+        const auto& base_H_IMU() const { return m_base_H_imu; }
+        const auto& modelSet() const { return m_model_set; }
+
+    private:
+        std::string m_base_link{""}; /**< name of the floating base link*/
+        std::string m_base_imu_frame{""}; /**< name of the IMU frame rigidly attached to the floating base link*/
+        std::string m_l_foot_contact_frame{""}; /**< name of the left foot contact frame expected to be in contact with the environment*/
+        std::string m_r_foot_contact_frame{""}; /**< name of the right foot contact frame expected to be in contact with the environment*/
+        iDynTree::FrameIndex m_base_link_idx{iDynTree::FRAME_INVALID_INDEX}; /**< base link's frame index in the loaded model*/
+        iDynTree::FrameIndex m_base_imu_idx{iDynTree::FRAME_INVALID_INDEX}; /**< IMU index in the loaded model*/
+        iDynTree::FrameIndex m_l_foot_contact_idx{iDynTree::FRAME_INVALID_INDEX}; /**< Left foot contact frame index in the loaded model*/
+        iDynTree::FrameIndex m_r_foot_contact_idx{iDynTree::FRAME_INVALID_INDEX}; /**< Right foot contact freame index in the loaded model*/
+
+        iDynTree::KinDynComputations m_kindyn; /**< KinDynComputations object to do the model specific computations */
+        iDynTree::Model m_model; /**< Loaded reduced model */
+        iDynTree::Transform m_base_H_imu; /**< Rigid body transform of IMU frame with respect to the base link frame */
+        int m_nr_joints{0}; /**< number of joints in the loaded reduced model */
+        bool m_model_set{false};
+    };
+
+
+    /**
+    * Configure generic parameters. The generic parameters include,
+    *  - sampling_period_in_s [PARAMETER|REQUIRED|Sampling period of the estimator in seconds]
+    *  - ModelInfo [GROUP|REQUIRED|URDF Model specific parameters used by the estimator]
+    *      - base_link [PARAMETER|REQUIRED|base link frame from the URDF model| Exists in "ModelInfo" GROUP]
+    *      - base_link_imu [PARAMETER|REQUIRED|IMU frame rigidly attached to thebase link from the URDF model| Exists in "ModelInfo" GROUP]
+    *      - left_foot_contact_frame [PARAMETER|REQUIRED|left foot contact frame from the URDF model| Exists in "ModelInfo" GROUP]
+    *      - right_foot_contact_frame [PARAMETER|REQUIRED|right foot contact frame from the URDF model| Exists in "ModelInfo" GROUP]
+    * @param handler configure the generic parameters for the estimator
+    * @note call modelComputations().setModel() before calling initialize
+    * @note any custom initialization of parameters or the algorithm implementation is not done here,
+    *       it must be done in customInitialization() by the child class implementing the algorithm
+    * @return bool
+    */
+    bool initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+    /**
+    * Set the polled IMU measurement
+    * @param[in] acc_meas linear accelerometer measurement expressed in the local IMU frame (m/s^2)
+    * @param[in] gyro_meas gyroscope measurement expressed in the local IMU frame (rad/s)
+    * @return True in case of success, false otherwise.
+    */
+    bool setIMUMeasurement(const Eigen::Vector3d& acc_meas,
+                           const Eigen::Vector3d& gyro_meas);
+
+    /**
+    * Set feet contact states
+    * @param[in] lf_contact left foot contact state [0, 1]
+    * @param[in] rf_contact right foot contact state [0, 1]
+    * @return True in case of success, false otherwise.
+    */
+    bool setContacts(const bool& lf_contact, const bool& rf_contact);
+
+    /**
+    * Set kinematic measurements
+    * @note it is assumed that the order of the joints loaded in the model and the order of the measurements in these vectors match
+    * @param[in] encoders joint positions measured through encoders
+    * @param[in] encoder_speeds joint velocities measured through encoders
+    * @return True in case of success, false otherwise.
+    */
+    bool setKinematics(const Eigen::VectorXd& encoders,
+                       const Eigen::VectorXd& encoder_speeds);
+
+    /**
+    * Compute one step of the estimator
+    * @return True in case of success, false otherwise.
+    */
+    virtual bool advance() final;
+
+    /**
+    * Get estimator outputs
+    * @return A struct containing he estimated internal states of the estiamtor and the associated covariance matrix
+    */
+    virtual const FBEOutput& get() const final;
+
+    /**
+    * Determines the validity of the object retrieved with get()
+    * @return True in case of success, false otherwise.
+    */
+    virtual bool isValid() const final { return (m_estimator_state == State::Running); };
+
+    /**
+    * Get ModelComputations object by reference
+    * @return ModelComputations object providing information between considered model related quantities in the estimator
+    * like the base link, IMU, feet contact frames.
+    */
+    ModelComputations& modelComputations();
+
+protected:
+    /**
+    *
+    * @param[in] handler p_handler:...
+    * @return bool
+    */
+    virtual bool customInitialization(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler) { return true; };
+
+    /**
+    * Propagate the states through the prediction model, if there exists any (eg. a strap-down IMU model)
+    * @param[in] meas measurements passed as exogeneous inputs to the prediction model
+    * @param[in] dt sampling period in seconds
+    * @param[out] state previous state estimate
+    * @param[out] P previous state covariance matrix
+    * @return True in case of success, false otherwise.
+    */
+    virtual bool predictState(const FBEMeasurements& meas,
+                              const double& dt) { return true; };
+
+    /**
+    * Update the predicted state estimates using kinematics and contact measurements
+    * @param[in] meas measurements to update the predicted states
+    * @param[in] dt sampling period in seconds
+    * @return True in case of success, false otherwise.
+    */
+    virtual bool updateKinematics(const FBEMeasurements& meas,
+                                  const double& dt) { return true; };
+
+   /**
+   * Update the states and the associated covariance using the Kalman gain and the innovations (in an EKF based implementation)
+   * @note this function should be called from within updateKinematics in an EKF base implementation, otherwise left unused
+   * @param[in] deltaY innovation vector
+   * @param[in] H discrete-time measurement model Jacobian
+   * @param[in] R discrete-time measurement noise covariance matrix
+   * @return bool
+   */
+   virtual bool updateStates(const Eigen::VectorXd& deltaY,
+                             const Eigen::MatrixXd& H,
+                             const Eigen::MatrixXd& R) { return true; };
+
+    ModelComputations m_model_comp; /**< Model computations object */
+    FBEOptions m_options; /**< Struct holding estimator options */
+    FBEMeasurements m_meas; /**< Struct holding the latest measurements that were set to the estimator */
+    FBEInternalState m_state, m_state_prev; /**< Structs holding the curent and previous internal states of the estimation algorithm */
+    FBEOutput m_estimator_out; /**< Struct holding outputs of the estimator */
+    FBEPriorsStdDev m_priors; /**< Struct holding standard deviations associated to prior state estimates */
+    FBESensorsStdDev m_sensors_dev; /**< Struct holding standard deviations associated to sensor measurements */
+
+    /**
+    * Enumerator used to determine the running state of the estimator
+    */
+    enum class State
+    {
+        NotInitialized, /**< The estimator is not initialized yet call RecursiveLeastSquare::initialze
+                           method to initialize it*/
+        Initialized,    /**< The estimator is initialized and ready to be used */
+        Running         /**< The estimator is running */
+    };
+
+    State m_estimator_state{State::NotInitialized}; /**< State of the estimator */
+
+    double m_dt{0.01}; /**< Fixed time step of the estimator, in seconds */
+
+private:
+    /**
+    * Setup model related parameters
+    *
+    * @param[in] handler parameter handler
+    * @return True in case of success, false otherwise.
+    */
+    bool setupModelParams(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+};
+
+
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_H
+

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorIO.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorIO.h
@@ -14,48 +14,50 @@ namespace BipedalLocomotion
 {
 namespace Estimators
 {
-
+namespace FloatingBaseEstimators
+{
 /**
 * @brief Struct holding the elements of the state representation
 *
 */
-struct FBEInternalState
+struct InternalState
 {
 
 
-    Eigen::Quaterniond A_q_imu; /**< Orientation of the base link IMU in the inertial frame (as a quaternion w,x,y,z) */
-    Eigen::Vector3d A_p_imu;   /**< Position of the base link IMU in the inertial frame */
-    Eigen::Vector3d IMUA_v_AIMU; /**< linear part of the mixed-velocity representation of the IMU with respect to the inertial frame */
-    Eigen::Quaterniond A_q_LF; /**< Orientation of the left foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
-    Eigen::Vector3d A_p_LF; /**< Position of the left foot contact frame in the inertial frame */
-    Eigen::Quaterniond A_q_RF; /**< Orientation of the right foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
-    Eigen::Vector3d A_p_RF; /**< Position of the right foot contact frame in the inertial frame*/
-    Eigen::Vector3d b_acc; /**< Bias of the accelerometer expressed in the IMU frame */
-    Eigen::Vector3d b_gyro; /**< Bias of the gyroscope expressed in the IMU frame */
+    Eigen::Quaterniond imu_orientation; /**< Orientation of the base link IMU in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d imu_position;   /**< Position of the base link IMU in the inertial frame */
+    Eigen::Vector3d imu_linear_velocity; /**< linear part of the mixed-velocity representation of the IMU with respect to the inertial frame */
+    Eigen::Quaterniond l_contact_frame_orientation; /**< Orientation of the left foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d l_contact_frame_position; /**< Position of the left foot contact frame in the inertial frame */
+    Eigen::Quaterniond r_contact_frame_orientation; /**< Orientation of the right foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d r_contact_frame_position; /**< Position of the right foot contact frame in the inertial frame*/
+    Eigen::Vector3d accelerometer_bias; /**< Bias of the accelerometer expressed in the IMU frame */
+    Eigen::Vector3d gyroscope_bias; /**< Bias of the gyroscope expressed in the IMU frame */
 };
 
 /**
 * @brief Struct holding the elements of the state representation
 *
 */
-struct FBEOutput
+struct Output
 {
-    FBEInternalState x; /**< Current state estimate of the estimator */
-    Eigen::MatrixXd P; /**< Current state covariance matrix */
+    InternalState state; /**< Current state estimate of the estimator */
+    Eigen::MatrixXd state_var; /**< Current state covariance matrix */
 };
 
 /**
 * @brief Struct holding the elements of the state representation
 *
 */
-struct FBEMeasurements
+struct Measurements
 {
     Eigen::Vector3d acc, gyro; /**< accelerometer and gyroscope measurements expressed in IMU frame */
     Eigen::VectorXd encoders, encoders_speed; /**< Joint position and joint velocity measurements */
-    bool lf_contact{false}; /**< left foot contact state */
-    bool rf_contact{false}; /**< right foot contact state */
+    bool lf_in_contact{false}; /**< left foot contact state */
+    bool rf_in_contact{false}; /**< right foot contact state */
 };
 
+} // namespace FloatingBaseEstimators
 } // namespace Estimators
 } // namespace BipedalLocomotion
 

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorIO.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorIO.h
@@ -9,6 +9,8 @@
 #define BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_IO_H
 
 #include <Eigen/Dense>
+#include <iDynTree/Core/Transform.h>
+#include <iDynTree/Core/Twist.h>
 
 namespace BipedalLocomotion
 {
@@ -16,23 +18,22 @@ namespace Estimators
 {
 namespace FloatingBaseEstimators
 {
+
 /**
 * @brief Struct holding the elements of the state representation
 *
 */
 struct InternalState
 {
-
-
-    Eigen::Quaterniond imu_orientation; /**< Orientation of the base link IMU in the inertial frame (as a quaternion w,x,y,z) */
-    Eigen::Vector3d imu_position;   /**< Position of the base link IMU in the inertial frame */
-    Eigen::Vector3d imu_linear_velocity; /**< linear part of the mixed-velocity representation of the IMU with respect to the inertial frame */
-    Eigen::Quaterniond l_contact_frame_orientation; /**< Orientation of the left foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
-    Eigen::Vector3d l_contact_frame_position; /**< Position of the left foot contact frame in the inertial frame */
-    Eigen::Quaterniond r_contact_frame_orientation; /**< Orientation of the right foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
-    Eigen::Vector3d r_contact_frame_position; /**< Position of the right foot contact frame in the inertial frame*/
-    Eigen::Vector3d accelerometer_bias; /**< Bias of the accelerometer expressed in the IMU frame */
-    Eigen::Vector3d gyroscope_bias; /**< Bias of the gyroscope expressed in the IMU frame */
+    Eigen::Quaterniond imuOrientation; /**< Orientation of the base link IMU in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d imuPosition;   /**< Position of the base link IMU in the inertial frame */
+    Eigen::Vector3d imuLinearVelocity; /**< linear part of the mixed-velocity representation of the IMU with respect to the inertial frame */
+    Eigen::Quaterniond lContactFrameOrientation; /**< Orientation of the left foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d lContactFramePosition; /**< Position of the left foot contact frame in the inertial frame */
+    Eigen::Quaterniond rContactFrameOrientation; /**< Orientation of the right foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d rContactFramePosition; /**< Position of the right foot contact frame in the inertial frame*/
+    Eigen::Vector3d accelerometerBias; /**< Bias of the accelerometer expressed in the IMU frame */
+    Eigen::Vector3d gyroscopeBias; /**< Bias of the gyroscope expressed in the IMU frame */
 };
 
 /**
@@ -42,7 +43,10 @@ struct InternalState
 struct Output
 {
     InternalState state; /**< Current state estimate of the estimator */
-    Eigen::MatrixXd state_var; /**< Current state covariance matrix */
+    StateStdDev stateStdDev; /**< Current state covariance matrix */
+
+    iDynTree::Transform basePose; /**< Estimated base link pose */
+    iDynTree::Twist baseTwist; /**< Estimate base link velocity in mixed-velocity representation */
 };
 
 /**
@@ -52,9 +56,9 @@ struct Output
 struct Measurements
 {
     Eigen::Vector3d acc, gyro; /**< accelerometer and gyroscope measurements expressed in IMU frame */
-    Eigen::VectorXd encoders, encoders_speed; /**< Joint position and joint velocity measurements */
-    bool lf_in_contact{false}; /**< left foot contact state */
-    bool rf_in_contact{false}; /**< right foot contact state */
+    Eigen::VectorXd encoders, encodersSpeed; /**< Joint position and joint velocity measurements */
+    bool lfInContact{false}; /**< left foot contact state */
+    bool rfInContact{false}; /**< right foot contact state */
 };
 
 } // namespace FloatingBaseEstimators

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorIO.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorIO.h
@@ -1,0 +1,63 @@
+/**
+ * @file FloatingBaseEstimatorIO.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_IO_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_IO_H
+
+#include <Eigen/Dense>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+
+/**
+* @brief Struct holding the elements of the state representation
+*
+*/
+struct FBEInternalState
+{
+
+
+    Eigen::Quaterniond A_q_imu; /**< Orientation of the base link IMU in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d A_p_imu;   /**< Position of the base link IMU in the inertial frame */
+    Eigen::Vector3d IMUA_v_AIMU; /**< linear part of the mixed-velocity representation of the IMU with respect to the inertial frame */
+    Eigen::Quaterniond A_q_LF; /**< Orientation of the left foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d A_p_LF; /**< Position of the left foot contact frame in the inertial frame */
+    Eigen::Quaterniond A_q_RF; /**< Orientation of the right foot contact frame in the inertial frame (as a quaternion w,x,y,z) */
+    Eigen::Vector3d A_p_RF; /**< Position of the right foot contact frame in the inertial frame*/
+    Eigen::Vector3d b_acc; /**< Bias of the accelerometer expressed in the IMU frame */
+    Eigen::Vector3d b_gyro; /**< Bias of the gyroscope expressed in the IMU frame */
+};
+
+/**
+* @brief Struct holding the elements of the state representation
+*
+*/
+struct FBEOutput
+{
+    FBEInternalState x; /**< Current state estimate of the estimator */
+    Eigen::MatrixXd P; /**< Current state covariance matrix */
+};
+
+/**
+* @brief Struct holding the elements of the state representation
+*
+*/
+struct FBEMeasurements
+{
+    Eigen::Vector3d acc, gyro; /**< accelerometer and gyroscope measurements expressed in IMU frame */
+    Eigen::VectorXd encoders, encoders_speed; /**< Joint position and joint velocity measurements */
+    bool lf_contact{false}; /**< left foot contact state */
+    bool rf_contact{false}; /**< right foot contact state */
+};
+
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_IO_H
+

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorParams.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorParams.h
@@ -20,124 +20,128 @@ namespace FloatingBaseEstimators
 * @brief Struct containing sensor measurement deviation parameters of floating base estimators
 *
 */
-class SensorsStdDev
+struct SensorsStdDev
 {
     /**
     * @brief Additive white Gaussian noise deviation for accelerometer measurements
     *        Expressed in local frame as m/(s^2), in continuous time
     */
-    Eigen::Vector3d accelerometer_noise;
+    Eigen::Vector3d accelerometerNoise;
 
     /**
     * @brief Additive white Gaussian noise deviation for gyroscope measurements
     *        Expressed in local frame as rad/s, in continuous time
     */
-    Eigen::Vector3d gyroscope_noise;
+    Eigen::Vector3d gyroscopeNoise;
 
     /**
     * @brief Random walk bias noise deviation for accelerometer measurements
     *        Expressed in local frame as m/s^3, in continuous time
     */
-    Eigen::Vector3d accelerometer_bias_noise;
+    Eigen::Vector3d accelerometerBiasNoise;
 
     /**
     * @brief Random walk bias noise deviation for gyroscope measurements
     *        Expressed in local frame as rad/s^2, in continuous time
     */
-    Eigen::Vector3d gyroscope_bias_noise;
+    Eigen::Vector3d gyroscopeBiasNoise;
 
     /**
     * @brief White Gaussian noise deviation for linear feet velocities in rigid contact with the environment
     *        Expressed in local frame as m/s^2, in continuous time
     */
-    Eigen::Vector3d contact_foot_linvel_noise;
+    Eigen::Vector3d contactFootLinvelNoise;
 
     /**
     * @brief White Gaussian noise deviation for angular feet velocities in rigid contact with the environment
     *        Expressed in local frame as rad/s, in continuous time
     */
-    Eigen::Vector3d contact_foot_angvel_noise;
+    Eigen::Vector3d contactFootAngvelNoise;
 
     /**
     * @brief White Gaussian noise deviation for linear feet velocities in swing phase
     *        Expressed in local frame as m/s^2, in continuous time
     */
-    Eigen::Vector3d swing_foot_linvel_noise;
+    Eigen::Vector3d swingFootLinvelNoise;
 
     /**
     * @brief White Gaussian noise deviation for angular feet velocities in swing phase
     *        Expressed in local frame as rad/s, in continuous time
     */
-    Eigen::Vector3d swing_foot_angvel_noise;
+    Eigen::Vector3d swingFootAngvelNoise;
 
     /**
     * @brief White Gaussian noise deviation for relative kinematics between IMU frame to foot contact frames
     *        Expressed in local frame, in continuous time
-    *
     */
-    Eigen::Matrix<double, 6, 1> forward_kinematics_noise;
+    Eigen::Matrix<double, 6, 1> forwardKinematicsNoise;
+
+    /**
+    * @brief White Gaussian noise deviation for encoder measurements in continuous time
+    */
+    Eigen::VectorXd encodersNoise;
 };
 
 /**
 * @brief Struct containing prior state deviation parameters of floating base estimators
 *
 */
-struct PriorsStdDev
+struct StateStdDev
 {
     /**
     * @brief Prior deviation of IMU orientation in inertial frame
     *        expressed in radians as rpy
     */
-    Eigen::Vector3d imu_orientation;
+    Eigen::Vector3d imuOrientation;
 
     /**
     * @brief Prior deviation of IMU position in inertial frame
     *        expressed in m as xyz
     */
-    Eigen::Vector3d imu_position;
+    Eigen::Vector3d imuPosition;
 
     /**
     * @brief Prior deviation of mixed-trivialized IMU linear velocity
     *        expressed in m/s
     */
-    Eigen::Vector3d imu_linear_velocity;
+    Eigen::Vector3d imuLinearVelocity;
 
     /**
     * @brief Prior deviation of left foot contact frame orientation in inertial frame
     *        expressed in radians as rpy
     */
-    Eigen::Vector3d l_contact_frame_orientation;
+    Eigen::Vector3d lContactFrameOrientation;
 
     /**
     * @brief Prior deviation of left foot contact frame position in inertial frame
     *        expressed in m as xyz
     */
-    Eigen::Vector3d l_contact_frame_position;
+    Eigen::Vector3d lContactFramePosition;
 
     /**
     * @brief Prior deviation of right foot contact frame orientation in inertial frame
     *        expressed in radians as rpy
     */
-    Eigen::Vector3d r_contact_frame_orientation;
+    Eigen::Vector3d rContactFrameOrientation;
 
     /**
     * @brief Prior deviation of right foot contact frame position in inertial frame
     *        expressed in m as xyz
     */
-    Eigen::Vector3d r_contact_frame_position;
+    Eigen::Vector3d rContactFramePosition;
 
     /**
     * @brief Prior deviation of IMU accelerometer bias in local frame
     *        expressed in m/s^2
     *
     */
-    Eigen::Vector3d accelerometer_bias;
+    Eigen::Vector3d accelerometerBias;
 
     /**
     * @brief Prior deviation of IMU gyroscope bias in local frame
     *        expressed in rad/s
     */
-    Eigen::Vector3d gyroscope_bias;
+    Eigen::Vector3d gyroscopeBias;
 };
 
 
@@ -151,7 +155,7 @@ struct Options
     * @brief Enable/disable online accelerometer and gyroscope bias estimation
     *
     */
-    bool imu_bias_estimation_enabled{false};
+    bool imuBiasEstimationEnabled{false};
 
     /**
     * @brief Enable/disable IMU bias initialization using
@@ -159,20 +163,26 @@ struct Options
     * @note also remember to set nr_samples_for_bias_initialization
     *
     */
-    bool static_imu_bias_initialization_enabled{false};
+    bool staticImuBiasInitializationEnabled{false};
 
     /**
     * @brief Number of initial measurement samples in a static configuration
     *        used for IMU bias initialization
     *
     */
-    int nr_samples_for_imu_bias_initialization{0};
+    int nrSamplesForImuBiasInitialization{0};
 
     /**
     * @brief Enable/disable measurement update step of the internal EKF
     *
     */
-    bool ekf_update_enabled{true};
+    bool ekfUpdateEnabled{true};
+
+    /**
+    * @brief Acceleration vector due to gravity
+    *
+    */
+    Eigen::Vector3d accelerationDueToGravity{0, 0, -9.80665};
 };
 
 } //namespace FloatingBaseEstimators

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorParams.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorParams.h
@@ -14,12 +14,13 @@ namespace BipedalLocomotion
 {
 namespace Estimators
 {
-
+namespace FloatingBaseEstimators
+{
 /**
 * @brief Struct containing sensor measurement deviation parameters of floating base estimators
 *
 */
-class FBESensorsStdDev
+class SensorsStdDev
 {
     /**
     * @brief Additive white Gaussian noise deviation for accelerometer measurements
@@ -81,7 +82,7 @@ class FBESensorsStdDev
 * @brief Struct containing prior state deviation parameters of floating base estimators
 *
 */
-struct FBEPriorsStdDev
+struct PriorsStdDev
 {
     /**
     * @brief Prior deviation of IMU orientation in inertial frame
@@ -144,13 +145,13 @@ struct FBEPriorsStdDev
 * @brief Struct containing options runtime options for floating base estimator
 *
 */
-struct FBEOptions
+struct Options
 {
     /**
     * @brief Enable/disable online accelerometer and gyroscope bias estimation
     *
     */
-    bool enable_imu_bias_estimation{false};
+    bool imu_bias_estimation_enabled{false};
 
     /**
     * @brief Enable/disable IMU bias initialization using
@@ -158,7 +159,7 @@ struct FBEOptions
     * @note also remember to set nr_samples_for_bias_initialization
     *
     */
-    bool enable_static_imu_bias_initialization{false};
+    bool static_imu_bias_initialization_enabled{false};
 
     /**
     * @brief Number of initial measurement samples in a static configuration
@@ -171,10 +172,10 @@ struct FBEOptions
     * @brief Enable/disable measurement update step of the internal EKF
     *
     */
-    bool enable_ekf_update{true};
+    bool ekf_update_enabled{true};
 };
 
-
+} //namespace FloatingBaseEstimators
 } // namespace Estimators
 } // namespace BipedalLocomotion
 

--- a/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorParams.h
+++ b/src/Estimators/include/BipedalLocomotion/Estimators/FloatingBaseEstimatorParams.h
@@ -1,0 +1,181 @@
+/**
+ * @file FloatingBaseEstimatorParams.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_PARAMS_H
+#define BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_PARAMS_H
+
+#include <Eigen/Dense>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+
+/**
+* @brief Struct containing sensor measurement deviation parameters of floating base estimators
+*
+*/
+class FBESensorsStdDev
+{
+    /**
+    * @brief Additive white Gaussian noise deviation for accelerometer measurements
+    *        Expressed in local frame as m/(s^2), in continuous time
+    */
+    Eigen::Vector3d accelerometer_noise;
+
+    /**
+    * @brief Additive white Gaussian noise deviation for gyroscope measurements
+    *        Expressed in local frame as rad/s, in continuous time
+    */
+    Eigen::Vector3d gyroscope_noise;
+
+    /**
+    * @brief Random walk bias noise deviation for accelerometer measurements
+    *        Expressed in local frame as m/s^3, in continuous time
+    */
+    Eigen::Vector3d accelerometer_bias_noise;
+
+    /**
+    * @brief Random walk bias noise deviation for gyroscope measurements
+    *        Expressed in local frame as rad/s^2, in continuous time
+    */
+    Eigen::Vector3d gyroscope_bias_noise;
+
+    /**
+    * @brief White Gaussian noise deviation for linear feet velocities in rigid contact with the environment
+    *        Expressed in local frame as m/s^2, in continuous time
+    */
+    Eigen::Vector3d contact_foot_linvel_noise;
+
+    /**
+    * @brief White Gaussian noise deviation for angular feet velocities in rigid contact with the environment
+    *        Expressed in local frame as rad/s, in continuous time
+    */
+    Eigen::Vector3d contact_foot_angvel_noise;
+
+    /**
+    * @brief White Gaussian noise deviation for linear feet velocities in swing phase
+    *        Expressed in local frame as m/s^2, in continuous time
+    */
+    Eigen::Vector3d swing_foot_linvel_noise;
+
+    /**
+    * @brief White Gaussian noise deviation for angular feet velocities in swing phase
+    *        Expressed in local frame as rad/s, in continuous time
+    */
+    Eigen::Vector3d swing_foot_angvel_noise;
+
+    /**
+    * @brief White Gaussian noise deviation for relative kinematics between IMU frame to foot contact frames
+    *        Expressed in local frame, in continuous time
+    *
+    */
+    Eigen::Matrix<double, 6, 1> forward_kinematics_noise;
+};
+
+/**
+* @brief Struct containing prior state deviation parameters of floating base estimators
+*
+*/
+struct FBEPriorsStdDev
+{
+    /**
+    * @brief Prior deviation of IMU orientation in inertial frame
+    *        expressed in radians as rpy
+    */
+    Eigen::Vector3d imu_orientation;
+
+    /**
+    * @brief Prior deviation of IMU position in inertial frame
+    *        expressed in m as xyz
+    */
+    Eigen::Vector3d imu_position;
+
+    /**
+    * @brief Prior deviation of mixed-trivialized IMU linear velocity
+    *        expressed in m/s
+    */
+    Eigen::Vector3d imu_linear_velocity;
+
+    /**
+    * @brief Prior deviation of left foot contact frame orientation in inertial frame
+    *        expressed in radians as rpy
+    */
+    Eigen::Vector3d l_contact_frame_orientation;
+
+    /**
+    * @brief Prior deviation of left foot contact frame position in inertial frame
+    *        expressed in m as xyz
+    */
+    Eigen::Vector3d l_contact_frame_position;
+
+    /**
+    * @brief Prior deviation of right foot contact frame orientation in inertial frame
+    *        expressed in radians as rpy
+    */
+    Eigen::Vector3d r_contact_frame_orientation;
+
+    /**
+    * @brief Prior deviation of right foot contact frame position in inertial frame
+    *        expressed in m as xyz
+    */
+    Eigen::Vector3d r_contact_frame_position;
+
+    /**
+    * @brief Prior deviation of IMU accelerometer bias in local frame
+    *        expressed in m/s^2
+    *
+    */
+    Eigen::Vector3d accelerometer_bias;
+
+    /**
+    * @brief Prior deviation of IMU gyroscope bias in local frame
+    *        expressed in rad/s
+    */
+    Eigen::Vector3d gyroscope_bias;
+};
+
+
+/**
+* @brief Struct containing options runtime options for floating base estimator
+*
+*/
+struct FBEOptions
+{
+    /**
+    * @brief Enable/disable online accelerometer and gyroscope bias estimation
+    *
+    */
+    bool enable_imu_bias_estimation{false};
+
+    /**
+    * @brief Enable/disable IMU bias initialization using
+    *        initial set of measurements in a static configuration
+    * @note also remember to set nr_samples_for_bias_initialization
+    *
+    */
+    bool enable_static_imu_bias_initialization{false};
+
+    /**
+    * @brief Number of initial measurement samples in a static configuration
+    *        used for IMU bias initialization
+    *
+    */
+    int nr_samples_for_imu_bias_initialization{0};
+
+    /**
+    * @brief Enable/disable measurement update step of the internal EKF
+    *
+    */
+    bool enable_ekf_update{true};
+};
+
+
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ESTIMATORS_FBE_PARAMS_H

--- a/src/Estimators/src/FloatingBaseEstimator.cpp
+++ b/src/Estimators/src/FloatingBaseEstimator.cpp
@@ -1,0 +1,338 @@
+/**
+ * @file FloatingBaseEstimator.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+
+#include <BipedalLocomotion/Estimators/FloatingBaseEstimator.h>
+
+using namespace BipedalLocomotion::Estimators;
+
+bool FloatingBaseEstimator::initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+{
+    if (!m_model_comp.modelSet())
+    {
+        std::cerr << "[FloatingBaseEstimator::initialize] "
+        "Please call modelComputations().setModel(iDynTree::Model& model) to set the model, before calling initialize()."
+        << std::endl;
+        return false;
+    }
+
+    if (m_estimator_state != State::NotInitialized)
+    {
+        std::cerr << "[FloatingBaseEstimator::initialize] "
+        "The estimator already seems to be initialized."
+        << std::endl;
+        return false;
+    }
+
+    auto handle = handler.lock();
+    if (handle == nullptr)
+    {
+        std::cerr << "[FloatingBaseEstimator::initialize] "
+        "The parameter handler has expired. Please check its scope."
+        << std::endl;
+        return false;
+    }
+
+    // setup sampling period
+    if (!handle->getParameter("sampling_period_in_s", m_dt))
+    {
+        std::cerr << "[FloatingBaseEstimator::initialize] "
+        "The parameter handler could not find \" sampling_period_in_s \" in the configuration file."
+        << std::endl;
+        return false;
+    }
+
+    // setup model related entities
+    auto model_handle = handle->getGroup("ModelInfo");
+    if (!setupModelParams(model_handle))
+    {
+        std::cerr << "[FloatingBaseEstimator::initialize] "
+        "Could not load model related parameters."
+        << std::endl;
+        return false;
+    }
+
+    if (!customInitialization(handler))
+    {
+        std::cerr << "[FloatingBaseEstimator::initialize] "
+        "Could not run custom initialization of the filter."
+        << std::endl;
+        return false;
+    }
+
+    m_estimator_state = State::Initialized;
+
+    return true;
+}
+
+bool FloatingBaseEstimator::advance()
+{
+    m_state_prev = m_state;
+
+    if (m_estimator_state != State::Initialized && m_estimator_state != State::Running)
+    {
+        std::cerr << "[FloatingBaseEstimator::advance] "
+        "Please initialize the estimator before calling advance()."
+        << std::endl;
+        return false;
+    }
+
+    if (m_estimator_state == State::Initialized)
+    {
+        m_estimator_state = State::Running;
+    }
+
+    auto ok = predictState(m_meas, m_dt);
+    if (m_options.enable_ekf_update)
+    {
+        ok = updateKinematics(m_meas, m_dt);
+    }
+
+    return ok;
+}
+
+bool FloatingBaseEstimator::ModelComputations::setModel(const iDynTree::Model& model)
+{
+    if (!m_kindyn.loadRobotModel(model))
+    {
+        return false;
+    }
+
+    m_model = model;
+    m_nr_joints = model.getNrOfDOFs();
+    m_model_set = true;
+    return true;
+}
+
+bool FloatingBaseEstimator::ModelComputations::setBaseLinkAndIMU(const std::string& base_link,
+                                                                 const std::string& imu_frame)
+{
+    m_base_link_idx = m_model.getFrameIndex(base_link);
+    if (m_base_link_idx == iDynTree::FRAME_INVALID_INDEX)
+    {
+        std::cerr << "[FloatingBaseEstimator::ModelComputations::setBaseLinkAndIMU] "
+        "Specified base link not available in the loaded URDF Model."
+        << std::endl;
+        return false;
+    }
+
+    m_base_imu_idx = m_model.getFrameIndex(imu_frame);
+    if (m_base_imu_idx == iDynTree::FRAME_INVALID_INDEX)
+    {
+        std::cerr << "[FloatingBaseEstimator::ModelComputations::setBaseLinkAndIMU] "
+        "Specified IMU frame not available in the loaded URDF Model."
+        << std::endl;
+        return false;
+    }
+
+    if (m_base_link_idx != m_model.getFrameLink(m_base_imu_idx))
+    {
+        std::cerr << "[FloatingBaseEstimator::ModelComputations::setBaseLinkAndIMU] "
+        "Specified IMU not rigidly attached to the base link. Please specify a base link colocated IMU."
+        << std::endl;
+        return false;
+    }
+
+
+    if (m_model.getDefaultBaseLink() != m_base_link_idx)
+    {
+        m_model.setDefaultBaseLink(m_base_link_idx);
+        this->setModel(m_model);
+    }
+
+    m_base_link = base_link;
+    m_base_imu_frame = imu_frame;
+    m_base_H_imu = m_model.getFrameTransform(m_base_imu_idx);
+    return true;
+}
+
+bool FloatingBaseEstimator::ModelComputations::setFeetContactFrames(const std::string& l_foot_contact_frame,
+                                                                    const std::string& r_foot_contact_frame)
+{
+    m_l_foot_contact_idx = m_model.getFrameIndex(l_foot_contact_frame);
+    if (m_l_foot_contact_idx == iDynTree::FRAME_INVALID_INDEX)
+    {
+        std::cerr << "[FloatingBaseEstimator::ModelComputations::setFeetContactFrames] "
+        "Specified left foot contact frame not available in the loaded URDF Model."
+        << std::endl;
+        return false;
+    }
+
+    m_r_foot_contact_idx = m_model.getFrameIndex(r_foot_contact_frame);
+    if (m_r_foot_contact_idx == iDynTree::FRAME_INVALID_INDEX)
+    {
+        std::cerr << "[FloatingBaseEstimator::ModelComputations::setFeetContactFrames] "
+        "Specified right foot contact frame not available in the loaded URDF Model."
+        << std::endl;
+        return false;
+    }
+
+    m_l_foot_contact_frame = l_foot_contact_frame;
+    m_r_foot_contact_frame = r_foot_contact_frame;
+
+    return true;
+}
+
+bool FloatingBaseEstimator::ModelComputations::checkModelInfoLoaded()
+{
+    bool loaded = (m_base_link_idx != iDynTree::FRAME_INVALID_INDEX) &&
+             (m_base_imu_idx != iDynTree::FRAME_INVALID_INDEX) &&
+             (m_l_foot_contact_idx != iDynTree::FRAME_INVALID_INDEX) &&
+             (m_r_foot_contact_idx != iDynTree::FRAME_INVALID_INDEX);
+
+    return loaded;
+}
+
+bool FloatingBaseEstimator::ModelComputations::getBaseStateFromIMUState(const iDynTree::Transform& A_H_IMU,
+                                                                        const iDynTree::Twist& v_IMU,
+                                                                        iDynTree::Transform& A_H_B,
+                                                                        iDynTree::Twist& v_B)
+{
+    if (!checkModelInfoLoaded())
+    {
+        std::cerr << "[FloatingBaseEstimator::ModelComputations::getBaseStateFromIMUState] "
+        "Please set required model info parameters, before calling getBaseStateFromIMUState(...)"
+        << std::endl;
+        return false;
+    }
+
+    A_H_B = A_H_IMU*(m_base_H_imu.inverse());
+
+    // transform velocity (mixed-representation)
+    auto base2IMUinWorld = A_H_B.getRotation()*m_base_H_imu.getPosition();
+    auto X = iDynTree::Transform(iDynTree::Rotation::Identity(), base2IMUinWorld);
+    v_B = X*v_IMU;
+
+    return true;
+}
+
+bool FloatingBaseEstimator::ModelComputations::getIMU_H_feet(const iDynTree::JointPosDoubleArray& encoders,
+                                                             iDynTree::Transform& IMU_H_l_foot,
+                                                             iDynTree::Transform& IMU_H_r_foot)
+{
+    if (!checkModelInfoLoaded())
+    {
+        std::cerr << "[FloatingBaseEstimator::ModelComputations::getIMU_H_feet] "
+        "Please set required model info parameters, before calling getIMU_H_feet(...)"
+        << std::endl;
+        return false;
+    }
+
+    m_kindyn.setJointPos(encoders);
+    IMU_H_l_foot = m_kindyn.getRelativeTransform(m_base_imu_idx, m_l_foot_contact_idx);
+    IMU_H_r_foot = m_kindyn.getRelativeTransform(m_base_imu_idx, m_r_foot_contact_idx);
+
+    return true;
+}
+
+bool FloatingBaseEstimator::setIMUMeasurement(const Eigen::Vector3d& acc_meas,
+                                              const Eigen::Vector3d& gyro_meas)
+{
+    m_meas.acc = acc_meas;
+    m_meas.gyro = gyro_meas;
+    return true;
+}
+
+
+bool FloatingBaseEstimator::setKinematics(const Eigen::VectorXd& encoders,
+                                          const Eigen::VectorXd& encoder_speeds)
+{
+    if ( (encoders.size() != encoder_speeds.size()) ||
+        (encoders.size() != modelComputations().nrJoints()))
+    {
+        std::cerr << "[FloatingBaseEstimator::setKinematics] "
+        "kinematic measurements size mismatch"
+        << std::endl;
+        return false;
+    }
+
+    m_meas.encoders = encoders;
+    m_meas.encoders_speed = encoder_speeds;
+    return true;
+}
+
+bool FloatingBaseEstimator::setContacts(const bool& lf_contact,
+                                        const bool& rf_contact)
+{
+    m_meas.lf_contact = lf_contact;
+    m_meas.rf_contact = rf_contact;
+    return true;
+}
+
+FloatingBaseEstimator::ModelComputations& FloatingBaseEstimator::modelComputations()
+{
+    return m_model_comp;
+}
+
+
+const FBEOutput& FloatingBaseEstimator::get() const
+{
+    return m_estimator_out;
+}
+
+
+bool FloatingBaseEstimator::setupModelParams(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+{
+    auto handle = handler.lock();
+    if (handle == nullptr)
+    {
+        std::cerr << "[FloatingBaseEstimator::setupModelParams] "
+        "The parameter handler has expired. Please check its scope."
+        << std::endl;
+        return false;
+    }
+
+    // setup base link and imu
+    std::string base_link, imu;
+    if (!handle->getParameter("base_link", base_link))
+    {
+        std::cerr << "[FloatingBaseEstimator::setupModelParams] "
+        "The parameter handler could not find \" base_link \" in the configuration file."
+        << std::endl;
+        return false;
+    }
+
+    if (!handle->getParameter("base_link_imu", imu))
+    {
+        std::cerr << "[FloatingBaseEstimator::setupModelParams] "
+        "The parameter handler could not find \" base_link_imu \" in the configuration file."
+        << std::endl;
+        return false;
+    }
+
+    // setup base lf_contact and rf_contact
+    std::string lf_contact, rf_contact;
+    if (!handle->getParameter("left_foot_contact_frame", lf_contact))
+    {
+        std::cerr << "[FloatingBaseEstimator::setupModelParams] "
+        "The parameter handler could not find \" base_link \" in the configuration file."
+        << std::endl;
+        return false;
+    }
+
+    if (!handle->getParameter("right_foot_contact_frame", rf_contact))
+    {
+        std::cerr << "[FloatingBaseEstimator::setupModelParams] "
+        "The parameter handler could not find \" base_link \" in the configuration file."
+        << std::endl;
+        return false;
+    }
+
+    if (!m_model_comp.setBaseLinkAndIMU(base_link, imu))
+    {
+        return false;
+    }
+
+    if (!m_model_comp.setFeetContactFrames(lf_contact, rf_contact))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+

--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -6,3 +6,12 @@ add_bipedal_test(
   NAME RecursiveLeastSquare
   SOURCES RecursiveLeastSquareTest.cpp
   LINKS BipedalLocomotion::Estimators BipedalLocomotion::ParametersHandler Eigen3::Eigen)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ResourceFolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ResourceFolderPath.h" @ONLY)
+
+add_bipedal_test(
+ NAME BareBonesBaseEstimator
+ SOURCES FloatingBaseEstimatorTest.cpp
+ LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler Eigen3::Eigen iDynTree::idyntree-modelio-urdf)
+

--- a/src/Estimators/tests/FloatingBaseEstimatorTest.cpp
+++ b/src/Estimators/tests/FloatingBaseEstimatorTest.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file FloatingBaseEstimatorTest.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/Estimators/FloatingBaseEstimator.h>
+
+#include <iDynTree/ModelIO/ModelLoader.h>
+#include <iDynTree/Core/TestUtils.h>
+
+#include <ResourceFolderPath.h>
+
+#include <Eigen/Dense>
+
+using namespace BipedalLocomotion::Estimators;
+using namespace BipedalLocomotion::ParametersHandler;
+
+bool populateConfig(std::weak_ptr<IParametersHandler> handler)
+{
+    auto handle = handler.lock();
+    if (handle == nullptr) {return false;}
+    handle->setParameter("sampling_period_in_s", 0.01);
+
+    auto modelInfoGroup = std::make_shared<StdImplementation>();
+    handle->setGroup("ModelInfo", modelInfoGroup);
+    modelInfoGroup->setParameter("base_link", "root_link");
+    modelInfoGroup->setParameter("base_link_imu", "root_link_imu_acc");
+    modelInfoGroup->setParameter("left_foot_contact_frame", "l_sole");
+    modelInfoGroup->setParameter("right_foot_contact_frame", "r_sole");
+
+    return true;
+}
+
+TEST_CASE("Bare Bones Base Estimator")
+{
+    std::shared_ptr<StdImplementation> originalHandler = std::make_shared<StdImplementation>();
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    REQUIRE(populateConfig(parameterHandler));
+
+    std::string model_path{getFBEURDFModelPath()};
+    std::cout << model_path << std::endl;
+    std::vector<std::string> joints_list = {"neck_pitch", "neck_roll", "neck_yaw",
+        "torso_pitch", "torso_roll", "torso_yaw",
+        "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow",
+        "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",
+        "l_hip_pitch", "l_hip_roll", "l_hip_yaw",
+        "l_knee", "l_ankle_pitch", "l_ankle_roll",
+        "r_hip_pitch", "r_hip_roll", "r_hip_yaw",
+        "r_knee", "r_ankle_pitch", "r_ankle_roll"};
+
+    iDynTree::ModelLoader mdl_ldr;
+    REQUIRE(mdl_ldr.loadReducedModelFromFile(model_path, joints_list));
+
+    auto model = mdl_ldr.model().copy();
+
+    // Instantiate the estimator
+    FloatingBaseEstimator estimator;
+    REQUIRE(estimator.modelComputations().setModel(model));
+    REQUIRE(estimator.initialize(parameterHandler));
+    REQUIRE(estimator.modelComputations().modelSet());
+    REQUIRE(estimator.modelComputations().nrJoints() == joints_list.size());
+    REQUIRE(estimator.modelComputations().baseLink() == "root_link");
+    REQUIRE(estimator.modelComputations().baseLinkIMU() == "root_link_imu_acc");
+    REQUIRE(estimator.modelComputations().leftFootContact() == "l_sole");
+    REQUIRE(estimator.modelComputations().rightFootContact() == "r_sole");
+
+    auto b_H_imu = model.getFrameTransform(model.getFrameIndex("root_link_imu_acc"));
+
+    ASSERT_EQUAL_TRANSFORM(b_H_imu, estimator.modelComputations().base_H_IMU());
+
+    // IMU measures
+    Eigen::Vector3d acc, gyro;
+    acc << 0.0,   -7.9431,   -5.7513;
+    gyro << 0.0, 0.0, 0.0;
+
+    // contact states
+    bool lf_contact{true}, rf_contact{true};
+
+    // kinematic measures
+    Eigen::VectorXd encoders(joints_list.size()), encoder_speeds(joints_list.size());
+    encoders << -0.0001, 0.0000, 0.0000,
+    0.1570, 0.0003, -0.0000,
+    -0.0609, 0.4350, 0.1833, 0.5375,
+    -0.0609,    0.4349, 0.1834, 0.5375,
+    0.0895, 0.0090, -0.0027,
+    -0.5694, -0.3771, -0.0211,
+    0.0896, 0.0090, -0.0027,
+    -0.5695, -0.3771, -0.0211;
+
+    encoder_speeds.setZero();
+
+    // estimate the parameters
+    for (int i = 0; i < 10000; i++)
+    {
+        REQUIRE(estimator.setIMUMeasurement(acc, gyro));
+        REQUIRE(estimator.setContacts(lf_contact, rf_contact));
+        REQUIRE(estimator.setKinematics(encoders, encoder_speeds));
+        REQUIRE(estimator.advance());
+    }
+
+}

--- a/src/Estimators/tests/FloatingBaseEstimatorTest.cpp
+++ b/src/Estimators/tests/FloatingBaseEstimatorTest.cpp
@@ -42,8 +42,10 @@ TEST_CASE("Bare Bones Base Estimator")
     std::shared_ptr<StdImplementation> originalHandler = std::make_shared<StdImplementation>();
     IParametersHandler::shared_ptr parameterHandler = originalHandler;
 
+    // Populate the input configuration to be passed to the estimator
     REQUIRE(populateConfig(parameterHandler));
 
+    // Load the reduced iDynTree model to be passed to the estimator
     std::string model_path{getFBEURDFModelPath()};
     std::cout << model_path << std::endl;
     std::vector<std::string> joints_list = {"neck_pitch", "neck_roll", "neck_yaw",
@@ -62,14 +64,13 @@ TEST_CASE("Bare Bones Base Estimator")
 
     // Instantiate the estimator
     FloatingBaseEstimator estimator;
-    REQUIRE(estimator.modelComputations().setModel(model));
-    REQUIRE(estimator.initialize(parameterHandler));
-    REQUIRE(estimator.modelComputations().modelSet());
+    REQUIRE(estimator.initialize(parameterHandler, model));
+    REQUIRE(estimator.modelComputations().isModelSet());
     REQUIRE(estimator.modelComputations().nrJoints() == joints_list.size());
     REQUIRE(estimator.modelComputations().baseLink() == "root_link");
     REQUIRE(estimator.modelComputations().baseLinkIMU() == "root_link_imu_acc");
-    REQUIRE(estimator.modelComputations().leftFootContact() == "l_sole");
-    REQUIRE(estimator.modelComputations().rightFootContact() == "r_sole");
+    REQUIRE(estimator.modelComputations().leftFootContactFrame() == "l_sole");
+    REQUIRE(estimator.modelComputations().rightFootContactFrame() == "r_sole");
 
     auto b_H_imu = model.getFrameTransform(model.getFrameIndex("root_link_imu_acc"));
 
@@ -96,7 +97,7 @@ TEST_CASE("Bare Bones Base Estimator")
 
     encoder_speeds.setZero();
 
-    // estimate the parameters
+    // set measurements and advance the estimator
     for (int i = 0; i < 10000; i++)
     {
         REQUIRE(estimator.setIMUMeasurement(acc, gyro));

--- a/src/Estimators/tests/ResourceFolderPath.h.in
+++ b/src/Estimators/tests/ResourceFolderPath.h.in
@@ -1,0 +1,19 @@
+/**
+ * @file ResourceFolderPath.h(.in)
+ * @authors Stefano Dafarra
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef RESOURCE_FOLDERPATH_H_IN
+#define RESOURCE_FOLDERPATH_H_IN
+
+#define SOURCE_CONFIG_DIR "@CMAKE_CURRENT_SOURCE_DIR@"
+
+inline std::string getFBEURDFModelPath()
+{
+    return std::string(SOURCE_CONFIG_DIR) + "/base-estimator/model.urdf";
+}
+
+#endif // RESOURCE_FOLDERPATH_H_IN
+

--- a/src/Estimators/tests/base-estimator/model.urdf
+++ b/src/Estimators/tests/base-estimator/model.urdf
@@ -1,0 +1,3411 @@
+<robot name="iCub">
+  <link name="root_link">
+    <inertial>
+      <origin xyz="0.0248821 0.000103947 -0.0440806" rpy="1.57079632679 0 -1.57079632679"/>
+      <mass value="5.09143"/>
+      <inertia ixx="0.0139679" ixy="-5.93488e-06" ixz="-1.55458e-05" iyy="0.0202112" iyz="-0.00170968" izz="0.0249124"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.0364 0 0.032" rpy="1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.0364 0 0.032" rpy="1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_root_link_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="root_link_imu_frame"/>
+  <joint name="root_link_imu_frame_fixed_joint" type="fixed">
+    <origin xyz="0.085155 -0.011 -0.112309" rpy="-2.09439521059 0 -1.57079632679"/>
+    <parent link="root_link"/>
+    <child link="root_link_imu_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_hip_1">
+    <inertial>
+      <origin xyz="-0.0005145 -0.0380753 -7.1e-05" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.919978"/>
+      <inertia ixx="0.000404268" ixy="-1.26852e-06" ixz="1.11055e-06" iyy="0.000574741" iyz="-7.69474e-07" izz="0.000580025"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428515000001 0.026 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_hip_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0428515000001 0.026 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_hip_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hip_pitch" type="revolute">
+    <origin xyz="0.0064515 0.026 -0.119913" rpy="0 0 -3.14159265359"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="root_link"/>
+    <child link="r_hip_1"/>
+    <limit effort="55.5" lower="-0.785398163397" upper="2.33874119767" velocity="5.1"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="r_hip_2">
+    <inertial>
+      <origin xyz="-0.0013754 3.49999999998e-06 -0.044282" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.418361"/>
+      <inertia ixx="0.000487866" ixy="-2.70231e-07" ixz="1.85338e-07" iyy="0.000286099" iyz="1.22793e-05" izz="0.000315174"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428514998094 0.0701 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_hip_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0428514998094 0.0701 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_hip_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hip_roll" type="revolute">
+    <origin xyz="0 -0.0441 0" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 -2.22044604925e-16"/>
+    <parent link="r_hip_1"/>
+    <child link="r_hip_2"/>
+    <limit effort="37.0" lower="-0.349065850399" upper="2.09439510239" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="r_hip_3">
+    <inertial>
+      <origin xyz="-0.000123 -0.0002823 0.008718" rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.126212"/>
+      <inertia ixx="3.27938e-05" ixy="2.67901e-07" ixz="-4.41463e-09" iyy="5.69957e-05" iyz="3.32338e-08" izz="3.26449e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998094 -0.0701 -0.226213" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_upper_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998094 -0.0701 -0.226213" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_upper_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_leg_ft_sensor" type="fixed">
+    <origin xyz="-0.0008575 0 -0.0743" rpy="3.14159265359 0 0"/>
+    <parent link="r_hip_2"/>
+    <child link="r_hip_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_upper_leg">
+    <inertial>
+      <origin xyz="0.0033999 -2.91e-05 -0.078954" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.8035"/>
+      <inertia ixx="0.00647751422999" ixy="0.000129579429588" ixz="5.48205094739e-06" iyy="0.0014593786411" iyz="-0.000136613086875" izz="0.00646720823813"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998094 0.0701 0.240813" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998094 0.0701 0.240813" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_hip_yaw" type="revolute">
+    <origin xyz="0 0 0.0144" rpy="-3.14159265359 0 0"/>
+    <axis xyz="0.0 -2.22044604925e-16 -1.0"/>
+    <parent link="r_hip_3"/>
+    <child link="r_upper_leg"/>
+    <limit effort="37.0" lower="-1.3962634016" upper="1.3962634016" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="r_upper_leg_back_contact"/>
+  <joint name="r_upper_leg_back_contact_fixed_joint" type="fixed">
+    <origin xyz="-0.0511999 0 0.0146" rpy="0 1.57079632679 0"/>
+    <parent link="r_upper_leg"/>
+    <child link="r_upper_leg_back_contact"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_upper_leg_dh_frame"/>
+  <joint name="r_upper_leg_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.145825" rpy="1.57079632679 0 0"/>
+    <parent link="r_upper_leg"/>
+    <child link="r_upper_leg_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg">
+    <inertial>
+      <origin xyz="0.0012363 -0.0035131 -0.088794" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.472"/>
+      <inertia ixx="0.00423993167478" ixy="0.000228814548854" ixz="-5.55646459453e-05" iyy="0.00152095043447" iyz="-0.000264132979243" izz="0.00457358584206"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998094 0.0701000001907 0.386638" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_shank_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998094 0.0701000001907 0.386638" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_shank_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_knee" type="revolute">
+    <origin xyz="0 0 -0.145825" rpy="0 0 0"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="r_upper_leg"/>
+    <child link="r_lower_leg"/>
+    <limit effort="37.0" lower="-2.16420827247" upper="0.0698131700798" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="r_lower_leg_skin_0"/>
+  <joint name="r_lower_leg_skin_0_fixed_joint" type="fixed">
+    <origin xyz="0.0544117 -0.031214 -0.002634" rpy="2.09173809157e-06 -1.41530676247 2.48648458622"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_0"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_3"/>
+  <joint name="r_lower_leg_skin_3_fixed_joint" type="fixed">
+    <origin xyz="0.05157878 0.0304205 -0.002843" rpy="0 -1.42951054083 -2.30391484186"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_4"/>
+  <joint name="r_lower_leg_skin_4_fixed_joint" type="fixed">
+    <origin xyz="0.0583103 0.0167836 0.007272" rpy="-2.98636361519e-07 -1.25636748876 -2.75892380087"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_4"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_5"/>
+  <joint name="r_lower_leg_skin_5_fixed_joint" type="fixed">
+    <origin xyz="0.0636503 0.0003094 -0.001972" rpy="0 -1.38652215068 -3.14147169807"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_5"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_6"/>
+  <joint name="r_lower_leg_skin_6_fixed_joint" type="fixed">
+    <origin xyz="0.05208552 0.0304434 -0.022149" rpy="-3.14158927953 -1.46785123411 0.837492889077"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_6"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_9"/>
+  <joint name="r_lower_leg_skin_9_fixed_joint" type="fixed">
+    <origin xyz="0.0598214 0.0167973 -0.030962" rpy="-3.14159202356 -1.34224755325 0.379294477718"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_9"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_10"/>
+  <joint name="r_lower_leg_skin_10_fixed_joint" type="fixed">
+    <origin xyz="0.0644607 0.0003424 -0.021205" rpy="3.14159265355 -1.47095803541 0.000430021675261"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_10"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_11"/>
+  <joint name="r_lower_leg_skin_11_fixed_joint" type="fixed">
+    <origin xyz="0.0607108 -0.0160916 -0.030885" rpy="-3.14159218252 -1.3281180406 -0.27213836788"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_11"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_14"/>
+  <joint name="r_lower_leg_skin_14_fixed_joint" type="fixed">
+    <origin xyz="0.0550477 -0.031176 -0.0219" rpy="-3.14159181885 -1.46502735635 -0.654033407167"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_14"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_15"/>
+  <joint name="r_lower_leg_skin_15_fixed_joint" type="fixed">
+    <origin xyz="0.0591708 -0.0161788 0.007243" rpy="4.27484256729e-07 -1.25203633076 2.86798859471"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_15"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_16"/>
+  <joint name="r_lower_leg_skin_16_fixed_joint" type="fixed">
+    <origin xyz="0.0272875 -0.050287 -0.004549" rpy="1.33075915123e-05 -1.53260853515 1.96280242835"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_16"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_17"/>
+  <joint name="r_lower_leg_skin_17_fixed_joint" type="fixed">
+    <origin xyz="0.027875 -0.050312 -0.023882" rpy="-3.1415645262 -1.56366240237 -1.18022508756"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_17"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_19"/>
+  <joint name="r_lower_leg_skin_19_fixed_joint" type="fixed">
+    <origin xyz="0.0357534 0.0410628 0.006065" rpy="-8.90877717426e-07 -1.43498696978 -2.15863618017"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_19"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_20"/>
+  <joint name="r_lower_leg_skin_20_fixed_joint" type="fixed">
+    <origin xyz="0.0234419 0.0479908 -0.004952" rpy="-3.20556549428e-06 -1.50015513031 -1.86755092413"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_20"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_21"/>
+  <joint name="r_lower_leg_skin_21_fixed_joint" type="fixed">
+    <origin xyz="0.0242704 0.0485378 -0.024277" rpy="2.29671149558e-05 -1.55545513881 -1.87411972316"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_21"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_28"/>
+  <joint name="r_lower_leg_skin_28_fixed_joint" type="fixed">
+    <origin xyz="0.04087215 -0.04244 -0.032756" rpy="3.14158088865 -1.52252462169 -0.929681029763"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_28"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_29"/>
+  <joint name="r_lower_leg_skin_29_fixed_joint" type="fixed">
+    <origin xyz="0.03846637 -0.043516 -0.05242" rpy="3.14158017044 -1.53429841563 -0.915436346631"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_29"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_31"/>
+  <joint name="r_lower_leg_skin_31_fixed_joint" type="fixed">
+    <origin xyz="0.03914638 -0.042271 0.006327" rpy="-6.58381747139e-07 -1.4186494462 2.20853032986"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_31"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_32"/>
+  <joint name="r_lower_leg_skin_32_fixed_joint" type="fixed">
+    <origin xyz="0.04598301 0.0325847 -0.080733" rpy="-3.14159014988 -1.52238289798 0.645940380887"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_32"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_35"/>
+  <joint name="r_lower_leg_skin_35_fixed_joint" type="fixed">
+    <origin xyz="0.04774866 -0.031232 -0.080113" rpy="-3.14158668275 -1.51758467332 -0.541532486468"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_35"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_36"/>
+  <joint name="r_lower_leg_skin_36_fixed_joint" type="fixed">
+    <origin xyz="0.05322409 -0.0156018 -0.088362" rpy="-3.14159034144 -1.51587265281 -0.20740733566"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_36"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_37"/>
+  <joint name="r_lower_leg_skin_37_fixed_joint" type="fixed">
+    <origin xyz="0.0552572 0.0009644 -0.078318" rpy="-3.14158180452 -1.52318336898 0.00752450583063"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_37"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_38"/>
+  <joint name="r_lower_leg_skin_38_fixed_joint" type="fixed">
+    <origin xyz="0.04880467 -0.031263 -0.060757" rpy="3.14158665199 -1.5157299554 -0.54215359959"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_38"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_41"/>
+  <joint name="r_lower_leg_skin_41_fixed_joint" type="fixed">
+    <origin xyz="0.0566009 -0.0159129 -0.049854" rpy="-3.14159198825 -1.40681343597 -0.248233089413"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_41"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_42"/>
+  <joint name="r_lower_leg_skin_42_fixed_joint" type="fixed">
+    <origin xyz="0.0570106 0.0007962 -0.05908" rpy="3.14158970239 -1.43524750416 0.00687943651504"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_42"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_43"/>
+  <joint name="r_lower_leg_skin_43_fixed_joint" type="fixed">
+    <origin xyz="0.04712542 0.0323653 -0.061362" rpy="-3.14159136621 -1.53843038237 0.624217523667"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_43"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_46"/>
+  <joint name="r_lower_leg_skin_46_fixed_joint" type="fixed">
+    <origin xyz="0.0558156 0.0172164 -0.05018" rpy="-3.14158987809 -1.42759881603 0.325607710876"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_46"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_47"/>
+  <joint name="r_lower_leg_skin_47_fixed_joint" type="fixed">
+    <origin xyz="0.05264163 0.0176389 -0.08886" rpy="3.14158963519 -1.51690559406 0.262640425058"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_47"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_49"/>
+  <joint name="r_lower_leg_skin_49_fixed_joint" type="fixed">
+    <origin xyz="0.04113137 0.0324385 -0.138859" rpy="-3.14158934751 -1.48996135695 0.729763592113"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_49"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_50"/>
+  <joint name="r_lower_leg_skin_50_fixed_joint" type="fixed">
+    <origin xyz="0.043016947 0.0325273 -0.119469" rpy="3.14159069596 -1.49900732636 0.695784020081"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_50"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_51"/>
+  <joint name="r_lower_leg_skin_51_fixed_joint" type="fixed">
+    <origin xyz="0.05141583 0.017759 -0.108206" rpy="-3.14158890179 -1.50628475717 0.272079935713"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_51"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_52"/>
+  <joint name="r_lower_leg_skin_52_fixed_joint" type="fixed">
+    <origin xyz="0.05299832 0.0012664 -0.116895" rpy="-3.14159164042 -1.50318674421 0.0108717260994"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_52"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_53"/>
+  <joint name="r_lower_leg_skin_53_fixed_joint" type="fixed">
+    <origin xyz="0.05207312 -0.0154339 -0.107654" rpy="3.14159063987 -1.50595307447 -0.211407322892"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_53"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_54"/>
+  <joint name="r_lower_leg_skin_54_fixed_joint" type="fixed">
+    <origin xyz="0.04512708 -0.030749 -0.118787" rpy="3.14158825193 -1.49745145571 -0.575115374473"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_54"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_55"/>
+  <joint name="r_lower_leg_skin_55_fixed_joint" type="fixed">
+    <origin xyz="0.043502663 -0.030489 -0.138143" rpy="3.14158906486 -1.48995787038 -0.597219943789"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_55"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_56"/>
+  <joint name="r_lower_leg_skin_56_fixed_joint" type="fixed">
+    <origin xyz="0.04926839 -0.015121 -0.146218" rpy="-3.14158920404 -1.49124819828 -0.2234844764"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_56"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_60"/>
+  <joint name="r_lower_leg_skin_60_fixed_joint" type="fixed">
+    <origin xyz="0.04836967 0.018056 -0.146938" rpy="-3.14159173337 -1.48985968527 0.302951871954"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_60"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_lower_leg_skin_61"/>
+  <joint name="r_lower_leg_skin_61_fixed_joint" type="fixed">
+    <origin xyz="0.05161952 0.0014266 -0.136169" rpy="-3.14159100925 -1.49602097086 0.0132014275205"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_lower_leg_skin_61"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_ankle_1">
+    <inertial>
+      <origin xyz="0.0151436 -0.0008686 4.2e-05" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.6803"/>
+      <inertia ixx="0.000404618848932" ixy="7.49819286945e-07" ixz="-3.01349467691e-05" iyy="0.000448633654664" iyz="2.5726697409e-06" izz="0.000308235939139"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998094 0.0701000001907 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_ankle_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998094 0.0701000001907 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_ankle_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_ankle_pitch" type="revolute">
+    <origin xyz="0 0 -0.2005" rpy="0 0 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="r_lower_leg"/>
+    <child link="r_ankle_1"/>
+    <limit effort="37.0" lower="-0.610865238198" upper="0.610865238198" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="r_ankle_2">
+    <inertial>
+      <origin xyz="0.0007673 -8.20000000001e-06 -0.038202" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.267485"/>
+      <inertia ixx="0.000335682" ixy="-7.53335e-08" ixz="2.93681e-08" iyy="0.00025387" iyz="-4.26218e-07" izz="0.000154833"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089996186 0.0701000001907 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_foot_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089996186 0.0701000001907 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_foot_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_ankle_roll" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 -2.22044604925e-16"/>
+    <parent link="r_ankle_1"/>
+    <child link="r_ankle_2"/>
+    <limit effort="37.0" lower="-0.436332312999" upper="0.436332312999" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="r_foot">
+    <inertial>
+      <origin xyz="0.0336001 0.0053719 -0.001147" rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.382866"/>
+      <inertia ixx="0.00120946" ixy="3.74585e-07" ixz="-5.78759e-05" iyy="0.00141439" iyz="-7.80325e-06" izz="0.000273599"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0472089996187 -0.0701000001907 -0.647438000286" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_sole_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0472089996187 -0.0701000001907 -0.647438000286" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_sole_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_foot_ft_sensor" type="fixed">
+    <origin xyz="-0.0035 0 -0.0605" rpy="3.14159265359 0 0"/>
+    <parent link="r_ankle_2"/>
+    <child link="r_foot"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole"/>
+  <joint name="r_sole_fixed_joint" type="fixed">
+    <origin xyz="0.0035 0 0.004" rpy="-3.14159265359 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_0"/>
+  <joint name="r_sole_skin_0_fixed_joint" type="fixed">
+    <origin xyz="0.0604767 -0.0254106 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_0"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_1"/>
+  <joint name="r_sole_skin_1_fixed_joint" type="fixed">
+    <origin xyz="0.0788511 -0.0194404 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_1"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_2"/>
+  <joint name="r_sole_skin_2_fixed_joint" type="fixed">
+    <origin xyz="0.0932087 -0.032368 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_2"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_3"/>
+  <joint name="r_sole_skin_3_fixed_joint" type="fixed">
+    <origin xyz="0.1115831 -0.0263978 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_4"/>
+  <joint name="r_sole_skin_4_fixed_joint" type="fixed">
+    <origin xyz="0.1156 -0.0075 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_4"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_8"/>
+  <joint name="r_sole_skin_8_fixed_joint" type="fixed">
+    <origin xyz="0.1052593 0.0243254 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_8"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_9"/>
+  <joint name="r_sole_skin_9_fixed_joint" type="fixed">
+    <origin xyz="0.0909017 0.037253 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_9"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_10"/>
+  <joint name="r_sole_skin_10_fixed_joint" type="fixed">
+    <origin xyz="0.0725273 0.031283 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_10"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_11"/>
+  <joint name="r_sole_skin_11_fixed_joint" type="fixed">
+    <origin xyz="0.0685104 0.012385 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_11"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_12"/>
+  <joint name="r_sole_skin_12_fixed_joint" type="fixed">
+    <origin xyz="0.082868 -0.0005426 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_12"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_13"/>
+  <joint name="r_sole_skin_13_fixed_joint" type="fixed">
+    <origin xyz="0.1012424 0.0054276 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_13"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_14"/>
+  <joint name="r_sole_skin_14_fixed_joint" type="fixed">
+    <origin xyz="0.05013603 0.0064148 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_14"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_15"/>
+  <joint name="r_sole_skin_15_fixed_joint" type="fixed">
+    <origin xyz="0.04611917 -0.012483 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_15"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_17"/>
+  <joint name="r_sole_skin_17_fixed_joint" type="fixed">
+    <origin xyz="-0.0296855 0.033257 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_17"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_18"/>
+  <joint name="r_sole_skin_18_fixed_joint" type="fixed">
+    <origin xyz="-0.0480599 0.027287 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_18"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_19"/>
+  <joint name="r_sole_skin_19_fixed_joint" type="fixed">
+    <origin xyz="-0.0520767 0.0083892 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_19"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_20"/>
+  <joint name="r_sole_skin_20_fixed_joint" type="fixed">
+    <origin xyz="-0.0377192 -0.0045384 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_20"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_21"/>
+  <joint name="r_sole_skin_21_fixed_joint" type="fixed">
+    <origin xyz="0.0357785 0.0193424 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_21"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_22"/>
+  <joint name="r_sole_skin_22_fixed_joint" type="fixed">
+    <origin xyz="0.0277448 -0.0184532 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_22"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_24"/>
+  <joint name="r_sole_skin_24_fixed_joint" type="fixed">
+    <origin xyz="-0.0049872 -0.0114958 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_24"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_25"/>
+  <joint name="r_sole_skin_25_fixed_joint" type="fixed">
+    <origin xyz="0.0133872 -0.0055256 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_25"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_26"/>
+  <joint name="r_sole_skin_26_fixed_joint" type="fixed">
+    <origin xyz="0.0174041 0.0133722 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_26"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_27"/>
+  <joint name="r_sole_skin_27_fixed_joint" type="fixed">
+    <origin xyz="0.0030465 0.0262998 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_27"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_28"/>
+  <joint name="r_sole_skin_28_fixed_joint" type="fixed">
+    <origin xyz="-0.0153279 0.0203296 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_28"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_sole_skin_29"/>
+  <joint name="r_sole_skin_29_fixed_joint" type="fixed">
+    <origin xyz="-0.0193448 0.0014318 0.0075" rpy="0 0 0"/>
+    <parent link="r_foot"/>
+    <child link="r_sole_skin_29"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_hip_1">
+    <inertial>
+      <origin xyz="-0.0005108 0.0380923 -8.3e-05" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.919725"/>
+      <inertia ixx="0.000404539" ixy="1.18502e-06" ixz="-9.64514e-07" iyy="0.000573315" iyz="-1.06028e-06" izz="0.000578982"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428515000001 -0.026 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_hip_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0428515000001 -0.026 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_hip_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hip_pitch" type="revolute">
+    <origin xyz="0.0064515 -0.026 -0.119913" rpy="0 0 -3.14159265359"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="root_link"/>
+    <child link="l_hip_1"/>
+    <limit effort="55.5" lower="-0.785398163397" upper="2.33874119767" velocity="5.1"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="l_hip_2">
+    <inertial>
+      <origin xyz="-0.0015762 -1.94e-05 -0.044053" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.421106"/>
+      <inertia ixx="0.000494284" ixy="1.5483e-07" ixz="-1.86308e-07" iyy="0.000288736" iyz="1.52962e-05" izz="0.000319008"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0428514998093 -0.0701 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_hip_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0428514998093 -0.0701 0.151913" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_hip_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hip_roll" type="revolute">
+    <origin xyz="0 0.0441 0" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 2.22044604925e-16"/>
+    <parent link="l_hip_1"/>
+    <child link="l_hip_2"/>
+    <limit effort="37.0" lower="-0.349065850399" upper="2.09439510239" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="l_hip_3">
+    <inertial>
+      <origin xyz="-0.000123 -0.0002823 0.008718" rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.126212"/>
+      <inertia ixx="3.27938e-05" ixy="2.67901e-07" ixz="-4.41463e-09" iyy="5.69957e-05" iyz="3.32338e-08" izz="3.26449e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998093 0.0701 -0.226213" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_upper_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998093 0.0701 -0.226213" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_upper_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_leg_ft_sensor" type="fixed">
+    <origin xyz="-0.0008575 0 -0.0743" rpy="3.14159265359 0 0"/>
+    <parent link="l_hip_2"/>
+    <child link="l_hip_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_upper_leg">
+    <inertial>
+      <origin xyz="0.0033868 0.0001018 -0.078916" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.8084"/>
+      <inertia ixx="0.00648512673084" ixy="-0.00012421121424" ixz="-3.97399421479e-06" iyy="0.00146250529833" iyz="-0.00013681806888" izz="0.00647619242046"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998093 -0.0701 0.240813" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998093 -0.0701 0.240813" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_thigh_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_hip_yaw" type="revolute">
+    <origin xyz="0 0 0.0144" rpy="-3.14159265359 0 0"/>
+    <axis xyz="0.0 2.22044604925e-16 1.0"/>
+    <parent link="l_hip_3"/>
+    <child link="l_upper_leg"/>
+    <limit effort="37.0" lower="-1.3962634016" upper="1.3962634016" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="l_upper_leg_back_contact"/>
+  <joint name="l_upper_leg_back_contact_fixed_joint" type="fixed">
+    <origin xyz="-0.0512567 0 0.0146" rpy="0 1.57079632679 0"/>
+    <parent link="l_upper_leg"/>
+    <child link="l_upper_leg_back_contact"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_upper_leg_dh_frame"/>
+  <joint name="l_upper_leg_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0 0 -0.145825" rpy="1.57079632679 0 0"/>
+    <parent link="l_upper_leg"/>
+    <child link="l_upper_leg_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_lower_leg">
+    <inertial>
+      <origin xyz="0.0009997 0.0034969 -0.088567" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="1.4724"/>
+      <inertia ixx="0.00423698606499" ixy="-0.000239615181423" ixz="6.76166218238e-05" iyy="0.00152221313636" iyz="-0.00023314283575" izz="0.00457007183207"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998093 -0.0701000001908 0.386638" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_shank_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998093 -0.0701000001908 0.386638" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_shank_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_knee" type="revolute">
+    <origin xyz="0 0 -0.145825" rpy="0 0 0"/>
+    <axis xyz="-2.22044604925e-16 -1.0 0.0"/>
+    <parent link="l_upper_leg"/>
+    <child link="l_lower_leg"/>
+    <limit effort="37.0" lower="-2.16420827247" upper="0.0698131700798" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="l_ankle_1">
+    <inertial>
+      <origin xyz="0.015153 0.0009021 4.2e-05" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.6798"/>
+      <inertia ixx="0.000404474297345" ixy="-1.13226038781e-06" ixz="3.04665105776e-05" iyy="0.00044788735407" iyz="2.57265834141e-06" izz="0.000307603045377"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089998093 -0.0701000001908 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_ankle_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089998093 -0.0701000001908 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_ankle_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_ankle_pitch" type="revolute">
+    <origin xyz="0 0 -0.2005" rpy="0 0 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="l_lower_leg"/>
+    <child link="l_ankle_1"/>
+    <limit effort="37.0" lower="-0.610865238198" upper="0.610865238198" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="l_ankle_2">
+    <inertial>
+      <origin xyz="0.0007673 -8.2e-06 -0.038202" rpy="1.57079632679 0 1.57079632679"/>
+      <mass value="0.267485"/>
+      <inertia ixx="0.000335682" ixy="-7.53335e-08" ixz="2.93681e-08" iyy="0.00025387" iyz="-4.26218e-07" izz="0.000154833"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0437089996186 -0.0701000001908 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_foot_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0437089996186 -0.0701000001908 0.587138" rpy="1.57079632679 0 1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_foot_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_ankle_roll" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="1.0 0.0 2.22044604925e-16"/>
+    <parent link="l_ankle_1"/>
+    <child link="l_ankle_2"/>
+    <limit effort="37.0" lower="-0.436332312999" upper="0.436332312999" velocity="7.64"/>
+    <dynamics damping="0.223" friction="0.0"/>
+  </joint>
+  <link name="l_foot">
+    <inertial>
+      <origin xyz="0.0336668 -0.0053736 -0.001164" rpy="-1.57079632679 0 -1.57079632679"/>
+      <mass value="0.382968"/>
+      <inertia ixx="0.00121242" ixy="-3.69533e-07" ixz="5.79273e-05" iyy="0.00141712" iyz="-7.64972e-06" izz="0.000273846"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0472089996186 0.0701000001908 -0.647438000286" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_sole_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0472089996186 0.0701000001908 -0.647438000286" rpy="-1.57079632679 0 -1.57079632679"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_sole_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_foot_ft_sensor" type="fixed">
+    <origin xyz="-0.0035 0 -0.0605" rpy="3.14159265359 0 0"/>
+    <parent link="l_ankle_2"/>
+    <child link="l_foot"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole"/>
+  <joint name="l_sole_fixed_joint" type="fixed">
+    <origin xyz="0.0035 0 0.004" rpy="-3.14159265359 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_0"/>
+  <joint name="l_sole_skin_0_fixed_joint" type="fixed">
+    <origin xyz="0.0932087 0.032368 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_0"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_1"/>
+  <joint name="l_sole_skin_1_fixed_joint" type="fixed">
+    <origin xyz="0.0788511 0.0194399 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_1"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_2"/>
+  <joint name="l_sole_skin_2_fixed_joint" type="fixed">
+    <origin xyz="0.0604767 0.0254106 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_2"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_3"/>
+  <joint name="l_sole_skin_3_fixed_joint" type="fixed">
+    <origin xyz="0.04611917 0.0124825 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_4"/>
+  <joint name="l_sole_skin_4_fixed_joint" type="fixed">
+    <origin xyz="0.05013603 -0.0064148 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_4"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_8"/>
+  <joint name="l_sole_skin_8_fixed_joint" type="fixed">
+    <origin xyz="0.0725273 -0.031283 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_8"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_9"/>
+  <joint name="l_sole_skin_9_fixed_joint" type="fixed">
+    <origin xyz="0.0909017 -0.037254 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_9"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_10"/>
+  <joint name="l_sole_skin_10_fixed_joint" type="fixed">
+    <origin xyz="0.1052593 -0.0243254 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_10"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_11"/>
+  <joint name="l_sole_skin_11_fixed_joint" type="fixed">
+    <origin xyz="0.1012424 -0.0054281 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_11"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_12"/>
+  <joint name="l_sole_skin_12_fixed_joint" type="fixed">
+    <origin xyz="0.082868 0.0005426 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_12"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_13"/>
+  <joint name="l_sole_skin_13_fixed_joint" type="fixed">
+    <origin xyz="0.0685104 -0.0123855 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_13"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_14"/>
+  <joint name="l_sole_skin_14_fixed_joint" type="fixed">
+    <origin xyz="0.1156 0.0074995 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_14"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_15"/>
+  <joint name="l_sole_skin_15_fixed_joint" type="fixed">
+    <origin xyz="0.1115831 0.0263973 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_15"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_17"/>
+  <joint name="l_sole_skin_17_fixed_joint" type="fixed">
+    <origin xyz="-0.0377192 0.0045384 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_17"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_18"/>
+  <joint name="l_sole_skin_18_fixed_joint" type="fixed">
+    <origin xyz="-0.0520767 -0.0083897 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_18"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_19"/>
+  <joint name="l_sole_skin_19_fixed_joint" type="fixed">
+    <origin xyz="-0.0480599 -0.027287 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_19"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_20"/>
+  <joint name="l_sole_skin_20_fixed_joint" type="fixed">
+    <origin xyz="-0.0296855 -0.033258 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_20"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_21"/>
+  <joint name="l_sole_skin_21_fixed_joint" type="fixed">
+    <origin xyz="0.0277448 0.0184532 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_21"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_22"/>
+  <joint name="l_sole_skin_22_fixed_joint" type="fixed">
+    <origin xyz="0.0357785 -0.0193429 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_22"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_24"/>
+  <joint name="l_sole_skin_24_fixed_joint" type="fixed">
+    <origin xyz="0.0030465 -0.0263003 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_24"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_25"/>
+  <joint name="l_sole_skin_25_fixed_joint" type="fixed">
+    <origin xyz="0.0174041 -0.0133722 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_25"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_26"/>
+  <joint name="l_sole_skin_26_fixed_joint" type="fixed">
+    <origin xyz="0.0133872 0.0055251 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_26"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_27"/>
+  <joint name="l_sole_skin_27_fixed_joint" type="fixed">
+    <origin xyz="-0.0049872 0.0114958 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_27"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_28"/>
+  <joint name="l_sole_skin_28_fixed_joint" type="fixed">
+    <origin xyz="-0.0193448 -0.0014323 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_28"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_sole_skin_29"/>
+  <joint name="l_sole_skin_29_fixed_joint" type="fixed">
+    <origin xyz="-0.0153279 -0.0203296 0.0075" rpy="0 0 0"/>
+    <parent link="l_foot"/>
+    <child link="l_sole_skin_29"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="torso_1">
+    <inertial>
+      <origin xyz="0.0270921359 0.02914798 -0.0004398" rpy="0 0 0"/>
+      <mass value="0.67144"/>
+      <inertia ixx="0.00040911" ixy="-1.04522e-06" ixz="-1.02516e-06" iyy="0.000384141" iyz="6.50708e-06" izz="0.000299445"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0270462998093 0.032 0.0364" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_lap_belt_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0270462998093 0.032 0.0364" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_lap_belt_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_pitch" type="revolute">
+    <origin xyz="0 0.0270463 0" rpy="1.57079632679 0 -1.57079632679"/>
+    <axis xyz="1.0 0.0 0.0"/>
+    <parent link="root_link"/>
+    <child link="torso_1"/>
+    <limit effort="50000" lower="-0.349065850399" upper="1.2217304764" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="torso_2">
+    <inertial>
+      <origin xyz="-0.000113507809265 0.0361525 0.0570963" rpy="0 0 0"/>
+      <mass value="0.425685"/>
+      <inertia ixx="0.000829234" ixy="2.37006e-08" ixz="9.25231e-08" iyy="0.000436517" iyz="-1.74814e-07" izz="0.000604802"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0.1433 0.0386531" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_lap_belt_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0.1433 0.0386531" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_lap_belt_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_roll" type="revolute">
+    <origin xyz="0.0270462998093 0.032 -0.0573446" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 -1.0"/>
+    <parent link="torso_1"/>
+    <child link="torso_2"/>
+    <limit effort="50000" lower="-0.523598775598" upper="0.523598775598" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="chest">
+    <inertial>
+      <origin xyz="0.000188619190735 0.073091 -0.0472381" rpy="0 0 0"/>
+      <mass value="7.638"/>
+      <inertia ixx="0.0430324878618" ixy="2.91075388804e-05" ixz="0.000181985229949" iyy="0.0440835725548" iyz="-0.000429106409108" izz="0.0260563249911"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0.0928 -0.024189" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_chest_bb_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0.0928 -0.024189" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_chest_bb_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="torso_yaw" type="revolute">
+    <origin xyz="0 0.05 0.0628421" rpy="0 0 0"/>
+    <axis xyz="0.0 -1.0 0.0"/>
+    <parent link="torso_2"/>
+    <child link="chest"/>
+    <limit effort="50000" lower="-0.872664625997" upper="0.872664625997" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_shoulder_1">
+    <inertial>
+      <origin xyz="-0.0122656014133 3.2e-05 -0.00321064290449" rpy="0 0 0"/>
+      <mass value="0.114862"/>
+      <inertia ixx="2.24541e-05" ixy="-1.65173e-08" ixz="-3.55626e-06" iyy="2.29582e-05" iyz="-6.13337e-08" izz="1.00116e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0990079253076 0 -0.0265292487558" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_shoulder_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0990079253076 0 -0.0265292487558" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_shoulder_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_pitch" type="revolute">
+    <origin xyz="-0.120015999809 0.0928 0.0079693" rpy="0 -0.523598883792 3.14159265359"/>
+    <axis xyz="-0.965925926173 0.0 0.258819275525"/>
+    <parent link="chest"/>
+    <child link="r_shoulder_1"/>
+    <limit effort="50000" lower="-1.66678943565" upper="0.174532925199" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_shoulder_2">
+    <inertial>
+      <origin xyz="-0.0214141709438 0.000271725272551 -0.0194402344535" rpy="0 0 0"/>
+      <mass value="0.238162"/>
+      <inertia ixx="0.000158626" ixy="-1.12091e-07" ixz="1.02574e-05" iyy="0.000206526" iyz="1.19785e-06" izz="0.000104956"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.106587808568 2.31914715418e-07 -0.0407392121175" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_shoulder_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.106587808568 2.31914715418e-07 -0.0407392121175" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_shoulder_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_roll" type="revolute">
+    <origin xyz="-0.00758046573227 0 0.0142102463639" rpy="-0.270597611583 -0.252680154648 -1.50155680035"/>
+    <axis xyz="-0.258819 -2.77555756156e-17 -0.965926"/>
+    <parent link="r_shoulder_1"/>
+    <child link="r_shoulder_2"/>
+    <limit effort="50000" lower="0.0" upper="2.80648943721" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_shoulder_3">
+    <inertial>
+      <origin xyz="-0.0267620766871 -6.99999999998e-06 0.0146999207713" rpy="0 0 0"/>
+      <mass value="0.35913"/>
+      <inertia ixx="0.000142333" ixy="3.60361e-07" ixz="4.94445e-05" iyy="0.000197746" iyz="2.65919e-07" izz="0.000151821"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.131933879164 0 -0.0353515667647" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_upper_arm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.131933879164 0 -0.0353515667647" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_upper_arm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_shoulder_yaw" type="revolute">
+    <origin xyz="-0.0253460713232 2.32750427306e-07 -0.00538764806457" rpy="-0.252689546175 0.0085186183214 0.067039889142"/>
+    <axis xyz="0.965925843882 -2.22044604925e-16 -0.258818979447"/>
+    <parent link="r_shoulder_2"/>
+    <child link="r_shoulder_3"/>
+    <limit effort="50000" lower="-0.645771823238" upper="1.3962634016" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_upper_arm">
+    <inertial>
+      <origin xyz="-0.006087 0.000126 0.0293121" rpy="0 1.30899700697 0"/>
+      <mass value="0.745104"/>
+      <inertia ixx="0.000509527" ixy="1.19292e-06" ixz="-1.17426e-05" iyy="0.000668487" iyz="1.13363e-06" izz="0.000599254"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.015 0 -0.1933" rpy="0 1.30899700697 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_elbow_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.015 0 -0.1933" rpy="0 1.30899700697 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_elbow_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_arm_ft_sensor" type="fixed">
+    <origin xyz="-0.0508973017665 0 0.0291670296206" rpy="0 -1.30899700697 0"/>
+    <parent link="r_shoulder_3"/>
+    <child link="r_upper_arm"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_elbow_1">
+    <inertial>
+      <origin xyz="-0.00673912932843 0.0188019 -0.00465769236154" rpy="0 0 0"/>
+      <mass value="0.267903"/>
+      <inertia ixx="8.13344e-05" ixy="7.36974e-06" ixz="-1.04536e-05" iyy="5.86947e-05" iyz="3.92498e-06" izz="9.68353e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.259390463317 0.0224999 -0.0850325886962" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_elbow_prosup_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.259390463317 0.0224999 -0.0850325886962" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_elbow_prosup_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_elbow" type="revolute">
+    <origin xyz="0 -0.0224999 0.07926" rpy="0 1.30899700697 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="r_upper_arm"/>
+    <child link="r_elbow_1"/>
+    <limit effort="50000" lower="0.261799387799" upper="1.85004900711" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_forearm">
+    <inertial>
+      <origin xyz="-0.0404391133886 -0.000328 0.00532733448387" rpy="0 0 0"/>
+      <mass value="0.6347"/>
+      <inertia ixx="0.000370044" ixy="-1.65419e-06" ixz="0.00010538" iyy="0.000672279" iyz="1.1456e-06" izz="0.000553637"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.296886967375 0 -0.0795506015227" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_forearm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.296886967375 0 -0.0795506015227" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_forearm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_prosup" type="revolute">
+    <origin xyz="-0.0384624299027 0.0224999 -0.00522316819403" rpy="0 0 0"/>
+    <axis xyz="0.965925843882 -2.22044604925e-16 -0.258818979447"/>
+    <parent link="r_elbow_1"/>
+    <child link="r_forearm"/>
+    <limit effort="50000" lower="-1.0471975512" upper="1.0471975512" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_forearm_skin_0"/>
+  <joint name="r_forearm_skin_0_fixed_joint" type="fixed">
+    <origin xyz="-0.0454493286618 0.030077 -0.00628656037901" rpy="1.69181522292 -0.271026744341 -3.06880438227"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_0"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_1"/>
+  <joint name="r_forearm_skin_1_fixed_joint" type="fixed">
+    <origin xyz="-0.0333728935826 0.028826 -0.0198456867711" rpy="1.86694023278 -0.274442533764 -3.09946977984"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_1"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_2"/>
+  <joint name="r_forearm_skin_2_fixed_joint" type="fixed">
+    <origin xyz="-0.0146988929852 0.031279 -0.0160117338371" rpy="1.72847287019 -0.264015219116 -3.12733260687"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_2"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_3"/>
+  <joint name="r_forearm_skin_3_fixed_joint" type="fixed">
+    <origin xyz="-0.045567293622 -0.030891 -0.00633000929351" rpy="-1.69487280859 -0.269757727104 3.07959743574"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_4"/>
+  <joint name="r_forearm_skin_4_fixed_joint" type="fixed">
+    <origin xyz="-0.0635326332996 -0.0281163 -0.00899784258066" rpy="-1.80734960194 -0.0393131796327 2.97997643632"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_4"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_5"/>
+  <joint name="r_forearm_skin_5_fixed_joint" type="fixed">
+    <origin xyz="-0.0688211941968 -0.0179483 -0.0231133361791" rpy="-2.5410475806 -0.385627260642 3.05486989667"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_5"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_6"/>
+  <joint name="r_forearm_skin_6_fixed_joint" type="fixed">
+    <origin xyz="-0.0333948436255 -0.0295479 -0.0198325583433" rpy="-1.86628164653 -0.272886336181 3.10448585021"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_6"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_7"/>
+  <joint name="r_forearm_skin_7_fixed_joint" type="fixed">
+    <origin xyz="-0.0147224260074 -0.0319422 -0.0159326482703" rpy="-1.72564640857 -0.263992900722 3.12721254266"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_7"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_8"/>
+  <joint name="r_forearm_skin_8_fixed_joint" type="fixed">
+    <origin xyz="-0.0228528628554 -0.0097862 -0.041885146375" rpy="-2.94801979137 -0.270605090512 3.13980557285"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_8"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_9"/>
+  <joint name="r_forearm_skin_9_fixed_joint" type="fixed">
+    <origin xyz="-0.0376032734683 -0.018955 -0.0340163371186" rpy="-2.58406517708 -0.2933217196 3.12128407396"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_9"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_10"/>
+  <joint name="r_forearm_skin_10_fixed_joint" type="fixed">
+    <origin xyz="-0.0542285210888 -0.0097861 -0.0321469082866" rpy="-2.94123313406 -0.328304471922 3.1276263754"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_10"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_11"/>
+  <joint name="r_forearm_skin_11_fixed_joint" type="fixed">
+    <origin xyz="-0.0542240912024 0.009043 -0.0321431259452" rpy="2.93929835957 -0.329101389745 -3.12731916446"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_11"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_12"/>
+  <joint name="r_forearm_skin_12_fixed_joint" type="fixed">
+    <origin xyz="-0.0375994633868 0.018216 -0.0340191179961" rpy="2.58303505964 -0.29483050207 -3.12026580314"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_12"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_13"/>
+  <joint name="r_forearm_skin_13_fixed_joint" type="fixed">
+    <origin xyz="-0.0228550868405 0.009048 -0.0418919009209" rpy="2.94896679198 -0.270583947189 -3.13981880352"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_13"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_14"/>
+  <joint name="r_forearm_skin_14_fixed_joint" type="fixed">
+    <origin xyz="-0.0687703276364 0.01716 -0.0230239558511" rpy="2.48044991868 -0.295542566281 -2.91877349139"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_14"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_15"/>
+  <joint name="r_forearm_skin_15_fixed_joint" type="fixed">
+    <origin xyz="-0.0633786419662 0.027145 -0.00879405455544" rpy="1.80492769741 -0.289783281916 -3.02765891428"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_15"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_16"/>
+  <joint name="r_forearm_skin_16_fixed_joint" type="fixed">
+    <origin xyz="-0.03792482187 0.030487 0.0206369503605" rpy="1.41280007026 -0.25082462139 -3.06572742343"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_16"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_17"/>
+  <joint name="r_forearm_skin_17_fixed_joint" type="fixed">
+    <origin xyz="-0.0543170548821 0.027725 0.0303291240179" rpy="1.27223716205 -0.23059304703 -3.03195542837"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_17"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_19"/>
+  <joint name="r_forearm_skin_19_fixed_joint" type="fixed">
+    <origin xyz="-0.0381266107138 -0.0312941 0.020690605393" rpy="-1.41560888703 -0.252569290226 3.07715217889"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_19"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_22"/>
+  <joint name="r_forearm_skin_22_fixed_joint" type="fixed">
+    <origin xyz="-0.0544173950421 -0.0287223 0.0306037516609" rpy="-1.2658242728 -0.234328151379 3.04788317971"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_22"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_24"/>
+  <joint name="r_forearm_skin_24_fixed_joint" type="fixed">
+    <origin xyz="-0.0700345319564 -0.0097164 0.050069108714" rpy="-0.23489327644 -0.0388172993982 3.08676345459"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_24"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_25"/>
+  <joint name="r_forearm_skin_25_fixed_joint" type="fixed">
+    <origin xyz="-0.0535999216295 -0.0182238 0.0454698125045" rpy="-0.564295527715 -0.136980272197 3.05963182792"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_25"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_28"/>
+  <joint name="r_forearm_skin_28_fixed_joint" type="fixed">
+    <origin xyz="-0.0535859272148 0.017412 0.045352037397" rpy="0.59077064408 -0.0531607226063 3.10597081167"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_28"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_skin_29"/>
+  <joint name="r_forearm_skin_29_fixed_joint" type="fixed">
+    <origin xyz="-0.0700355805031 0.008954 0.0500111036233" rpy="0.248630982209 -0.0383136556786 -3.08328999116"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_skin_29"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_forearm_dh_frame"/>
+  <joint name="r_forearm_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="-0.102871102373 7.00000000002e-06 0.0275642213111" rpy="-0.261799319827 0 -1.57079632679"/>
+    <parent link="r_forearm"/>
+    <child link="r_forearm_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="r_wrist_1">
+    <inertial>
+      <origin xyz="0.000986101955547 -0.001176 0.00410132736724" rpy="0 0 0"/>
+      <mass value="0.0362615"/>
+      <inertia ixx="5.57722e-06" ixy="-3.10462e-08" ixz="-9.44554e-07" iyy="5.29845e-06" iyz="-1.59685e-07" izz="1.87724e-06"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.400392176248 -7.00000000009e-06 -0.104748304516" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_wrist_pitch_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.400392176248 -7.00000000009e-06 -0.104748304516" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_wrist_pitch_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_pitch" type="revolute">
+    <origin xyz="-0.103505208873 7.00000000002e-06 0.0251977029936" rpy="0 0 0"/>
+    <axis xyz="0.258818979447 0.0 0.965925843882"/>
+    <parent link="r_forearm"/>
+    <child link="r_wrist_1"/>
+    <limit effort="50000" lower="-1.3962634016" upper="0.436332312999" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_hand">
+    <inertial>
+      <origin xyz="-0.064668163717 0.0056002 0.0226812940918" rpy="0 0 0"/>
+      <mass value="0.248289"/>
+      <inertia ixx="0.000162381" ixy="-2.3536e-06" ixz="3.61526e-05" iyy="0.00043138" iyz="2.07146e-05" izz="0.00030575"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.399758069749 0.0194929 -0.107114822834" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_hand_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.399758069749 0.0194929 -0.107114822834" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_r_hand_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="r_wrist_yaw" type="revolute">
+    <origin xyz="0.000634106499644 -0.0194999 0.00236651831751" rpy="0 0 0"/>
+    <axis xyz="2.22044604925e-16 1.0 0.0"/>
+    <parent link="r_wrist_1"/>
+    <child link="r_hand"/>
+    <limit effort="50000" lower="-0.349065850399" upper="0.436332312999" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="r_hand_dh_frame"/>
+  <joint name="r_hand_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="-0.0576542978428 -0.0055568 0.0136938323083" rpy="-1.57079632679 -0.261799319827 3.14159265359"/>
+    <parent link="r_hand"/>
+    <child link="r_hand_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_shoulder_1">
+    <inertial>
+      <origin xyz="-0.008985 -3.3e-05 -0.0088998" rpy="0 0 0"/>
+      <mass value="0.114882"/>
+      <inertia ixx="2.24676e-05" ixy="-1.77064e-08" ixz="3.55951e-06" iyy="2.29712e-05" iyz="6.57597e-08" izz="1.00139e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.120257482 0 -0.032223" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_shoulder_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.120257482 0 -0.032223" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_shoulder_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_pitch" type="revolute">
+    <origin xyz="0.120016000191 0.0928 0.0079693" rpy="0 0 0"/>
+    <axis xyz="0.965926 0.0 0.258819"/>
+    <parent link="chest"/>
+    <child link="l_shoulder_1"/>
+    <limit effort="50000" lower="-1.66678943565" upper="0.174532925199" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="l_shoulder_2">
+    <inertial>
+      <origin xyz="0.0214745951272 0.000268957899687 -0.0194107361535" rpy="0 0 0"/>
+      <mass value="0.238162"/>
+      <inertia ixx="0.000159621" ixy="1.19701e-07" ixz="-1.29687e-05" iyy="0.000222574" iyz="1.20112e-06" izz="0.000120056"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.106586691581 1.10800934344e-07 -0.040743380771" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_shoulder_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="pink">
+        <color rgba="1 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.106586691581 1.10800934344e-07 -0.040743380771" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_shoulder_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_roll" type="revolute">
+    <origin xyz="-0.013671 0 0.0085204" rpy="0.270597317916 0.252680177542 -1.50155688559"/>
+    <axis xyz="-0.258819 2.77555756156e-17 0.965926"/>
+    <parent link="l_shoulder_1"/>
+    <child link="l_shoulder_2"/>
+    <limit effort="50000" lower="0.0" upper="2.80648943721" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="l_shoulder_3">
+    <inertial>
+      <origin xyz="0.026798412222 -1.6e-05 0.0146956806177" rpy="0 0 0"/>
+      <mass value="0.35913"/>
+      <inertia ixx="0.00014245" ixy="-2.22441e-07" ixz="-4.95846e-05" iyy="0.000197807" iyz="1.07538e-07" izz="0.000151706"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.131901037685 0 -0.0353427669194" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_upper_arm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="cyan">
+        <color rgba="0 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.131901037685 0 -0.0353427669194" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_upper_arm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_shoulder_yaw" type="revolute">
+    <origin xyz="0.0253143468312 1.11636438205e-07 -0.00540061656265" rpy="-0.252689546175 -0.0085186183214 -0.067039889142"/>
+    <axis xyz="0.965925843882 2.22044604925e-16 0.258818979447"/>
+    <parent link="l_shoulder_2"/>
+    <child link="l_shoulder_3"/>
+    <limit effort="50000" lower="-0.645771823238" upper="1.3962634016" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="l_upper_arm">
+    <inertial>
+      <origin xyz="-0.006121 -0.000189 0.0293684" rpy="0 -1.30899700697 -3.14159265359"/>
+      <mass value="0.746799"/>
+      <inertia ixx="0.000509731" ixy="-6.90767e-07" ixz="1.20048e-05" iyy="0.00067086" iyz="3.11833e-06" izz="0.000601202"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.015 0 -0.1933" rpy="0 -1.30899700697 -3.14159265359"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_elbow_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.015 0 -0.1933" rpy="0 -1.30899700697 -3.14159265359"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_elbow_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_arm_ft_sensor" type="fixed">
+    <origin xyz="0.0509301432452 0 0.0291758294659" rpy="0 -1.30899700697 3.14159265359"/>
+    <parent link="l_shoulder_3"/>
+    <child link="l_upper_arm"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_elbow_1">
+    <inertial>
+      <origin xyz="0.00673912932843 0.0303019 -0.00465769236154" rpy="0 0 0"/>
+      <mass value="0.267903"/>
+      <inertia ixx="8.13352e-05" ixy="-7.37159e-06" ixz="1.04505e-05" iyy="5.86823e-05" iyz="3.9319e-06" izz="9.68469e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.259390463317 0.0339999 -0.0850325886962" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_elbow_prosup_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="white">
+        <color rgba="1 1 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.259390463317 0.0339999 -0.0850325886962" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_elbow_prosup_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_elbow" type="revolute">
+    <origin xyz="0 0.0339999 0.07926" rpy="0 -1.30899700697 -3.14159265359"/>
+    <axis xyz="2.22044604925e-16 -1.0 0.0"/>
+    <parent link="l_upper_arm"/>
+    <child link="l_elbow_1"/>
+    <limit effort="50000" lower="0.261799387799" upper="1.85004900711" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="l_forearm">
+    <inertial>
+      <origin xyz="0.0404511828823 -0.000686 0.00532363214379" rpy="0 0 0"/>
+      <mass value="0.636185"/>
+      <inertia ixx="0.000371447" ixy="4.34562e-06" ixz="-0.000105871" iyy="0.000674229" iyz="4.05222e-06" izz="0.000557115"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.296886967375 0 -0.0795506015227" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_forearm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dblue">
+        <color rgba="0 0 0.8 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.296886967375 0 -0.0795506015227" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_forearm_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_prosup" type="revolute">
+    <origin xyz="0.0384624299027 0.0339999 -0.00522316819403" rpy="0 0 0"/>
+    <axis xyz="0.965925843882 2.22044604925e-16 0.258818979447"/>
+    <parent link="l_elbow_1"/>
+    <child link="l_forearm"/>
+    <limit effort="50000" lower="-1.0471975512" upper="1.0471975512" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="l_forearm_skin_0"/>
+  <joint name="l_forearm_skin_0_fixed_joint" type="fixed">
+    <origin xyz="0.0454493286618 -0.0323169 -0.00628656037901" rpy="1.69181522292 -0.271026744341 0.0727882713185"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_0"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_1"/>
+  <joint name="l_forearm_skin_1_fixed_joint" type="fixed">
+    <origin xyz="0.0333728935826 -0.0310662 -0.0198456867711" rpy="1.86694023278 -0.274442533764 0.0421228737473"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_1"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_2"/>
+  <joint name="l_forearm_skin_2_fixed_joint" type="fixed">
+    <origin xyz="0.0146988929852 -0.0335184 -0.0160117338371" rpy="1.72847287019 -0.264015219116 0.0142600467197"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_2"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_3"/>
+  <joint name="l_forearm_skin_3_fixed_joint" type="fixed">
+    <origin xyz="0.045567293622 0.028651 -0.00633000929351" rpy="-1.69487280859 -0.269757727104 -0.061995217851"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_3"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_4"/>
+  <joint name="l_forearm_skin_4_fixed_joint" type="fixed">
+    <origin xyz="0.0635326332996 0.025877 -0.00899784258066" rpy="-1.81747870108 -0.287406884885 -0.0998316152826"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_4"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_5"/>
+  <joint name="l_forearm_skin_5_fixed_joint" type="fixed">
+    <origin xyz="0.0688211941968 0.015709 -0.0231133361791" rpy="-2.5410475806 -0.385627260642 -0.0867227569203"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_5"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_6"/>
+  <joint name="l_forearm_skin_6_fixed_joint" type="fixed">
+    <origin xyz="0.0333948436255 0.027308 -0.0198325583433" rpy="-1.86628164653 -0.272886336181 -0.0371068033783"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_6"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_7"/>
+  <joint name="l_forearm_skin_7_fixed_joint" type="fixed">
+    <origin xyz="0.0147224260074 0.029702 -0.0159326482703" rpy="-1.72564640857 -0.263992900722 -0.0143801109253"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_7"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_8"/>
+  <joint name="l_forearm_skin_8_fixed_joint" type="fixed">
+    <origin xyz="0.0228528628554 0.007546 -0.041885146375" rpy="-2.94801979137 -0.270605090512 -0.00178708074348"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_8"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_9"/>
+  <joint name="l_forearm_skin_9_fixed_joint" type="fixed">
+    <origin xyz="0.0376032734683 0.016715 -0.0340163371186" rpy="-2.58406517708 -0.2933217196 -0.0203085796276"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_9"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_10"/>
+  <joint name="l_forearm_skin_10_fixed_joint" type="fixed">
+    <origin xyz="0.0542285210888 0.007546 -0.0321469082866" rpy="-2.94123313406 -0.328304471922 -0.0139662781936"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_10"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_11"/>
+  <joint name="l_forearm_skin_11_fixed_joint" type="fixed">
+    <origin xyz="0.0542240912024 -0.0112832 -0.0321431259452" rpy="2.93929835957 -0.329101389745 0.0142734891292"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_11"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_12"/>
+  <joint name="l_forearm_skin_12_fixed_joint" type="fixed">
+    <origin xyz="0.0375994633868 -0.0204556 -0.0340191179961" rpy="2.58303505964 -0.29483050207 0.021326850448"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_12"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_13"/>
+  <joint name="l_forearm_skin_13_fixed_joint" type="fixed">
+    <origin xyz="0.0228550868405 -0.0112878 -0.0418919009209" rpy="2.94896679198 -0.270583947189 0.00177385006765"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_13"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_14"/>
+  <joint name="l_forearm_skin_14_fixed_joint" type="fixed">
+    <origin xyz="0.0687703276364 -0.0193999 -0.0230239558511" rpy="2.52462250363 -0.387794511771 0.0912924111683"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_14"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_15"/>
+  <joint name="l_forearm_skin_15_fixed_joint" type="fixed">
+    <origin xyz="0.0633786419662 -0.0293843 -0.00879405455544" rpy="1.80492769741 -0.289783281916 0.113933739306"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_15"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_16"/>
+  <joint name="l_forearm_skin_16_fixed_joint" type="fixed">
+    <origin xyz="0.03792482187 -0.0327268 0.0206369503605" rpy="1.41280007026 -0.25082462139 0.0758652301584"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_16"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_17"/>
+  <joint name="l_forearm_skin_17_fixed_joint" type="fixed">
+    <origin xyz="0.0543170548821 -0.0299646 0.0303291240179" rpy="1.27223716205 -0.23059304703 0.109637225219"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_17"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_19"/>
+  <joint name="l_forearm_skin_19_fixed_joint" type="fixed">
+    <origin xyz="0.0381266107138 0.029054 0.020690605393" rpy="-1.41560888703 -0.252569290226 -0.0644404747027"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_19"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_22"/>
+  <joint name="l_forearm_skin_22_fixed_joint" type="fixed">
+    <origin xyz="0.0544173950421 0.026483 0.0306037516609" rpy="-1.2658242728 -0.234328151379 -0.0937094738802"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_22"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_24"/>
+  <joint name="l_forearm_skin_24_fixed_joint" type="fixed">
+    <origin xyz="0.0700345319564 0.007477 0.050069108714" rpy="-0.23489327644 -0.0388172993982 -0.0548291989999"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_24"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_25"/>
+  <joint name="l_forearm_skin_25_fixed_joint" type="fixed">
+    <origin xyz="0.0535999216295 0.015984 0.0454698125045" rpy="-0.564295527715 -0.136980272197 -0.0819608256656"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_25"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_28"/>
+  <joint name="l_forearm_skin_28_fixed_joint" type="fixed">
+    <origin xyz="0.0535859272148 -0.0196522 0.045352037397" rpy="0.579311106949 -0.133994306778 0.0867597858312"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_28"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_skin_29"/>
+  <joint name="l_forearm_skin_29_fixed_joint" type="fixed">
+    <origin xyz="0.0700355805031 -0.0111936 0.0500111036233" rpy="0.248630982209 -0.0383136556786 0.0583026624266"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_skin_29"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_forearm_dh_frame"/>
+  <joint name="l_forearm_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0.102871102373 7.00000000002e-06 0.0275642213111" rpy="2.87979333376 0 1.57079632679"/>
+    <parent link="l_forearm"/>
+    <child link="l_forearm_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="l_wrist_1">
+    <inertial>
+      <origin xyz="-0.000981313804428 -0.001178 0.00408345773913" rpy="0 0 0"/>
+      <mass value="0.0362152"/>
+      <inertia ixx="5.56774e-06" ixy="3.08362e-08" ixz="9.42153e-07" iyy="5.28838e-06" iyz="-1.58924e-07" izz="1.87579e-06"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.400314530555 -7.00000000009e-06 -0.105038082269" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_wrist_pitch_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="dgreen">
+        <color rgba="0.1 0.8 0.1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.400314530555 -7.00000000009e-06 -0.105038082269" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_wrist_pitch_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_pitch" type="revolute">
+    <origin xyz="0.103427563179 7.00000000002e-06 0.0254874807467" rpy="0 0 0"/>
+    <axis xyz="0.258818979447 0.0 -0.965925843882"/>
+    <parent link="l_forearm"/>
+    <child link="l_wrist_1"/>
+    <limit effort="50000" lower="-1.3962634016" upper="0.436332312999" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="l_hand">
+    <inertial>
+      <origin xyz="0.0647680204057 0.0056304 0.0226602208449" rpy="0 0 0"/>
+      <mass value="0.247806"/>
+      <inertia ixx="0.000162491" ixy="2.96453e-06" ixz="-3.68906e-05" iyy="0.000430657" iyz="2.06885e-05" izz="0.000304729"/>
+    </inertial>
+    <visual>
+      <origin xyz="-0.399680424055 0.0194929 -0.107404600587" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_hand_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.399680424055 0.0194929 -0.107404600587" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_l_hand_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="l_wrist_yaw" type="revolute">
+    <origin xyz="-0.000634106499644 -0.0194999 0.00236651831751" rpy="0 0 0"/>
+    <axis xyz="-2.22044604925e-16 1.0 0.0"/>
+    <parent link="l_wrist_1"/>
+    <child link="l_hand"/>
+    <limit effort="50000" lower="-0.349065850399" upper="0.436332312999" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="l_hand_dh_frame"/>
+  <joint name="l_hand_dh_frame_fixed_joint" type="fixed">
+    <origin xyz="0.0576542978428 -0.0055568 0.0136938323083" rpy="-1.57079632679 -0.261799319827 0"/>
+    <parent link="l_hand"/>
+    <child link="l_hand_dh_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="neck_1">
+    <inertial>
+      <origin xyz="0.0143705608 0.006567 -0.0063842" rpy="0 0 0"/>
+      <mass value="0.125793"/>
+      <inertia ixx="4.0647e-05" ixy="8.09156e-08" ixz="-3.74998e-08" iyy="3.881e-05" iyz="9.39717e-06" izz="4.7535e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.0142999998093 -0.079997 -0.0295008" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_neck_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0.0142999998093 -0.079997 -0.0295008" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_neck_1_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_pitch" type="revolute">
+    <origin xyz="-0.0142999998093 0.172797 0.0053118" rpy="0 0 0"/>
+    <axis xyz="-1.0 0.0 0.0"/>
+    <parent link="chest"/>
+    <child link="neck_1"/>
+    <limit effort="50000" lower="-0.698131700798" upper="0.383972435439" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="neck_2">
+    <inertial>
+      <origin xyz="-8.8573009265e-05 0.035225 -0.01954527" rpy="0 0 0"/>
+      <mass value="0.177087"/>
+      <inertia ixx="0.000117943" ixy="-5.25591e-07" ixz="4.68307e-07" iyy="4.04013e-05" iyz="9.81476e-06" izz="0.000105186"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.089497 -0.05030077" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_neck_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 -0.089497 -0.05030077" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_neck_2_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_roll" type="revolute">
+    <origin xyz="0.0142999998093 0.0095 0.02079997" rpy="0 0 0"/>
+    <axis xyz="0.0 0.0 1.0"/>
+    <parent link="neck_1"/>
+    <child link="neck_2"/>
+    <limit effort="50000" lower="-0.349065850399" upper="0.349065850399" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="head">
+    <inertial>
+      <origin xyz="-0.000574157809265 0.113511 -0.0075392" rpy="0 0 0"/>
+      <mass value="1.50691"/>
+      <inertia ixx="0.00680478" ixy="-1.60267e-05" ixz="7.28166e-05" iyy="0.00634736" iyz="0.000292091" izz="0.00478116"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.067153 -0.0295008" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_head_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 -0.067153 -0.0295008" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://iCub/meshes/simmechanics/sim_sea_2-5_head_prt-binary.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="neck_yaw" type="revolute">
+    <origin xyz="0 -0.022344 -0.02079997" rpy="0 0 0"/>
+    <axis xyz="0.0 1.0 0.0"/>
+    <parent link="neck_2"/>
+    <child link="head"/>
+    <limit effort="50000" lower="-0.872664625997" upper="0.872664625997" velocity="50000"/>
+    <dynamics damping="0.06" friction="0.0"/>
+  </joint>
+  <link name="imu_frame"/>
+  <joint name="imu_frame_fixed_joint" type="fixed">
+    <origin xyz="0.00950000019074 0.133444 0.0093" rpy="-1.57079632679 1.57079632679 0"/>
+    <parent link="head"/>
+    <child link="imu_frame"/>
+    <dynamics damping="0.1"/>
+  </joint>
+  <link name="base_link"/>
+  <joint name="base_fixed_joint" type="fixed">
+  <origin xyz="0 0 0" rpy="0 -0 0"/>
+  <axis xyz="0 0 0"/>
+  <parent link="base_link"/>
+  <child link="root_link"/>
+</joint>
+  <link name="l_foot_dh_frame"/>
+  <joint name="l_foot_dh_frame_fixed_joint" type="fixed">
+  <origin xyz="0.0 0 0.004" rpy="0 1.5708 0"/>
+  <axis xyz="0 0 0"/>
+  <parent link="l_foot"/>
+  <child link="l_foot_dh_frame"/>
+</joint>
+  <link name="r_foot_dh_frame"/>
+  <joint name="r_foot_dh_frame_fixed_joint" type="fixed">
+  <origin xyz="0.0 0 0.004" rpy="0 1.5708 0"/>
+  <axis xyz="0 0 0"/>
+  <parent link="r_foot"/>
+  <child link="r_foot_dh_frame"/>
+</joint>
+  <gazebo reference="r_arm_ft_sensor">
+  <disableFixedJointLumping>true</disableFixedJointLumping>
+</gazebo>
+  <gazebo reference="l_arm_ft_sensor">
+  <disableFixedJointLumping>true</disableFixedJointLumping>
+</gazebo>
+  <gazebo reference="r_leg_ft_sensor">
+  <disableFixedJointLumping>true</disableFixedJointLumping>
+</gazebo>
+  <gazebo reference="l_leg_ft_sensor">
+  <disableFixedJointLumping>true</disableFixedJointLumping>
+</gazebo>
+  <gazebo reference="r_foot_ft_sensor">
+  <disableFixedJointLumping>true</disableFixedJointLumping>
+</gazebo>
+  <gazebo reference="l_foot_ft_sensor">
+  <disableFixedJointLumping>true</disableFixedJointLumping>
+</gazebo>
+  <gazebo reference="l_foot">
+  <collision> <surface> <bounce>
+    <restitution_coefficient>0</restitution_coefficient>
+    <threshold>100000</threshold>
+  </bounce> </surface> </collision>
+  <maxContacts>4</maxContacts>
+  <kp>18000000</kp>
+  <kd>100</kd>
+  <maxVel>100</maxVel>
+  <minDepth>0.0001</minDepth>
+  <mu1>1</mu1>
+  <mu2>1</mu2>
+  <fdir1>0 0 0</fdir1>
+</gazebo>
+  <gazebo reference="r_foot">
+  <collision> <surface> <bounce>
+    <restitution_coefficient>0</restitution_coefficient>
+    <threshold>100000</threshold>
+  </bounce> </surface> </collision>
+  <maxContacts>4</maxContacts>
+  <kp>18000000</kp>
+  <kd>100</kd>
+  <maxVel>100</maxVel>
+  <minDepth>0.0001</minDepth>
+  <mu1>1</mu1>
+  <mu2>1</mu2>
+  <fdir1>0 0 0</fdir1>
+</gazebo>
+  <gazebo>
+<plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
+  <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_left_leg_mtb.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
+  <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_right_leg_mtb.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
+  <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_left_arm_mtb.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
+  <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_right_arm_mtb.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
+  <yarpConfigurationFile>model://iCub/conf/MTB/gazebo_icub_torso_mtb.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_torso" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>model://iCub/conf/gazebo_icub_torso.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_head_without_eyes" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>model://iCub/conf/gazebo_icub_head_without_eyes.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_left_arm_no_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
+  <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.0</initialConfiguration>
+</plugin>
+<plugin name="controlboard_right_arm_no_hand" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
+  <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.0</initialConfiguration>
+</plugin>
+<plugin name="controlboard_right_leg" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_leg.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="controlboard_left_leg" filename="libgazebo_yarp_controlboard.so">
+  <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_leg.ini</yarpConfigurationFile>
+</plugin>
+<plugin name="apply_external_wrench" filename="libgazebo_yarp_externalwrench.so">
+  <robotNamefromConfigFile>model://iCub/conf/gazebo_icub_robotname.ini</robotNamefromConfigFile>
+</plugin>
+</gazebo>
+  <gazebo reference="r_hip_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hip_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_hip_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_knee">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_ankle_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_ankle_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hip_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hip_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_hip_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_knee">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_ankle_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_ankle_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="torso_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_shoulder_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_elbow">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_prosup">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="r_wrist_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_shoulder_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_elbow">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_prosup">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_wrist_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_pitch">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_roll">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="neck_yaw">
+   <implicitSpringDamper>1</implicitSpringDamper>
+</gazebo>
+  <gazebo reference="l_leg_ft_sensor">
+    <sensor name="l_leg_ft_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+      <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+  <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_leg_ft_sensor" type="force_torque">
+    <parent joint="l_leg_ft_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="r_leg_ft_sensor">
+    <sensor name="r_leg_ft_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+      <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+  <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_leg_ft_sensor" type="force_torque">
+    <parent joint="r_leg_ft_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="l_foot_ft_sensor">
+    <sensor name="l_foot_ft_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+      <plugin name="left_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+  <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_foot_ft.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_ft_sensor" type="force_torque">
+    <parent joint="l_foot_ft_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="r_foot_ft_sensor">
+    <sensor name="r_foot_ft_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+      <plugin name="right_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+  <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_foot_ft.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_ft_sensor" type="force_torque">
+    <parent joint="r_foot_ft_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="l_arm_ft_sensor">
+    <sensor name="l_arm_ft_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+      <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+  <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_arm_ft.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_arm_ft_sensor" type="force_torque">
+    <parent joint="l_arm_ft_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="r_arm_ft_sensor">
+    <sensor name="r_arm_ft_sensor" type="force_torque">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <force_torque>
+        <frame>child</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+      <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+  <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_arm_ft.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_arm_ft_sensor" type="force_torque">
+    <parent joint="r_arm_ft_sensor"/>
+    <force_torque>
+      <frame>child</frame>
+      <measure_direction>child_to_parent</measure_direction>
+    </force_torque>
+  </sensor>
+  <gazebo reference="head">
+    <sensor name="head_imu_acc_1x1" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.00950000019074 0.133444 0.0093 -1.57079632679 1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+    <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="head_imu_acc_1x1" type="accelerometer">
+    <parent link="head"/>
+    <origin rpy="-1.57079632679 1.57079632679 0.0" xyz="0.00950000019074 0.133444 0.0093"/>
+  </sensor>
+  <gazebo reference="root_link">
+    <sensor name="root_link_ems_acc_eb5" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0493308 -0.0125771 -0.115691 -3.14159265359 1.29154404503 3.14159265359</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="root_link_ems_acc_eb5" type="accelerometer">
+    <parent link="root_link"/>
+    <origin rpy="-3.14159265359 1.29154404503 3.14159265359" xyz="0.0493308 -0.0125771 -0.115691"/>
+  </sensor>
+  <gazebo reference="root_link">
+    <sensor name="root_link_ems_gyro_eb5" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0493308 -0.0125771 -0.115691 -3.14159265359 1.29154404503 3.14159265359</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="root_link_ems_gyro_eb5" type="gyroscope">
+    <parent link="root_link"/>
+    <origin rpy="-3.14159265359 1.29154404503 3.14159265359" xyz="0.0493308 -0.0125771 -0.115691"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_acc_eb1" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0647855001907 0.064043 -0.0647091 3.1415169123 -0.261799309122 0.000292641880255</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_acc_eb1" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="3.1415169123 -0.261799309122 0.000292641880255" xyz="0.0647855001907 0.064043 -0.0647091"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_gyro_eb1" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0692016001907 0.064548 -0.0635258 3.1415169123 -0.261799309122 0.000292641880255</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_gyro_eb1" type="gyroscope">
+    <parent link="chest"/>
+    <origin rpy="3.1415169123 -0.261799309122 0.000292641880255" xyz="0.0692016001907 0.064548 -0.0635258"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_acc_eb2" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0204533001907 0.088063 -0.0641645 3.14159050104 0.261799319819 3.14158433678</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_acc_eb2" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="3.14159050104 0.261799319819 3.14158433678" xyz="0.0204533001907 0.088063 -0.0641645"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_gyro_eb2" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0160371001907 0.087559 -0.0653479 3.14159050104 0.261799319819 3.14158433678</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_gyro_eb2" type="gyroscope">
+    <parent link="chest"/>
+    <origin rpy="3.14159050104 0.261799319819 3.14158433678" xyz="0.0160371001907 0.087559 -0.0653479"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_acc_eb3" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0230587998093 0.064019 -0.0758985 3.14110916203 0.261100516471 -0.000309071462555</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_acc_eb3" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="3.14110916203 0.261100516471 -0.000309071462555" xyz="-0.0230587998093 0.064019 -0.0758985"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_gyro_eb3" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0186416998093 0.064521 -0.0770785 3.14110916203 0.261100516471 -0.000309071462555</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_gyro_eb3" type="gyroscope">
+    <parent link="chest"/>
+    <origin rpy="3.14110916203 0.261100516471 -0.000309071462555" xyz="-0.0186416998093 0.064521 -0.0770785"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_acc_eb4" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0621620998093 0.088063 -0.0529887 -3.14159050476 -0.261799319819 3.14158433987</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_acc_eb4" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="-3.14159050476 -0.261799319819 3.14158433987" xyz="-0.0621620998093 0.088063 -0.0529887"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_ems_gyro_eb4" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0665783998093 0.087559 -0.0518054 -3.14159050476 -0.261799319819 3.14158433987</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_ems_gyro_eb4" type="gyroscope">
+    <parent link="chest"/>
+    <origin rpy="-3.14159050476 -0.261799319819 3.14158433987" xyz="-0.0665783998093 0.087559 -0.0518054"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_mtb_acc_0b7" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0607539998093 -0.0017836 0.0442341 0.875167771492 0.116363734392 -1.48597350247</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_mtb_acc_0b7" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="0.875167771492 0.116363734392 -1.48597350247" xyz="-0.0607539998093 -0.0017836 0.0442341"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_mtb_acc_0b8" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0457046998093 -0.001846 0.0567427 0.500960084689 0.107313688983 -1.4778325291</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_mtb_acc_0b8" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="0.500960084689 0.107313688983 -1.4778325291" xyz="-0.0457046998093 -0.001846 0.0567427"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_mtb_acc_0b9" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0439036001907 -0.0017841 0.0577221 -0.500959928973 0.107315404248 -1.66376017469</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_mtb_acc_0b9" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="-0.500959928973 0.107315404248 -1.66376017469" xyz="0.0439036001907 -0.0017841 0.0577221"/>
+  </sensor>
+  <gazebo reference="chest">
+    <sensor name="chest_mtb_acc_0b10" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0594286001907 -0.0018543 0.0457981 -0.875168153475 0.116362025479 -1.65561807505</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="chest_mtb_acc_0b10" type="accelerometer">
+    <parent link="chest"/>
+    <origin rpy="-0.875168153475 0.116362025479 -1.65561807505" xyz="0.0594286001907 -0.0018543 0.0457981"/>
+  </sensor>
+  <gazebo reference="r_upper_arm">
+    <sensor name="r_upper_arm_mtb_acc_2b10" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0412194 0.029588 0.0295279 1.57079546365 1.57078381225 -2.68257161165</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_arm_mtb_acc_2b10" type="accelerometer">
+    <parent link="r_upper_arm"/>
+    <origin rpy="1.57079546365 1.57078381225 -2.68257161165" xyz="-0.0412194 0.029588 0.0295279"/>
+  </sensor>
+  <gazebo reference="r_upper_arm">
+    <sensor name="r_upper_arm_mtb_acc_2b11" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0430568 0.02868 0.0760604 -1.57079614695 -1.57050350741 0.459021725219</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_arm_mtb_acc_2b11" type="accelerometer">
+    <parent link="r_upper_arm"/>
+    <origin rpy="-1.57079614695 -1.57050350741 0.459021725219" xyz="-0.0430568 0.02868 0.0760604"/>
+  </sensor>
+  <gazebo reference="r_upper_arm">
+    <sensor name="r_upper_arm_mtb_acc_2b12" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0430554 0.028681 0.0049922 -1.11177442168 -1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_arm_mtb_acc_2b12" type="accelerometer">
+    <parent link="r_upper_arm"/>
+    <origin rpy="-1.11177442168 -1.57079632679 0.0" xyz="-0.0430554 0.028681 0.0049922"/>
+  </sensor>
+  <gazebo reference="r_upper_arm">
+    <sensor name="r_upper_arm_mtb_acc_2b13" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.010593237 0.02835 -0.010738 1.57079632702 -0.000214520362041 2.47803674451</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_arm_mtb_acc_2b13" type="accelerometer">
+    <parent link="r_upper_arm"/>
+    <origin rpy="1.57079632702 -0.000214520362041 2.47803674451" xyz="0.010593237 0.02835 -0.010738"/>
+  </sensor>
+  <gazebo reference="r_forearm">
+    <sensor name="r_forearm_mtb_acc_2b7" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0768727847342 0.005497 -0.0110479126068 0.26179949998 0.000370413042328 1.57125816863</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_forearm_mtb_acc_2b7" type="accelerometer">
+    <parent link="r_forearm"/>
+    <origin rpy="0.26179949998 0.000370413042328 1.57125816863" xyz="-0.0768727847342 0.005497 -0.0110479126068"/>
+  </sensor>
+  <gazebo reference="r_forearm">
+    <sensor name="r_forearm_mtb_acc_2b8" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0514186150796 0.015786 0.0407521537277 -0.661143946092 0.147825248461 0.092070114703</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_forearm_mtb_acc_2b8" type="accelerometer">
+    <parent link="r_forearm"/>
+    <origin rpy="-0.661143946092 0.147825248461 0.092070114703" xyz="-0.0514186150796 0.015786 0.0407521537277"/>
+  </sensor>
+  <gazebo reference="r_forearm">
+    <sensor name="r_forearm_mtb_acc_2b9" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0216379956759 0.027924 -0.0132490254018 -1.76682626732 0.261191225646 0.054048344372</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_forearm_mtb_acc_2b9" type="accelerometer">
+    <parent link="r_forearm"/>
+    <origin rpy="-1.76682626732 0.261191225646 0.054048344372" xyz="-0.0216379956759 0.027924 -0.0132490254018"/>
+  </sensor>
+  <gazebo reference="l_upper_arm">
+    <sensor name="l_upper_arm_mtb_acc_1b10" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0430554 -0.028681 0.0295279 -1.57079650664 -1.57050350741 2.68257092837</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_arm_mtb_acc_1b10" type="accelerometer">
+    <parent link="l_upper_arm"/>
+    <origin rpy="-1.57079650664 -1.57050350741 2.68257092837" xyz="-0.0430554 -0.028681 0.0295279"/>
+  </sensor>
+  <gazebo reference="l_upper_arm">
+    <sensor name="l_upper_arm_mtb_acc_1b11" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0412181 -0.029589 0.0760604 -1.57079650664 -1.57050350741 2.68257092837</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_arm_mtb_acc_1b11" type="accelerometer">
+    <parent link="l_upper_arm"/>
+    <origin rpy="-1.57079650664 -1.57050350741 2.68257092837" xyz="-0.0412181 -0.029589 0.0760604"/>
+  </sensor>
+  <gazebo reference="l_upper_arm">
+    <sensor name="l_upper_arm_mtb_acc_1b12" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0412194 -0.029588 0.0049921 -1.5707971899 -1.57078381225 2.68257161159</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_arm_mtb_acc_1b12" type="accelerometer">
+    <parent link="l_upper_arm"/>
+    <origin rpy="-1.5707971899 -1.57078381225 2.68257161159" xyz="-0.0412194 -0.029588 0.0049921"/>
+  </sensor>
+  <gazebo reference="l_upper_arm">
+    <sensor name="l_upper_arm_mtb_acc_1b13" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.010592709 -0.028351 -0.0086914 -1.57079632657 0.000214520362042 -2.47803674451</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_arm_mtb_acc_1b13" type="accelerometer">
+    <parent link="l_upper_arm"/>
+    <origin rpy="-1.57079632657 0.000214520362042 -2.47803674451" xyz="0.010592709 -0.028351 -0.0086914"/>
+  </sensor>
+  <gazebo reference="l_forearm">
+    <sensor name="l_forearm_mtb_acc_1b7" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0768727847342 -0.005483 -0.0110479126068 0.26179949998 0.000370413042328 -1.57033448496</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_forearm_mtb_acc_1b7" type="accelerometer">
+    <parent link="l_forearm"/>
+    <origin rpy="0.26179949998 0.000370413042328 -1.57033448496" xyz="0.0768727847342 -0.005483 -0.0110479126068"/>
+  </sensor>
+  <gazebo reference="l_forearm">
+    <sensor name="l_forearm_mtb_acc_1b8" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0514241740607 -0.0180279 0.0407507258436 -0.661143946092 0.147825248461 -3.04952253889</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_forearm_mtb_acc_1b8" type="accelerometer">
+    <parent link="l_forearm"/>
+    <origin rpy="-0.661143946092 0.147825248461 -3.04952253889" xyz="0.0514241740607 -0.0180279 0.0407507258436"/>
+  </sensor>
+  <gazebo reference="l_forearm">
+    <sensor name="l_forearm_mtb_acc_1b9" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0220991874996 0.025657 -0.0151174243212 1.76682134218 0.261099829847 3.08752548202</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_forearm_mtb_acc_1b9" type="accelerometer">
+    <parent link="l_forearm"/>
+    <origin rpy="1.76682134218 0.261099829847 3.08752548202" xyz="0.0220991874996 0.025657 -0.0151174243212"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_ems_acc_eb8" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0125751 0.0404072 -0.040227 1.57079632679 1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_ems_acc_eb8" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="1.57079632679 1.57079632679 0.0" xyz="-0.0125751 0.0404072 -0.040227"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_ems_acc_eb11" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0125771 -0.040407 -0.083407 1.57079632679 1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_ems_acc_eb11" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="1.57079632679 1.57079632679 0.0" xyz="-0.0125771 -0.040407 -0.083407"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_ems_gyro_eb8" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.013079 0.0404072 -0.035655 1.57079632679 1.57079632679 0.0</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_ems_gyro_eb8" type="gyroscope">
+    <parent link="r_upper_leg"/>
+    <origin rpy="1.57079632679 1.57079632679 0.0" xyz="-0.013079 0.0404072 -0.035655"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_ems_gyro_eb11" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.013081 -0.040407 -0.087979 1.57079632679 1.57079632679 0.0</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_ems_gyro_eb11" type="gyroscope">
+    <parent link="r_upper_leg"/>
+    <origin rpy="1.57079632679 1.57079632679 0.0" xyz="-0.013081 -0.040407 -0.087979"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_mtb_acc_11b1" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.043588612 -0.030195 0.04894 2.52670843803 -1.57044484253 -0.22287382498</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_mtb_acc_11b1" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="2.52670843803 -1.57044484253 -0.22287382498" xyz="0.043588612 -0.030195 0.04894"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_mtb_acc_11b2" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0539467 -0.0064065 0.039056 -3.12940212057 -1.57038181496 -0.273989852569</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_mtb_acc_11b2" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="-3.12940212057 -1.57038181496 -0.273989852569" xyz="0.0539467 -0.0064065 0.039056"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_mtb_acc_11b3" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0538313 -0.0130214 0.003986 -2.87731085451 -1.5703518031 -0.264281823992</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_mtb_acc_11b3" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="-2.87731085451 -1.5703518031 -0.264281823992" xyz="0.0538313 -0.0130214 0.003986"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_mtb_acc_11b4" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0322719 0.0422675 -0.005045 -1.87390998809 -1.57025771326 -0.0808589029571</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_mtb_acc_11b4" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="-1.87390998809 -1.57025771326 -0.0808589029571" xyz="0.0322719 0.0422675 -0.005045"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_mtb_acc_11b5" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0538313 0.0164786 0.003986 -2.87731085451 -1.5703518031 -0.264281823992</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_mtb_acc_11b5" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="-2.87731085451 -1.5703518031 -0.264281823992" xyz="0.0538313 0.0164786 0.003986"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_mtb_acc_11b6" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0437518 -0.0157594 -0.026565 1.95410275534e-17 1.5703672368 -3.14159265359</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_mtb_acc_11b6" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="1.95410275534e-17 1.5703672368 -3.14159265359" xyz="-0.0437518 -0.0157594 -0.026565"/>
+  </sensor>
+  <gazebo reference="r_upper_leg">
+    <sensor name="r_upper_leg_mtb_acc_11b7" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0437518 0.0162386 -0.026566 0.264252523901 1.57035180662 -2.87734010478</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_upper_leg_mtb_acc_11b7" type="accelerometer">
+    <parent link="r_upper_leg"/>
+    <origin rpy="0.264252523901 1.57035180662 -2.87734010478" xyz="-0.0437518 0.0162386 -0.026566"/>
+  </sensor>
+  <gazebo reference="r_lower_leg">
+    <sensor name="r_lower_leg_ems_acc_eb9" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.04351373 0.0138396 -0.092765 -3.14159265359 -1.35262978345 -8.47684971046e-16</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_lower_leg_ems_acc_eb9" type="accelerometer">
+    <parent link="r_lower_leg"/>
+    <origin rpy="-3.14159265359 -1.35262978345 -8.47684971046e-16" xyz="0.04351373 0.0138396 -0.092765"/>
+  </sensor>
+  <gazebo reference="r_lower_leg">
+    <sensor name="r_lower_leg_ems_gyro_eb9" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.044503292 0.0143435 -0.088301 -3.14159265359 -1.35262978345 -8.47684971046e-16</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="r_lower_leg_ems_gyro_eb9" type="gyroscope">
+    <parent link="r_lower_leg"/>
+    <origin rpy="-3.14159265359 -1.35262978345 -8.47684971046e-16" xyz="0.044503292 0.0143435 -0.088301"/>
+  </sensor>
+  <gazebo reference="r_lower_leg">
+    <sensor name="r_lower_leg_mtb_acc_11b8" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.05362922 -0.0151958 -0.004318 -1.57079699431 -1.5706802101 -1.81514182543</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_lower_leg_mtb_acc_11b8" type="accelerometer">
+    <parent link="r_lower_leg"/>
+    <origin rpy="-1.57079699431 -1.5706802101 -1.81514182543" xyz="0.05362922 -0.0151958 -0.004318"/>
+  </sensor>
+  <gazebo reference="r_lower_leg">
+    <sensor name="r_lower_leg_mtb_acc_11b9" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0537517 0.0157229 -0.004318 -1.57079629188 -1.57068021044 -1.2217307215</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_lower_leg_mtb_acc_11b9" type="accelerometer">
+    <parent link="r_lower_leg"/>
+    <origin rpy="-1.57079629188 -1.57068021044 -1.2217307215" xyz="0.0537517 0.0157229 -0.004318"/>
+  </sensor>
+  <gazebo reference="r_lower_leg">
+    <sensor name="r_lower_leg_mtb_acc_11b10" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0278945 -0.042214 -0.043468 1.83259550627 -1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_lower_leg_mtb_acc_11b10" type="accelerometer">
+    <parent link="r_lower_leg"/>
+    <origin rpy="1.83259550627 -1.57079632679 0.0" xyz="0.0278945 -0.042214 -0.043468"/>
+  </sensor>
+  <gazebo reference="r_lower_leg">
+    <sensor name="r_lower_leg_mtb_acc_11b11" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0164801 0.042249 -0.092958 -1.57079369547 -1.57068021035 -0.261801810497</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_lower_leg_mtb_acc_11b11" type="accelerometer">
+    <parent link="r_lower_leg"/>
+    <origin rpy="-1.57079369547 -1.57068021035 -0.261801810497" xyz="0.0164801 0.042249 -0.092958"/>
+  </sensor>
+  <gazebo reference="r_foot">
+    <sensor name="r_foot_mtb_acc_11b12" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.1034794 -0.0008122 -0.001215 1.46487522971e-16 2.22044521133e-16 -1.57079604303</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_mtb_acc_11b12" type="accelerometer">
+    <parent link="r_foot"/>
+    <origin rpy="1.46487522971e-16 2.22044521133e-16 -1.57079604303" xyz="0.1034794 -0.0008122 -0.001215"/>
+  </sensor>
+  <gazebo reference="r_foot">
+    <sensor name="r_foot_mtb_acc_11b13" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0784794 -0.0118122 -0.001215 2.22044604925e-16 2.22044604925e-16 -1.57079632679</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_mtb_acc_11b13" type="accelerometer">
+    <parent link="r_foot"/>
+    <origin rpy="2.22044604925e-16 2.22044604925e-16 -1.57079632679" xyz="0.0784794 -0.0118122 -0.001215"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_ems_acc_eb6" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0125771 -0.0404072 -0.083407 1.57079632679 1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_ems_acc_eb6" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="1.57079632679 1.57079632679 0.0" xyz="-0.0125771 -0.0404072 -0.083407"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_ems_acc_eb10" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.0125751 0.040407 -0.040227 -1.57079632679 -1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_ems_acc_eb10" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="-1.57079632679 -1.57079632679 0.0" xyz="-0.0125751 0.040407 -0.040227"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_ems_gyro_eb6" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.013081 -0.0404072 -0.087979 1.57079632679 1.57079632679 0.0</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_ems_gyro_eb6" type="gyroscope">
+    <parent link="l_upper_leg"/>
+    <origin rpy="1.57079632679 1.57079632679 0.0" xyz="-0.013081 -0.0404072 -0.087979"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_ems_gyro_eb10" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.013079 0.040407 -0.035655 -1.57079632679 -1.57079632679 0.0</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_ems_gyro_eb10" type="gyroscope">
+    <parent link="l_upper_leg"/>
+    <origin rpy="-1.57079632679 -1.57079632679 0.0" xyz="-0.013079 0.040407 -0.035655"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_mtb_acc_10b1" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.04200163 0.031565 0.049132 -1.57079551857 -1.57068021034 -0.733039094713</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_mtb_acc_10b1" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="-1.57079551857 -1.57068021034 -0.733039094713" xyz="0.04200163 0.031565 0.049132"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_mtb_acc_10b2" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.05352109 0.0077657 0.039252 -1.57079638638 -1.57068021039 -1.3089969474</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_mtb_acc_10b2" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="-1.57079638638 -1.57068021039 -1.3089969474" xyz="0.05352109 0.0077657 0.039252"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_mtb_acc_10b3" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.053785 0.0150706 0.004182 3.14159265359 -1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_mtb_acc_10b3" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="3.14159265359 -1.57079632679 0.0" xyz="0.053785 0.0150706 0.004182"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_mtb_acc_10b4" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.053785 -0.0144294 0.004182 3.14159265359 -1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_mtb_acc_10b4" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="3.14159265359 -1.57079632679 0.0" xyz="0.053785 -0.0144294 0.004182"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_mtb_acc_10b5" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.03412949 -0.0414999 -0.004858 1.95476889104 -1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_mtb_acc_10b5" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="1.95476889104 -1.57079632679 0.0" xyz="0.03412949 -0.0414999 -0.004858"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_mtb_acc_10b6" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.043785 0.0178111 -0.026411 -1.57079632679 1.57077431394 1.57079632679</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_mtb_acc_10b6" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="-1.57079632679 1.57077431394 1.57079632679" xyz="-0.043785 0.0178111 -0.026411"/>
+  </sensor>
+  <gazebo reference="l_upper_leg">
+    <sensor name="l_upper_leg_mtb_acc_10b7" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>-0.043785 -0.0141918 -0.026411 1.5707963268 1.57064733889 -1.57079632679</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_upper_leg_mtb_acc_10b7" type="accelerometer">
+    <parent link="l_upper_leg"/>
+    <origin rpy="1.5707963268 1.57064733889 -1.57079632679" xyz="-0.043785 -0.0141918 -0.026411"/>
+  </sensor>
+  <gazebo reference="l_lower_leg">
+    <sensor name="l_lower_leg_ems_acc_eb7" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.04351373 0.0113146 -0.092765 -3.14159265359 -1.35262978345 -8.47684971046e-16</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_lower_leg_ems_acc_eb7" type="accelerometer">
+    <parent link="l_lower_leg"/>
+    <origin rpy="-3.14159265359 -1.35262978345 -8.47684971046e-16" xyz="0.04351373 0.0113146 -0.092765"/>
+  </sensor>
+  <gazebo reference="l_lower_leg">
+    <sensor name="l_lower_leg_ems_gyro_eb7" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.044503292 0.0118185 -0.088301 -3.14159265359 -1.35262978345 -8.47684971046e-16</pose>
+    </sensor>
+  </gazebo>
+  <sensor name="l_lower_leg_ems_gyro_eb7" type="gyroscope">
+    <parent link="l_lower_leg"/>
+    <origin rpy="-3.14159265359 -1.35262978345 -8.47684971046e-16" xyz="0.044503292 0.0118185 -0.088301"/>
+  </sensor>
+  <gazebo reference="l_lower_leg">
+    <sensor name="l_lower_leg_mtb_acc_10b8" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.05313347 0.0171841 -0.004318 -2.89724648752 -1.57079632679 0.0</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_lower_leg_mtb_acc_10b8" type="accelerometer">
+    <parent link="l_lower_leg"/>
+    <origin rpy="-2.89724648752 -1.57079632679 0.0" xyz="0.05313347 0.0171841 -0.004318"/>
+  </sensor>
+  <gazebo reference="l_lower_leg">
+    <sensor name="l_lower_leg_mtb_acc_10b9" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0544518 -0.0137991 -0.004318 -1.57079636645 -1.57068021044 -1.91986192735</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_lower_leg_mtb_acc_10b9" type="accelerometer">
+    <parent link="l_lower_leg"/>
+    <origin rpy="-1.57079636645 -1.57068021044 -1.91986192735" xyz="0.0544518 -0.0137991 -0.004318"/>
+  </sensor>
+  <gazebo reference="l_lower_leg">
+    <sensor name="l_lower_leg_mtb_acc_10b10" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0259151 0.042744 -0.043468 -1.57079369547 -1.57068021035 -0.261801810497</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_lower_leg_mtb_acc_10b10" type="accelerometer">
+    <parent link="l_lower_leg"/>
+    <origin rpy="-1.57079369547 -1.57068021035 -0.261801810497" xyz="0.0259151 0.042744 -0.043468"/>
+  </sensor>
+  <gazebo reference="l_lower_leg">
+    <sensor name="l_lower_leg_mtb_acc_10b11" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0184593 -0.0417187 -0.092958 1.57079531928 -1.57076999786 0.261800187025</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_lower_leg_mtb_acc_10b11" type="accelerometer">
+    <parent link="l_lower_leg"/>
+    <origin rpy="1.57079531928 -1.57076999786 0.261800187025" xyz="0.0184593 -0.0417187 -0.092958"/>
+  </sensor>
+  <gazebo reference="l_foot">
+    <sensor name="l_foot_mtb_acc_10b12" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.1055274 0.0008122 -0.001215 0.0 -0.0 1.57079632679</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_mtb_acc_10b12" type="accelerometer">
+    <parent link="l_foot"/>
+    <origin rpy="0.0 -0.0 1.57079632679" xyz="0.1055274 0.0008122 -0.001215"/>
+  </sensor>
+  <gazebo reference="l_foot">
+    <sensor name="l_foot_mtb_acc_10b13" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0805274 0.0118122 -0.001215 0.0 -0.0 1.57079632679</pose>
+      <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so"/>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_mtb_acc_10b13" type="accelerometer">
+    <parent link="l_foot"/>
+    <origin rpy="0.0 -0.0 1.57079632679" xyz="0.0805274 0.0118122 -0.001215"/>
+  </sensor>
+  <gazebo reference="root_link">
+    <sensor name="root_link_imu_acc" type="imu">
+      <always_on>1</always_on>
+      <update_rate>400</update_rate>
+      <pose>0.085155 -0.011 -0.112309 -2.09439521059 -3.88578058619e-16 -1.57079632679</pose>
+      <plugin name="root_link_xsens_imu_plugin" filename="libgazebo_yarp_imu.so">
+    <yarpConfigurationFile>model://iCub/conf/gazebo_icub_xsens_inertial.ini</yarpConfigurationFile>
+</plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="root_link_imu_acc" type="accelerometer">
+    <parent link="root_link"/>
+    <origin rpy="-2.09439521059 -3.88578058619e-16 -1.57079632679" xyz="0.085155 -0.011 -0.112309"/>
+  </sensor>
+  <gazebo reference="r_hip_2">
+  <sensor name="r_upper_leg_ft_acc_3b11" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.0065638 -0.0085861 -0.059282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="r_upper_leg_ft_acc_3b11" type="accelerometer">
+  <parent link="r_hip_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.0065638 -0.0085861 -0.059282"/>
+</sensor>
+<gazebo reference="r_hip_2">
+  <sensor name="r_upper_leg_ft_gyro_3b11" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.0065638 -0.0085861 -0.059282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="r_upper_leg_ft_gyro_3b11" type="gyroscope">
+  <parent link="r_hip_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.0065638 -0.0085861 -0.059282"/>
+</sensor>
+<gazebo reference="r_ankle_2">
+  <sensor name="r_foot_ft_acc_3b14" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.0040001 -0.0086 -0.045282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="r_foot_ft_acc_3b14" type="accelerometer">
+  <parent link="r_ankle_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.0040001 -0.0086 -0.045282"/>
+</sensor>
+<gazebo reference="r_ankle_2">
+  <sensor name="r_foot_ft_gyro_3b14" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.0040001 -0.0086 -0.045282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="r_foot_ft_gyro_3b14" type="gyroscope">
+  <parent link="r_ankle_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.0040001 -0.0086 -0.045282"/>
+</sensor>
+<gazebo reference="l_hip_2">
+  <sensor name="l_upper_leg_ft_acc_3b12" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.00667 -0.0085248 -0.059282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="l_upper_leg_ft_acc_3b12" type="accelerometer">
+  <parent link="l_hip_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.00667 -0.0085248 -0.059282"/>
+</sensor>
+<gazebo reference="l_hip_2">
+  <sensor name="l_upper_leg_ft_gyro_3b12" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.00667 -0.0085248 -0.059282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="l_upper_leg_ft_gyro_3b12" type="gyroscope">
+  <parent link="l_hip_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.00667 -0.0085248 -0.059282"/>
+</sensor>
+<gazebo reference="l_ankle_2">
+  <sensor name="l_foot_ft_acc_3b13" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.0040002 -0.0086 -0.045282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="l_foot_ft_acc_3b13" type="accelerometer">
+  <parent link="l_ankle_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.0040002 -0.0086 -0.045282"/>
+</sensor>
+<gazebo reference="l_ankle_2">
+  <sensor name="l_foot_ft_gyro_3b13" type="imu">
+    <always_on>1</always_on>
+    <update_rate>100</update_rate>
+    <pose>0.0040002 -0.0086 -0.045282 -2.22044604925e-16 2.22044604925e-16 1.57079632679</pose>
+  </sensor>
+</gazebo>
+<sensor name="l_foot_ft_gyro_3b13" type="gyroscope">
+  <parent link="l_ankle_2"/>
+  <origin rpy="-2.22044604925e-16 2.22044604925e-16 1.57079632679" xyz="0.0040002 -0.0086 -0.045282"/>
+</sensor>
+  <gazebo>
+    <pose>0.0 0.0 0.63 0.0 0.0 3.14</pose>
+  </gazebo>
+</robot>


### PR DESCRIPTION
This PR,
- Adds a `FloatingBaseEstimators` library currently implementing the base class `FloatingBaseEstimator` which needs to be derived for proper implementations. It must be noted that this implementation assumes that an IMU is rigidly attached to the floating base link of the bipedal robot.
- Adds a `FloatingBaseEstimatorTest` which describes the generic usage of the `FloatingBaseEstimator` class.

