### PR TITLE
Add StdImplementation.tpp to Public headers in ParameterHandler CMakeList

### DIFF
--- a/src/ParametersHandler/CMakeLists.txt
+++ b/src/ParametersHandler/CMakeLists.txt
@@ -2,9 +2,11 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+set(H_PREFIX include/BipedalLocomotion/ParametersHandler)
+
 add_bipedal_locomotion_library(
   NAME                  ParametersHandler
-  PUBLIC_HEADERS        include/BipedalLocomotion/ParametersHandler/IParametersHandler.h include/BipedalLocomotion/ParametersHandler/StdImplementation.h
+  PUBLIC_HEADERS        ${H_PREFIX}/IParametersHandler.h ${H_PREFIX}/StdImplementation.h ${H_PREFIX}/StdImplementation.tpp
   SOURCES                src/StdImplementation.cpp
   PUBLIC_LINK_LIBRARIES BipedalLocomotion::GenericContainer
   SUBDIRECTORIES        tests YarpImplementation)


### PR DESCRIPTION
Since StdImplementation.tpp is included in StdImplementation.h, this is required.