### PR TITLE
Use manif in the contacts component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   Catch2_TAG: v2.11.3
   Qhull_TAG: v8.0.0
   CasADi_TAG: 3.5.1
-  manif_TAG: 4d24db396e6afa57b3de72b52ee1f92df6e0adba
+  manif_TAG: 56bb7744aea51820bd80875b4ee4369eb7d52dfb
 
 jobs:
   build:
@@ -166,9 +166,8 @@ jobs:
 
 
         # manif
-        # Please check the associated issue: https://github.com/artivis/manif/issues/156
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/GiulioRomualdi/manif.git
+        git clone https://github.com/artivis/manif.git
         cd manif
         git checkout ${manif_TAG}
         mkdir build
@@ -224,9 +223,8 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target install
 
         # manif
-        # Please check the associated issue: https://github.com/artivis/manif/issues/156
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/GiulioRomualdi/manif.git
+        git clone https://github.com/artivis/manif.git
         cd manif
         git checkout ${manif_TAG}
         mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   Catch2_TAG: v2.11.3
   Qhull_TAG: v8.0.0
   CasADi_TAG: 3.5.1
+  manif_TAG: 4d24db396e6afa57b3de72b52ee1f92df6e0adba
 
 jobs:
   build:
@@ -84,7 +85,7 @@ jobs:
       with:
         path: ${{ github.workspace }}/install/deps
         # Including ${{ runner.temp }} is a workaround taken from https://github.com/robotology/whole-body-estimators/pull/62 to fix macos configuration failure on https://github.com/dic-iit/bipedal-locomotion-framework/pull/45
-        key: source-deps-${{ runner.os }}-${{runner.temp}}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-catch2-${{ env.Catch2_TAG }}-qhull-${{ env.Qhull_TAG }}-casADi-${{ env.CasADi_TAG }}
+        key: source-deps-${{ runner.os }}-${{runner.temp}}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-catch2-${{ env.Catch2_TAG }}-qhull-${{ env.Qhull_TAG }}-casADi-${{ env.CasADi_TAG }}-manif-${{ env.manif_TAG }}
 
 
     - name: Source-based Dependencies [Windows]
@@ -164,6 +165,21 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target install
 
 
+        # manif
+        # Please check the associated issue: https://github.com/artivis/manif/issues/156
+        cd ${GITHUB_WORKSPACE}
+        git clone https://github.com/GiulioRomualdi/manif.git
+        cd manif
+        git checkout ${manif_TAG}
+        mkdir build
+        cd build
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
+                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                     -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                     -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
+        cmake --build . --config ${{ matrix.build_type }} --target install
+
+
     - name: Source-based Dependencies [Ubuntu/macOS]
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && (matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest')
       shell: bash
@@ -207,6 +223,16 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps -DWITH_IPOPT=BOOL:ON ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
+        # manif
+        # Please check the associated issue: https://github.com/artivis/manif/issues/156
+        cd ${GITHUB_WORKSPACE}
+        git clone https://github.com/GiulioRomualdi/manif.git
+        cd manif
+        git checkout ${manif_TAG}
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
+        cmake --build . --config ${{ matrix.build_type }} --target install
 
     - name: Source-based Dependencies [Ubuntu]
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'ubuntu-latest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,10 @@ if (FRAMEWORK_USE_cppad)
   list(APPEND FRAMEWORK_PUBLIC_DEPENDENCIES cppad)
 endif()
 
+if (FRAMEWORK_USE_manif)
+  list(APPEND FRAMEWORK_PUBLIC_DEPENDENCIES manif)
+endif()
+
 include(InstallBasicPackageFiles)
 install_basic_package_files(${PROJECT_NAME}
                             NAMESPACE BipedalLocomotion::

--- a/cmake/BipedalLocomotionFrameworkFindDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkFindDependencies.cmake
@@ -147,6 +147,9 @@ checkandset_dependency(casadi)
 find_package(cppad QUIET)
 checkandset_dependency(cppad)
 
+find_package(manif QUIET)
+checkandset_dependency(manif)
+
 framework_dependent_option(FRAMEWORK_COMPILE_YarpUtilities
   "Compile YarpHelper library?" ON
   "FRAMEWORK_USE_YARP" OFF)

--- a/cmake/BipedalLocomotionFrameworkFindDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkFindDependencies.cmake
@@ -164,7 +164,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_Estimators
 
 framework_dependent_option(FRAMEWORK_COMPILE_Planners
   "Compile Planners libraries?" ON
-  "FRAMEWORK_USE_Qhull;FRAMEWORK_USE_casadi" OFF)
+  "FRAMEWORK_USE_Qhull;FRAMEWORK_USE_casadi;FRAMEWORK_USE_manif" OFF)
 
 framework_dependent_option(FRAMEWORK_COMPILE_ContactModels
   "Compile ContactModels library?" ON

--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -10,7 +10,7 @@ if (FRAMEWORK_COMPILE_Planners)
     NAME                  Contact
     PUBLIC_HEADERS        ${H_PREFIX}/Contact.h ${H_PREFIX}/ContactList.h ${H_PREFIX}/ContactPhase.h ${H_PREFIX}/ContactPhaseList.h
     SOURCES               src/ContactList.cpp src/ContactPhase.cpp src/ContactPhaseList.cpp
-    PUBLIC_LINK_LIBRARIES iDynTree::idyntree-core
+    PUBLIC_LINK_LIBRARIES MANIF::manif
     INSTALLATION_FOLDER   Planners
     )
 

--- a/src/Planners/include/BipedalLocomotion/Planners/Contact.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/Contact.h
@@ -8,7 +8,8 @@
 #ifndef BIPEDAL_LOCOMOTION_PLANNERS_CONTACT_H
 #define BIPEDAL_LOCOMOTION_PLANNERS_CONTACT_H
 
-#include <iDynTree/Core/Transform.h>
+#include <manif/SE3.h>
+
 #include <string>
 
 namespace BipedalLocomotion
@@ -37,7 +38,7 @@ struct Contact
     /**
      * Pose of the contact.
      */
-    iDynTree::Transform pose {iDynTree::Transform::Identity()};
+    manif::SE3d pose{manif::SE3d::Identity()};
 
     /**
      * Instant from which the contact can be considered active.

--- a/src/Planners/include/BipedalLocomotion/Planners/ContactList.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/ContactList.h
@@ -12,7 +12,7 @@
 #include <BipedalLocomotion/Planners/Contact.h>
 
 //iDynTree
-#include <iDynTree/Core/Transform.h>
+#include <manif/manif.h>
 
 //std
 #include <set>
@@ -89,7 +89,7 @@ public:
      * @return false if it was not possible to insert the contact.
      * Possible failures: the activation time is greater than the deactivation time, or the new contact ovelaps with an existing contact.
      */
-    bool addContact(const iDynTree::Transform& newTransform, double activationTime, double deactivationTime);
+    bool addContact(const manif::SE3d& newTransform, double activationTime, double deactivationTime);
 
     /**
      * @brief Erase a contact

--- a/src/Planners/src/ContactList.cpp
+++ b/src/Planners/src/ContactList.cpp
@@ -61,7 +61,7 @@ bool ContactList::addContact(const Contact &newContact)
     return true;
 }
 
-bool ContactList::addContact(const iDynTree::Transform &newTransform, double activationTime, double deactivationTime)
+bool ContactList::addContact(const manif::SE3d &newTransform, double activationTime, double deactivationTime)
 {
     Contact newContact;
     newContact.pose = newTransform;
@@ -228,4 +228,3 @@ void ContactList::removeLastContact()
 {
     erase(lastContact());
 }
-

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -344,7 +344,7 @@ struct TimeVaryingDCMPlanner::Impl
         {
             for (const auto& footCorner : this->optiSettings.footCorners)
             {
-                point = activeContact->pose.isometry() * footCorner;
+                point = activeContact->pose.act(footCorner);
                 points.col(columnIndex) = point.head(numberOfCoordinates);
                 columnIndex++;
             }

--- a/src/Planners/tests/ContactListTest.cpp
+++ b/src/Planners/tests/ContactListTest.cpp
@@ -17,8 +17,9 @@ using namespace BipedalLocomotion::Planners;
 
 bool contactsAreEqual(const Contact& c1, const Contact& c2)
 {
+    constexpr double tolerance = 1e-5;
     return (c1.type == c2.type) && (c1.name == c2.name)
-           && (((c1.pose * c2.pose.inverse()).log()).isApprox(Eigen::Matrix<double, 6, 1>::Zero()))
+           && (c1.pose.coeffs().isApprox(c2.pose.coeffs(), tolerance))
            && (c1.activationTime == c2.activationTime)
            && (c1.deactivationTime == c2.deactivationTime);
 }

--- a/src/Planners/tests/ContactListTest.cpp
+++ b/src/Planners/tests/ContactListTest.cpp
@@ -1,6 +1,6 @@
 /**
  * @file ContactListTest.cpp
- * @authors Stefano Dafarra
+ * @authors Stefano Dafarra, Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
@@ -8,8 +8,8 @@
 // Catch2
 #include <catch2/catch.hpp>
 
-#include <iDynTree/Core/Utils.h>
-#include <iDynTree/Core/EigenHelpers.h>
+// manif
+#include <manif/manif.h>
 
 #include <BipedalLocomotion/Planners/ContactList.h>
 
@@ -17,12 +17,10 @@ using namespace BipedalLocomotion::Planners;
 
 bool contactsAreEqual(const Contact& c1, const Contact& c2)
 {
-    return (c1.type == c2.type) &&
-           (c1.name == c2.name) &&
-           (iDynTree::toEigen((c1.pose * c2.pose.inverse()).asHomogeneousTransform()).isApprox(
-               iDynTree::toEigen(iDynTree::Transform::Identity().asHomogeneousTransform()))) &&
-           (iDynTree::checkDoublesAreEqual(c1.activationTime, c2.activationTime)) &&
-           (iDynTree::checkDoublesAreEqual(c1.deactivationTime, c2.deactivationTime));
+    return (c1.type == c2.type) && (c1.name == c2.name)
+           && (((c1.pose * c2.pose.inverse()).log()).isApprox(Eigen::Matrix<double, 6, 1>::Zero()))
+           && (c1.activationTime == c2.activationTime)
+           && (c1.deactivationTime == c2.deactivationTime);
 }
 
 TEST_CASE("ContactList")
@@ -102,7 +100,7 @@ TEST_CASE("ContactList")
         bool ok = true;
         for (size_t i = 0; i < 49; ++i)
         {
-            ok = ok && list.addContact(iDynTree::Transform::Identity(), 2.0 + i, 2.5 + i);
+            ok = ok && list.addContact(manif::SE3d::Identity(), 2.0 + i, 2.5 + i);
         }
         REQUIRE(ok);
         REQUIRE(list.size() == 51);

--- a/src/Planners/tests/ContactPhaseListTest.cpp
+++ b/src/Planners/tests/ContactPhaseListTest.cpp
@@ -19,12 +19,12 @@ TEST_CASE("ContactPhaseList")
     SECTION("Set from map")
     {
         ContactListMap contactListMap;
-        REQUIRE(contactListMap["left"].addContact(iDynTree::Transform::Identity(), 0.0, 1.0));
-        REQUIRE(contactListMap["left"].addContact(iDynTree::Transform::Identity(), 2.0, 5.0));
-        REQUIRE(contactListMap["left"].addContact(iDynTree::Transform::Identity(), 6.0, 7.0));
+        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 0.0, 1.0));
+        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 2.0, 5.0));
+        REQUIRE(contactListMap["left"].addContact(manif::SE3d::Identity(), 6.0, 7.0));
 
-        REQUIRE(contactListMap["right"].addContact(iDynTree::Transform::Identity(), 0.0, 3.0));
-        REQUIRE(contactListMap["right"].addContact(iDynTree::Transform::Identity(), 4.0, 7.0));
+        REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 0.0, 3.0));
+        REQUIRE(contactListMap["right"].addContact(manif::SE3d::Identity(), 4.0, 7.0));
 
         phaseList.setLists(contactListMap);
     }
@@ -34,15 +34,15 @@ TEST_CASE("ContactPhaseList")
     contactListRight.setDefaultName("right");
     contactListAdditional.setDefaultName("additional");
 
-    REQUIRE(contactListLeft.addContact(iDynTree::Transform::Identity(), 0.0, 1.0));
-    REQUIRE(contactListLeft.addContact(iDynTree::Transform::Identity(), 2.0, 5.0));
-    REQUIRE(contactListLeft.addContact(iDynTree::Transform::Identity(), 6.0, 7.0));
+    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 0.0, 1.0));
+    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 2.0, 5.0));
+    REQUIRE(contactListLeft.addContact(manif::SE3d::Identity(), 6.0, 7.0));
 
-    REQUIRE(contactListRight.addContact(iDynTree::Transform::Identity(), 0.0, 3.0));
-    REQUIRE(contactListRight.addContact(iDynTree::Transform::Identity(), 4.0, 7.0));
+    REQUIRE(contactListRight.addContact(manif::SE3d::Identity(), 0.0, 3.0));
+    REQUIRE(contactListRight.addContact(manif::SE3d::Identity(), 4.0, 7.0));
 
-    REQUIRE(contactListAdditional.addContact(iDynTree::Transform::Identity(), 4.0, 5.0));
-    REQUIRE(contactListAdditional.addContact(iDynTree::Transform::Identity(), 6.0, 7.5));
+    REQUIRE(contactListAdditional.addContact(manif::SE3d::Identity(), 4.0, 5.0));
+    REQUIRE(contactListAdditional.addContact(manif::SE3d::Identity(), 6.0, 7.5));
 
     REQUIRE(phaseList.setLists({contactListAdditional, contactListLeft, contactListRight}));
 

--- a/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
+++ b/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
@@ -24,7 +24,7 @@ TEST_CASE("TimeVaryingDCMPlanner")
     // left foot
     // first footstep
     manif::SE3d leftTransform = manif::SE3d::Identity();
-    leftTransform.coeffs().bottomRows<3>() << 0, -0.8, 0;
+    leftTransform.coeffs().head<3>() << 0, -0.8, 0;
     REQUIRE(contactListMap["left"].addContact(leftTransform, 0.0, 1.0));
 
     // second footstep
@@ -35,7 +35,7 @@ TEST_CASE("TimeVaryingDCMPlanner")
     // right foot
     // first footstep
     manif::SE3d rightTransform = manif::SE3d::Identity();
-    rightTransform.coeffs().bottomRows<3>() << 0, 0.8, 0;
+    leftTransform.coeffs().head<3>() << 0, 0.8, 0;
     REQUIRE(contactListMap["right"].addContact(rightTransform, 0.0, 3.0));
 
     // second footstep

--- a/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
+++ b/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
@@ -23,24 +23,28 @@ TEST_CASE("TimeVaryingDCMPlanner")
 
     // left foot
     // first footstep
-    manif::SE3d leftTransform = manif::SE3d::Identity();
-    leftTransform.coeffs().head<3>() << 0, -0.8, 0;
+    Eigen::Vector3d leftPos;
+    leftPos << 0, -0.8, 0;
+    manif::SE3d leftTransform(leftPos, manif::SO3d::Identity());
     REQUIRE(contactListMap["left"].addContact(leftTransform, 0.0, 1.0));
 
     // second footstep
-    leftTransform.coeffs()[0] = 0.25;
-    leftTransform.coeffs()[2] = 0.2;
+    leftPos(0) = 0.25;
+    leftPos(2) = 0.2;
+    leftTransform = manif::SE3d(leftPos, manif::SO3d::Identity());
     REQUIRE(contactListMap["left"].addContact(leftTransform, 2.0, 7.0));
 
     // right foot
     // first footstep
-    manif::SE3d rightTransform = manif::SE3d::Identity();
-    rightTransform.coeffs().head<3>() << 0, 0.8, 0;
+    Eigen::Vector3d rightPos;
+    rightPos << 0, 0.8, 0;
+    manif::SE3d rightTransform(rightPos, manif::SO3d::Identity());
     REQUIRE(contactListMap["right"].addContact(rightTransform, 0.0, 3.0));
 
     // second footstep
-    rightTransform.coeffs()[0] = 0.25;
-    rightTransform.coeffs()[2] = 0.2;
+    rightPos(0) = 0.25;
+    rightPos(2) = 0.2;
+    rightTransform = manif::SE3d(rightPos, manif::SO3d::Identity());
     REQUIRE(contactListMap["right"].addContact(rightTransform, 4.0, 7.0));
     phaseList->setLists(contactListMap);
 

--- a/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
+++ b/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
@@ -35,7 +35,7 @@ TEST_CASE("TimeVaryingDCMPlanner")
     // right foot
     // first footstep
     manif::SE3d rightTransform = manif::SE3d::Identity();
-    leftTransform.coeffs().head<3>() << 0, 0.8, 0;
+    rightTransform.coeffs().head<3>() << 0, 0.8, 0;
     REQUIRE(contactListMap["right"].addContact(rightTransform, 0.0, 3.0));
 
     // second footstep

--- a/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
+++ b/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
@@ -12,8 +12,6 @@
 #include <BipedalLocomotion/Planners/ContactPhaseList.h>
 #include <BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h>
 
-#include <iDynTree/Core/VectorFixSize.h>
-
 using namespace BipedalLocomotion::Planners;
 using namespace BipedalLocomotion::ParametersHandler;
 
@@ -23,34 +21,27 @@ TEST_CASE("TimeVaryingDCMPlanner")
 
     ContactListMap contactListMap;
 
-    iDynTree::Transform leftTransform = iDynTree::Transform::Identity();
-    iDynTree::Position leftPosition;
-
-    leftPosition[0] = 0;
-    leftPosition[1] = -0.8;
-    leftPosition[2] = 0;
-    leftTransform.setPosition(leftPosition);
+    // left foot
+    // first footstep
+    manif::SE3d leftTransform = manif::SE3d::Identity();
+    leftTransform.coeffs().bottomRows<3>() << 0, -0.8, 0;
     REQUIRE(contactListMap["left"].addContact(leftTransform, 0.0, 1.0));
 
-    leftPosition[0] = 0.25;
-    leftPosition[2] = 0.2;
-    leftTransform.setPosition(leftPosition);
+    // second footstep
+    leftTransform.coeffs()[0] = 0.25;
+    leftTransform.coeffs()[2] = 0.2;
     REQUIRE(contactListMap["left"].addContact(leftTransform, 2.0, 7.0));
 
-    iDynTree::Transform rightTransform = iDynTree::Transform::Identity();
-    iDynTree::Position rightPosition;
-
-    rightPosition[0] = 0;
-    rightPosition[1] = 0.8;
-    rightPosition[2] = 0;
-    rightTransform.setPosition(rightPosition);
+    // right foot
+    // first footstep
+    manif::SE3d rightTransform = manif::SE3d::Identity();
+    rightTransform.coeffs().bottomRows<3>() << 0, 0.8, 0;
     REQUIRE(contactListMap["right"].addContact(rightTransform, 0.0, 3.0));
 
-    rightPosition[0] = 0.25;
-    rightPosition[2] = 0.2;
-    rightTransform.setPosition(rightPosition);
+    // second footstep
+    rightTransform.coeffs()[0] = 0.25;
+    rightTransform.coeffs()[2] = 0.2;
     REQUIRE(contactListMap["right"].addContact(rightTransform, 4.0, 7.0));
-
     phaseList->setLists(contactListMap);
 
     // Set the parameters
@@ -58,7 +49,8 @@ TEST_CASE("TimeVaryingDCMPlanner")
     handler->setParameter("planner_sampling_time", 0.05);
     handler->setParameter("number_of_foot_corners", 4);
 
-    iDynTree::Vector3 footCorner;
+    // set the foot-corners
+    std::vector<double> footCorner(3);
     footCorner[0] = 0.1;
     footCorner[1] = 0.05;
     footCorner[2] = 0;
@@ -98,7 +90,8 @@ TEST_CASE("TimeVaryingDCMPlanner")
 
     REQUIRE(planner.computeTrajectory());
 
-    for(int i = 0; i < 150; i++)
+    constexpr std::size_t numberOfIterations = 150;
+    for (std::size_t i = 0; i < numberOfIterations; i++)
     {
         REQUIRE(planner.advance());
     }


### PR DESCRIPTION
In this PR I removed the `iDyntree` dependency in favor of `manif`.

I also updated the CI adding `manif` dependency. Here I'm cloning manif from   https://github.com/GiulioRomualdi/manif.git because of https://github.com/artivis/manif/issues/156. I already opened a PR upstream https://github.com/artivis/manif/pull/157 as soon as it has been merged I will update this code.

I would like to wait for the review of @S-Dafarra since he is the first developer of this part of the code 