### PR TITLE
Avoid checking FRAMEWORK_HAS_Eigen3 in Planner/test/CMakeLists.txt

### DIFF
--- a/src/Planners/tests/CMakeLists.txt
+++ b/src/Planners/tests/CMakeLists.txt
@@ -2,13 +2,10 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-if (FRAMEWORK_HAS_Eigen3)
-    add_bipedal_test(
-        NAME ContactList
-        SOURCES ContactListTest.cpp
-        LINKS BipedalLocomotion::Contact Eigen3::Eigen)
-
-endif()
+add_bipedal_test(
+    NAME ContactList
+    SOURCES ContactListTest.cpp
+    LINKS BipedalLocomotion::Contact Eigen3::Eigen)
 
 add_bipedal_test(
     NAME ContactPhaseList


### PR DESCRIPTION
https://github.com/dic-iit/bipedal-locomotion-framework/pull/71 removed `checkandset_dependency(Eigen3)` from ` cmake/BipedalLocomotionFrameworkFindDependencies.cmake` as a consequence `FRAMEWORK_HAS_Eigen3` is not defined anymore. Consequentally the test `ContactList` was not compiled anymore.

This PR reenables the compilation of the test 