### PR TITLE
Implement the QuinticSpline class

### DIFF
--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -16,8 +16,8 @@ if (FRAMEWORK_COMPILE_Planners)
 
   add_bipedal_locomotion_library(
     NAME                   Planners
-    PUBLIC_HEADERS         ${H_PREFIX}/ConvexHullHelper.h ${H_PREFIX}/DCMPlanner.h ${H_PREFIX}/TimeVaryingDCMPlanner.h
-    SOURCES                src/ConvexHullHelper.cpp  src/DCMPlanner.cpp src/TimeVaryingDCMPlanner.cpp
+    PUBLIC_HEADERS         ${H_PREFIX}/ConvexHullHelper.h ${H_PREFIX}/DCMPlanner.h ${H_PREFIX}/TimeVaryingDCMPlanner.h ${H_PREFIX}/QuinticSpline.h
+    SOURCES                src/ConvexHullHelper.cpp  src/DCMPlanner.cpp src/TimeVaryingDCMPlanner.cpp src/QuinticSpline.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::System BipedalLocomotion::Contact
     PRIVATE_LINK_LIBRARIES Qhull::qhullcpp Qhull::qhullstatic_r casadi
     INSTALLATION_FOLDER    Planners)

--- a/src/Planners/include/BipedalLocomotion/Planners/QuinticSpline.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/QuinticSpline.h
@@ -1,0 +1,86 @@
+/**
+ * @file QuinticSpline.h
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_PLANNERS_QUINTIC_SPLINE_H
+#define BIPEDAL_LOCOMOTION_PLANNERS_QUINTIC_SPLINE_H
+
+#include <vector>
+#include <memory>
+
+#include <Eigen/Dense>
+
+namespace BipedalLocomotion
+{
+namespace Planners
+{
+/**
+ * Quintic spline implement a 5-th order polynomial spline in \$f\mathbb{R}^n\$f.
+ */
+class QuinticSpline
+{
+    /**
+     * Private implementation of the class
+     */
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl; /**< Private implementation */
+
+public:
+
+    /**
+     * Constructor.
+     */
+    QuinticSpline();
+
+    /**
+     * Destructor.
+     * @note It is required by the PIMPL idiom.
+     */
+    ~QuinticSpline();
+
+    /**
+     * Set the knots of the spline.
+     * @param position position of the knots in \$f\mathbb{R}^n\$f.
+     * @param time vector containing the time instant of the knots.
+     * @return True in case of success, false otherwise.
+     */
+    bool setKnots(const std::vector<Eigen::VectorXd>& position, const std::vector<double>& time);
+
+    /**
+     * Set the initial condition of the spline
+     * @param velocity initial velocity (i.e. first derivative).
+     * @param acceleration initial acceleration (i.e. second derivative).
+     * @return True in case of success, false otherwise.
+     */
+    bool setInitialConditions(Eigen::Ref<const Eigen::VectorXd> velocity,
+                              Eigen::Ref<const Eigen::VectorXd> acceleration);
+
+    /**
+     * Set the final condition of the spline
+     * @param velocity final velocity (i.e. first derivative).
+     * @param acceleration final acceleration (i.e. second derivative).
+     * @return True in case of success, false otherwise.
+     */
+    bool setFinalConditions(Eigen::Ref<const Eigen::VectorXd> velocity,
+                            Eigen::Ref<const Eigen::VectorXd> acceleration);
+
+    /**
+     * Evaluate the spline at a given point
+     * @param t instant time
+     * @param position position at time t
+     * @param velocity velocity at time t
+     * @param acceleration acceleration at time t
+     * @return True in case of success, false otherwise.
+     */
+    bool evaluatePoint(const double& t,
+                       Eigen::Ref<Eigen::VectorXd> position,
+                       Eigen::Ref<Eigen::VectorXd> velocity,
+                       Eigen::Ref<Eigen::VectorXd> acceleration);
+};
+} // namespace Planners
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_PLANNERS_QUINTIC_SPLINE_H

--- a/src/Planners/include/BipedalLocomotion/Planners/QuinticSpline.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/QuinticSpline.h
@@ -13,14 +13,24 @@
 
 #include <Eigen/Dense>
 
+#include <BipedalLocomotion/System/Advanceable.h>
+
 namespace BipedalLocomotion
 {
 namespace Planners
 {
+
+struct QuinticSplineState
+{
+    Eigen::VectorXd position;
+    Eigen::VectorXd velocity;
+    Eigen::VectorXd acceleration;
+};
+
 /**
  * Quintic spline implement a 5-th order polynomial spline in \$f\mathbb{R}^n\$f.
  */
-class QuinticSpline
+class QuinticSpline : public System::Advanceable<QuinticSplineState>
 {
     /**
      * Private implementation of the class
@@ -29,7 +39,6 @@ class QuinticSpline
     std::unique_ptr<Impl> m_pimpl; /**< Private implementation */
 
 public:
-
     /**
      * Constructor.
      */
@@ -40,6 +49,14 @@ public:
      * @note It is required by the PIMPL idiom.
      */
     ~QuinticSpline();
+
+    /**
+     * Set the time step of the advance interface.
+     * @warning if the the time step is not set the user cannot use the advance features.
+     * @param dt the time step of the advance block.
+     * @return True in case of success, false otherwise.
+     */
+    bool setAdvanceTimeStep(const double& dt);
 
     /**
      * Set the knots of the spline.
@@ -79,6 +96,40 @@ public:
                        Eigen::Ref<Eigen::VectorXd> position,
                        Eigen::Ref<Eigen::VectorXd> velocity,
                        Eigen::Ref<Eigen::VectorXd> acceleration);
+
+    /**
+     * Evaluate the spline at a given point
+     * @param t instant time
+     * @param state of the system
+     * @return True in case of success, false otherwise.
+     */
+    bool evaluatePoint(const double& t,
+                       QuinticSplineState& state);
+
+    /**
+     * Get the state of the system.
+     * @warning if the the time step of the advance is not set the user cannot use the advance
+     * features.
+     * @return a const reference of the requested object.
+     */
+    const QuinticSplineState& get() const final;
+
+    /**
+     * Determines the validity of the object retrieved with get()
+     * @warning if the the time step of the advance is not set the user cannot use the advance
+     * features.
+     * @return True if the object is valid, false otherwise.
+     */
+    bool isValid() const final;
+
+    /**
+     * Advance the internal state. This may change the value retrievable from get().
+     * @warning if the the time step of the advance is not set the user cannot use the advance
+     * features.
+     * @return True if the advance is successfull.
+     */
+    bool advance() final;
+
 };
 } // namespace Planners
 } // namespace BipedalLocomotion

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -169,7 +169,7 @@ QuinticSpline::QuinticSpline()
 QuinticSpline::~QuinticSpline() = default;
 
 bool QuinticSpline::setInitialConditions(Eigen::Ref<const Eigen::VectorXd> velocity,
-                                               Eigen::Ref<const Eigen::VectorXd> acceleration)
+                                         Eigen::Ref<const Eigen::VectorXd> acceleration)
 {
     if (velocity.size() != acceleration.size())
     {
@@ -290,7 +290,7 @@ bool QuinticSpline::Impl::computeCoefficients()
     this->polynomials.resize(knots.size() - 1);
 
     // set the velocity and acceleration boundary conditions
-    if(!this->setBoundaryVelocitiesAndAcceleration())
+    if (!this->setBoundaryVelocitiesAndAcceleration())
     {
         std::cerr << "[QuinticSpline::Impl::computeCoefficients] Unable to set the boundary "
                      "conditions related to the velocity and acceleration."
@@ -308,7 +308,7 @@ bool QuinticSpline::Impl::computeCoefficients()
     }
 
     // populate the polynomials vector with the knots
-    for(int i = 0; i < polynomials.size(); i++)
+    for (int i = 0; i < polynomials.size(); i++)
     {
         polynomials[i].initialPoint = &(knots[i]);
         polynomials[i].finalPoint = &(knots[i + 1]);
@@ -484,8 +484,8 @@ void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
 }
 
 void QuinticSpline::Impl::addKnownTermKnotPosition(const std::size_t& knotIndex,
-                                             const std::size_t& coordinateIndex,
-                                             Eigen::Ref<Eigen::VectorXd> b)
+                                                   const std::size_t& coordinateIndex,
+                                                   Eigen::Ref<Eigen::VectorXd> b)
 {
     const auto& poly = polynomials;
 
@@ -516,7 +516,7 @@ void QuinticSpline::Impl::addKnownTermNextKnot(const std::size_t& knotIndex,
 
     Eigen::Matrix2d tempMatrix;
     tempMatrix << -8 / std::pow(poly[i].duration, 2), 1 / poly[i].duration,
-                  14 / std::pow(poly[i].duration, 3), -2 / std::pow(poly[i].duration, 2);
+        14 / std::pow(poly[i].duration, 3), -2 / std::pow(poly[i].duration, 2);
 
     Eigen::Vector2d tempVector;
     tempVector << knots[i + 1].velocity[j], knots[i + 1].acceleration[j];
@@ -534,7 +534,7 @@ void QuinticSpline::Impl::addKnownTermPreviousKnot(const std::size_t& knotIndex,
 
     Eigen::Matrix2d tempMatrix;
     tempMatrix << 8 / std::pow(poly[i - 1].duration, 2), 1 / poly[i - 1].duration,
-                 14 / std::pow(poly[i - 1].duration, 3), 2 / std::pow(poly[i - 1].duration, 2);
+        14 / std::pow(poly[i - 1].duration, 3), 2 / std::pow(poly[i - 1].duration, 2);
 
     Eigen::Vector2d tempVector;
     tempVector << knots[i - 1].velocity[j], knots[i - 1].acceleration[j];
@@ -579,7 +579,7 @@ void QuinticSpline::Impl::computeIntermediateVelocitiesAndAcceleration()
     std::vector<Eigen::Triplet<double>> tripletsList;
 
     std::size_t numberOfExpectedTriplets = 4;
-    if(numberOfInteriorKnots  > 1)
+    if (numberOfInteriorKnots > 1)
     {
         numberOfExpectedTriplets = 2 * (6 * (numberOfInteriorKnots - 2) + 2 * 4);
     }
@@ -593,15 +593,11 @@ void QuinticSpline::Impl::computeIntermediateVelocitiesAndAcceleration()
         if (i == 0 && (i + 1) == numberOfInteriorKnots)
         {
             this->addTripletCurrentKnot(absoluteKnotIndex, 0, 0, tripletsList);
-        }
-        else if (i == 0)
+        } else if (i == 0)
         {
             this->addTripletCurrentKnot(absoluteKnotIndex, i * 2, 0, tripletsList);
             this->addTripletNextKnot(absoluteKnotIndex, i * 2, 2, tripletsList);
-
-        }
-
-        else if (i + 1 == numberOfInteriorKnots)
+        } else if (i + 1 == numberOfInteriorKnots)
         {
             this->addTripletPreviousKnot(absoluteKnotIndex, i * 2, 2 * (i - 1), tripletsList);
             this->addTripletCurrentKnot(absoluteKnotIndex, i * 2, 2 * (i - 1) + 2, tripletsList);
@@ -653,7 +649,7 @@ void QuinticSpline::Impl::computeIntermediateVelocitiesAndAcceleration()
         qrDecomposition.compute(A);
         Eigen::VectorXd solution = qrDecomposition.solve(b);
 
-        for(size_t i = 0; i < numberOfInteriorKnots; i++)
+        for (size_t i = 0; i < numberOfInteriorKnots; i++)
         {
             const int absoluteKnotIndex = i + 1;
 

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -263,19 +263,11 @@ bool QuinticSpline::Impl::computePhasesDuration()
     {
         polynomials[i].duration = knots[i + 1].timeInstant - knots[i].timeInstant;
 
-        // This is required for stability purposes, the matrix below may not be invertible
+        // This is required or stability purposes, the matrix A may not be invertible.
         if (polynomials[i].duration == 0)
         {
             std::cerr << "[QuinticSpline::Impl::computePhasesDuration] Two consecutive points have "
                          "the same time coordinate."
-                      << std::endl;
-            return false;
-        }
-
-        if (polynomials[i].duration == 0)
-        {
-            std::cerr << "[QuinticSpline::Impl::computePhasesDuration] The input points are "
-                         "expected to be consecutive, strictly increasing in the time variable."
                       << std::endl;
             return false;
         }

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -303,7 +303,7 @@ bool QuinticSpline::Impl::computePhasesDuration()
         polynomials[i].duration = knots[i + 1].timeInstant - knots[i].timeInstant;
 
         // This is required or stability purposes, the matrix A may not be invertible.
-        if (polynomials[i].duration == 0)
+        if (std::abs(polynomials[i].duration) <= std::numeric_limits<double>::epsilon())
         {
             std::cerr << "[QuinticSpline::Impl::computePhasesDuration] Two consecutive points have "
                          "the same time coordinate."

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -637,11 +637,11 @@ void QuinticSpline::Impl::computeIntermediateVelocitiesAndAcceleration()
     //                         |__                                       __|
     //
     // where x represents a non zero number and 0 represents the number 0. The matrix A can be
-    // stored as a spare matrix where the number of non zero entries fro the extremum elements are 4
-    // * 2 and the number of non zero elements for the interior (non extremum elements) are 6 * 2.
-    // The matrix A is a square matrix whose number of columns (and rows) is equal to the number of
-    // interior knots of the spline times 2.
-    // If there is only an interior knot, A is a 2x2 dense matrix.
+    // stored as a sparse matrix where the number of non zero entries for the extremum elements are
+    // 4 * 2 and the number of non zero elements for the interior (non extremum elements) are 6
+    // * 2. The matrix A is a square matrix whose number of columns (and rows) is equal to the
+    // number of interior knots of the spline times 2. If there is only an interior knot, A is a 2x2
+    // dense matrix.
     std::size_t numberOfExpectedTriplets = 4;
     if (numberOfInteriorKnots > 1)
     {

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -96,7 +96,7 @@ struct QuinticSpline::Impl
     bool setBoundaryVelocitiesAndAcceleration();
 
     /**
-     * addTripletCurrentKnot is an helper function to generate a triplet containing a 2x2 matrix.
+     * addTripletCurrentKnot is a helper function to generate a triplet containing a 2x2 matrix.
      * This matrix is used to compute the intermediate velocity and acceleration.
      */
     void addTripletCurrentKnot(const int& knotIndex,
@@ -105,7 +105,7 @@ struct QuinticSpline::Impl
                                std::vector<Eigen::Triplet<double>>& tripletList);
 
     /**
-     * addTripletPreviousKnot is an helper function to generate a triplet containing a 2x2 matrix.
+     * addTripletPreviousKnot is a helper function to generate a triplet containing a 2x2 matrix.
      * This matrix is used to compute the intermediate velocity and acceleration.
      */
     void addTripletPreviousKnot(const int& knotIndex,
@@ -113,7 +113,7 @@ struct QuinticSpline::Impl
                                 const int& columnOffset,
                                 std::vector<Eigen::Triplet<double>>& tripletList);
     /**
-     * addTripletNextKnot is an helper function to generate a triplet containing a 2x2 matrix.
+     * addTripletNextKnot is a helper function to generate a triplet containing a 2x2 matrix.
      * This matrix is used to compute the intermediate velocity and acceleration.
      */
     void addTripletNextKnot(const int& knotIndex,
@@ -122,7 +122,7 @@ struct QuinticSpline::Impl
                             std::vector<Eigen::Triplet<double>>& tripletList);
 
     /**
-     * addKnownTermKnotPosition is an helper function to generate a 2-d vector,
+     * addKnownTermKnotPosition is a helper function to generate a 2-d vector,
      * This vector is the known term used to compute the intermediate velocity and acceleration.
      */
     void addKnownTermKnotPosition(const std::size_t& knotIndex,
@@ -130,7 +130,7 @@ struct QuinticSpline::Impl
                                   Eigen::Ref<Eigen::VectorXd> b);
 
     /**
-     * addKnownTermNextKnot is an helper function to generate a 2-d vector,
+     * addKnownTermNextKnot is a helper function to generate a 2-d vector,
      * This vector is the known term used to compute the intermediate velocity and acceleration.
      */
     void addKnownTermNextKnot(const std::size_t& knotIndex,
@@ -138,7 +138,7 @@ struct QuinticSpline::Impl
                               Eigen::Ref<Eigen::VectorXd> b);
 
     /**
-     * addKnownTermPreviousKnot is an helper function to generate a 2-d vector,
+     * addKnownTermPreviousKnot is a helper function to generate a 2-d vector,
      * This vector is the known term used to compute the intermediate velocity and acceleration.
      */
     void addKnownTermPreviousKnot(const std::size_t& knotIndex,
@@ -286,7 +286,7 @@ bool QuinticSpline::Impl::computeCoefficients()
         return false;
     }
 
-    // the number of polynomials is equal to the number of knots - -1
+    // the number of polynomials is equal to the "number of knots - 1"
     this->polynomials.resize(knots.size() - 1);
 
     // set the velocity and acceleration boundary conditions

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -617,10 +617,40 @@ void QuinticSpline::Impl::computeIntermediateVelocitiesAndAcceleration()
     Eigen::SparseMatrix<double> A(2 * numberOfInteriorKnots, 2 * numberOfInteriorKnots);
     std::vector<Eigen::Triplet<double>> tripletsList;
 
+    // Given a set of interior points the we can define a matrix A as
+    //                          __                                        __
+    //                         | x x x x 0 0 0 0 0 0 0 0 ... 0 0 0 0 0 0 0 |
+    //                         | x x x x 0 0 0 0 0 0 0 0 ... 0 0 0 0 0 0 0 |
+    //                         | x x x x x x 0 0 0 0 0 0 ... 0 0 0 0 0 0 0 |
+    //                         | x x x x x x 0 0 0 0 0 0 ... 0 0 0 0 0 0 0 |
+    //                         | 0 0 x x x x x x 0 0 0 0 ... 0 0 0 0 0 0 0 |
+    //                         | 0 0 x x x x x x 0 0 0 0 ... 0 0 0 0 0 0 0 |
+    //     /\      ______      | 0 0 0 0 x x x x x x 0 0 ... 0 0 0 0 0 0 0 |
+    //    /  \    |______|     | 0 0 0 0 x x x x x x 0 0 ... 0 0 0 0 0 0 0 |
+    //   / /\ \    ______      |         ........................          |
+    //  / ____ \  |______|     |         ........................          |
+    // /_/    \_\              |         ........................          |
+    //                         | 0 0 0 0 0 0 0 0 0 0 0 0 ... x x x x x x x |
+    //                         | 0 0 0 0 0 0 0 0 0 0 0 0 ... x x x x x x x |
+    //                         | 0 0 0 0 0 0 0 0 0 0 0 0 ... 0 0 x x x x x |
+    //                         | 0 0 0 0 0 0 0 0 0 0 0 0 ... 0 0 x x x x x |
+    //                         |__                                       __|
+    //
+    // where x represents a non zero number and 0 represents the number 0. The matrix A can be
+    // stored as a spare matrix where the number of non zero entries fro the extremum elements are 4
+    // * 2 and the number of non zero elements for the interior (non extremum elements) are 6 * 2.
+    // The matrix A is a square matrix whose number of columns (and rows) is equal to the number of
+    // interior knots of the spline times 2.
+    // If there is only an interior knot, A is a 2x2 dense matrix.
     std::size_t numberOfExpectedTriplets = 4;
     if (numberOfInteriorKnots > 1)
     {
-        numberOfExpectedTriplets = 2 * (6 * (numberOfInteriorKnots - 2) + 2 * 4);
+        constexpr std::size_t numberOfExtremumElements = 4;
+        constexpr std::size_t numberOfNonExtremumElements = 6;
+        constexpr std::size_t numberOfExtremum = 2;
+        numberOfExpectedTriplets = 2 * (numberOfNonExtremumElements * (numberOfInteriorKnots
+                                                                       - numberOfExtremum)
+                                        + numberOfExtremum * numberOfExtremumElements);
     }
     tripletsList.reserve(numberOfExpectedTriplets);
 

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -90,7 +90,7 @@ struct QuinticSpline::Impl
     bool computePhasesDuration();
 
     /**
-     * Set tthe boundary condition. This function is called before computing all the intermediate
+     * Set the boundary condition. This function is called before computing all the intermediate
      * velocities and accelerations.
      */
     bool setBoundaryVelocitiesAndAccelaration();
@@ -213,7 +213,7 @@ bool QuinticSpline::setKnots(const std::vector<Eigen::VectorXd>& position,
 {
     if (position.size() < 2)
     {
-        std::cerr << "[QuinticSpline::setKnots] The number of knots has to be greater equal 2."
+        std::cerr << "[QuinticSpline::setKnots] The number of knots has to be at least 2."
                   << std::endl;
         return false;
     }
@@ -240,7 +240,7 @@ bool QuinticSpline::setKnots(const std::vector<Eigen::VectorXd>& position,
         if (position[i].size() != sizeOfVectors)
         {
             std::cerr << "[QuinticSpline::setKnots] The size of the knot number " << i
-                      << " in different from the one expected. Expected: " << sizeOfVectors
+                      << " is different from the one expected. Expected: " << sizeOfVectors
                       << " Retrieved: " << position[i].size() << "." << std::endl;
             return false;
         }
@@ -263,7 +263,7 @@ bool QuinticSpline::Impl::computePhasesDuration()
     {
         polynomials[i].duration = knots[i + 1].timeInstant - knots[i].timeInstant;
 
-        // This is required or stability purposes, the matrix below may not be invertible
+        // This is required for stability purposes, the matrix below may not be invertible
         if (polynomials[i].duration == 0)
         {
             std::cerr << "[QuinticSpline::Impl::computePhasesDuration] Two consecutive points have "

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -93,7 +93,7 @@ struct QuinticSpline::Impl
      * Set the boundary condition. This function is called before computing all the intermediate
      * velocities and accelerations.
      */
-    bool setBoundaryVelocitiesAndAccelaration();
+    bool setBoundaryVelocitiesAndAcceleration();
 
     /**
      * addTripletCurrentKnot is an helper function to generate a triplet containing a 2x2 matrix.
@@ -148,7 +148,7 @@ struct QuinticSpline::Impl
     /**
      * Compute the intermediate velocity and accelerations.
      */
-    void computeIntermediateVelocitiesAndAccelaration();
+    void computeIntermediateVelocitiesAndAcceleration();
 
     /**
      * Function to set the coefficients of the polynomials
@@ -290,7 +290,7 @@ bool QuinticSpline::Impl::computeCoefficients()
     this->polynomials.resize(knots.size() - 1);
 
     // set the velocity and acceleration boundary conditions
-    if(!this->setBoundaryVelocitiesAndAccelaration())
+    if(!this->setBoundaryVelocitiesAndAcceleration())
     {
         std::cerr << "[QuinticSpline::Impl::computeCoefficients] Unable to set the boundary "
                      "conditions related to the velocity and acceleration."
@@ -317,7 +317,7 @@ bool QuinticSpline::Impl::computeCoefficients()
     // intermediate conditions have to be computed only if the knots are greater than equal 3
     if (knots.size() > 2)
     {
-        this->computeIntermediateVelocitiesAndAccelaration();
+        this->computeIntermediateVelocitiesAndAcceleration();
     }
 
     // populate the coefficients of each polynomial
@@ -332,7 +332,7 @@ bool QuinticSpline::Impl::computeCoefficients()
     return true;
 }
 
-bool QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration()
+bool QuinticSpline::Impl::setBoundaryVelocitiesAndAcceleration()
 {
     // this is an internal function and it is called only after setting the knots. However
     // the following assert checks that the number of knots is at least 1
@@ -342,7 +342,7 @@ bool QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration()
 
     if (knotSize != initialCondition.velocity.size())
     {
-        std::cerr << "[QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration] The size of the "
+        std::cerr << "[QuinticSpline::Impl::setBoundaryVelocitiesAndAcceleration] The size of the "
                      "initial velocity is different from the expected one. Expected: "
                   << knotSize << ", Retrieved: " << initialCondition.velocity.size() << "."
                   << std::endl;
@@ -351,7 +351,7 @@ bool QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration()
 
     if (knotSize != initialCondition.acceleration.size())
     {
-        std::cerr << "[QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration] The size of the "
+        std::cerr << "[QuinticSpline::Impl::setBoundaryVelocitiesAndAcceleration] The size of the "
                      "initial acceleration is different from the expected one. Expected: "
                   << knotSize << ", Retrieved: " << initialCondition.acceleration.size() << "."
                   << std::endl;
@@ -360,7 +360,7 @@ bool QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration()
 
     if (knotSize != finalCondition.velocity.size())
     {
-        std::cerr << "[QuinticSpline::setBoundaryVelocitiesAndAccelaration] The size of the "
+        std::cerr << "[QuinticSpline::setBoundaryVelocitiesAndAcceleration] The size of the "
                      "final velocity is different from the expected one. Expected: "
                   << knotSize << ", Retrieved: " << finalCondition.velocity.size() << "."
                   << std::endl;
@@ -369,7 +369,7 @@ bool QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration()
 
     if (knotSize != finalCondition.acceleration.size())
     {
-        std::cerr << "[QuinticSpline::setBoundaryVelocitiesAndAccelaration] The size of the "
+        std::cerr << "[QuinticSpline::setBoundaryVelocitiesAndAcceleration] The size of the "
                      "final acceleration is different from the expected one. Expected: "
                   << knotSize << ", Retrieved: " << finalCondition.acceleration.size() << "."
                   << std::endl;
@@ -572,7 +572,7 @@ void QuinticSpline::Impl::setPolynomialCoefficients(Polynomial& poly)
               * (-1.0 / 2.0);
 }
 
-void QuinticSpline::Impl::computeIntermediateVelocitiesAndAccelaration()
+void QuinticSpline::Impl::computeIntermediateVelocitiesAndAcceleration()
 {
     // here we assume that at least 3 points has been defined
     const std::size_t numberOfInteriorKnots = knots.size() - 2;

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -391,7 +391,8 @@ void QuinticSpline::Impl::addTripletCurrentKnot(const int& knotIndex,
                                                 const int& columnOffset,
                                                 std::vector<Eigen::Triplet<double>>& tripletList)
 {
-    const auto& poly = polynomials;
+    const auto& poly = polynomials[knotIndex];
+    const auto& prevPoly = polynomials[knotIndex - 1];
 
     // The following triplets represent this matrix
     // /    /   1      1\          /   1      1\ \
@@ -407,24 +408,25 @@ void QuinticSpline::Impl::addTripletCurrentKnot(const int& knotIndex,
     // |    |T        T |         |T    T     |  |
     // \    \ i - 1    i/         \ i    i - 1/  /
 
-    tripletList.push_back({rowOffset,
-                           columnOffset,
-                           12 * (1 / std::pow(poly[knotIndex - 1].duration, 2)
-                                 - 1 / std::pow(poly[knotIndex].duration, 2))});
+    tripletList.push_back(
+        {rowOffset,
+         columnOffset,
+         12 * ((1 / std::pow(prevPoly.duration, 2)) - (1 / std::pow(poly.duration, 2)))});
 
-    tripletList.push_back({rowOffset,
-                           columnOffset + 1,
-                           -3 * (1 / poly[knotIndex - 1].duration + 1 / poly[knotIndex].duration)});
+    tripletList.push_back(
+        {rowOffset,
+         columnOffset + 1,
+         -3 * ((1 / prevPoly.duration) + (1 / poly.duration))});
 
-    tripletList.push_back({rowOffset + 1,
-                           columnOffset,
-                           16 * (1 / std::pow(poly[knotIndex - 1].duration, 3)
-                                 + 1 / std::pow(poly[knotIndex].duration, 3))});
+    tripletList.push_back(
+        {rowOffset + 1,
+         columnOffset,
+         16 * ((1 / std::pow(prevPoly.duration, 3)) + (1 / std::pow(poly.duration, 3)))});
 
-    tripletList.push_back({rowOffset + 1,
-                           columnOffset + 1,
-                           3 * (-1 / std::pow(poly[knotIndex - 1].duration, 2)
-                                + 1 / std::pow(poly[knotIndex].duration, 2))});
+    tripletList.push_back(
+        {rowOffset + 1,
+         columnOffset + 1,
+         3 * ((-1 / std::pow(prevPoly.duration, 2)) + (1 / std::pow(poly.duration, 2)))});
 }
 
 void QuinticSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
@@ -432,7 +434,7 @@ void QuinticSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
                                                  const int& columnOffset,
                                                  std::vector<Eigen::Triplet<double>>& tripletList)
 {
-    const auto& poly = polynomials;
+    const auto& poly = polynomials[knotIndex - 1];
 
     // The following triplets represent this matrix
     // /    8          1    \
@@ -448,12 +450,10 @@ void QuinticSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
     // | T          T       |
     // \  i - 1      i - 1  /
 
-    tripletList.push_back({rowOffset, columnOffset, 8 / std::pow(poly[knotIndex - 1].duration, 2)});
-    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly[knotIndex - 1].duration});
-    tripletList.push_back(
-        {rowOffset + 1, columnOffset, 14 / std::pow(poly[knotIndex - 1].duration, 3)});
-    tripletList.push_back(
-        {rowOffset + 1, columnOffset + 1, 2 / std::pow(poly[knotIndex - 1].duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset, 8 / std::pow(poly.duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly.duration});
+    tripletList.push_back({rowOffset + 1, columnOffset, 14 / std::pow(poly.duration, 3)});
+    tripletList.push_back({rowOffset + 1, columnOffset + 1, 2 / std::pow(poly.duration, 2)});
 }
 
 void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
@@ -461,7 +461,7 @@ void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
                                              const int& columnOffset,
                                              std::vector<Eigen::Triplet<double>>& tripletList)
 {
-    const auto& poly = polynomials;
+    const auto& poly = polynomials[knotIndex];
 
     // The following triplets represent this matrix
     // /    8          1    \
@@ -477,12 +477,10 @@ void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
     // |  T            T    |
     // \   i            i   /
 
-    tripletList.push_back({rowOffset, columnOffset, -8 / std::pow(poly[knotIndex].duration, 2)});
-    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly[knotIndex].duration});
-    tripletList.push_back(
-        {rowOffset + 1, columnOffset, 14 / std::pow(poly[knotIndex].duration, 3)});
-    tripletList.push_back(
-        {rowOffset + 1, columnOffset + 1, -2 / std::pow(poly[knotIndex].duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset, -8 / std::pow(poly.duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly.duration});
+    tripletList.push_back({rowOffset + 1, columnOffset, 14 / std::pow(poly.duration, 3)});
+    tripletList.push_back({rowOffset + 1, columnOffset + 1, -2 / std::pow(poly.duration, 2)});
 }
 
 void QuinticSpline::Impl::addKnownTermKnotPosition(const std::size_t& knotIndex,

--- a/src/Planners/src/QuinticSpline.cpp
+++ b/src/Planners/src/QuinticSpline.cpp
@@ -1,0 +1,787 @@
+/**
+ * @file QuinticSpline.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <algorithm>
+#include <iostream>
+
+#include <Eigen/Sparse>
+
+#include <BipedalLocomotion/Planners/QuinticSpline.h>
+using namespace BipedalLocomotion::Planners;
+
+struct QuinticSpline::Impl
+{
+    /**
+     * Struct containing the boundary condtion
+     */
+    struct BoundaryConditions
+    {
+        Eigen::VectorXd velocity;
+        Eigen::VectorXd acceleration;
+    };
+
+    /**
+     * Description of a knot
+     */
+    struct Knot
+    {
+        Eigen::VectorXd position; /**< Knot position */
+        Eigen::VectorXd velocity; /**< first derivative of spline computed at t@knot */
+        Eigen::VectorXd acceleration; /**< second derivative of spline computed at t@knot */
+
+        double timeInstant; /**< Knot time (it is an absolute time ) */
+    };
+
+    /**
+     * Description of a 5-th polynomial. It contains the coefficients, the initial/final knots and
+     * the duration of the sub-trajectory.
+     */
+    struct Polynomial
+    {
+        Eigen::VectorXd a0;
+        Eigen::VectorXd a1;
+        Eigen::VectorXd a2;
+        Eigen::VectorXd a3;
+        Eigen::VectorXd a4;
+        Eigen::VectorXd a5;
+
+        const Knot* initialPoint;
+        const Knot* finalPoint;
+
+        double duration;
+    };
+
+    BoundaryConditions initialCondition; /**< Initial condition */
+    BoundaryConditions finalCondition; /**< Final condition */
+
+    std::vector<Knot> knots; /**< Collection of all the knots */
+    std::vector<Polynomial> polynomials; /**< Collection of all the polynomials */
+
+    bool areCoefficientsComputed{false}; /**< If true the coefficients are computed and updated */
+
+    /**
+     * Get the position at given time for a sub-trajectory
+     */
+    void getPositionAtTime(const double& t,
+                           const Polynomial& poly,
+                           Eigen::Ref<Eigen::VectorXd> position);
+
+    /**
+     * Get the velocity at given time for a sub-trajectory
+     */
+    void getVelocityAtTime(const double& t,
+                           const Polynomial& poly,
+                           Eigen::Ref<Eigen::VectorXd> velocity);
+
+    /**
+     * Get the acceleration at given time for a sub-trajectory
+     */
+    void getAccelerationAtTime(const double& t,
+                               const Polynomial& poly,
+                               Eigen::Ref<Eigen::VectorXd> acceleration);
+
+    /**
+     * Compute the duration of each phase
+     */
+    bool computePhasesDuration();
+
+    /**
+     * Set tthe boundary condition. This function is called before computing all the intermediate
+     * velocities and accelerations.
+     */
+    bool setBoundaryVelocitiesAndAccelaration();
+
+    /**
+     * addTripletCurrentKnot is an helper function to generate a triplet containing a 2x2 matrix.
+     * This matrix is used to compute the intermediate velocity and acceleration.
+     */
+    void addTripletCurrentKnot(const int& knotIndex,
+                               const int& rowOffset,
+                               const int& columnOffset,
+                               std::vector<Eigen::Triplet<double>>& tripletList);
+
+    /**
+     * addTripletPreviousKnot is an helper function to generate a triplet containing a 2x2 matrix.
+     * This matrix is used to compute the intermediate velocity and acceleration.
+     */
+    void addTripletPreviousKnot(const int& knotIndex,
+                                const int& rowOffset,
+                                const int& columnOffset,
+                                std::vector<Eigen::Triplet<double>>& tripletList);
+    /**
+     * addTripletNextKnot is an helper function to generate a triplet containing a 2x2 matrix.
+     * This matrix is used to compute the intermediate velocity and acceleration.
+     */
+    void addTripletNextKnot(const int& knotIndex,
+                            const int& rowOffset,
+                            const int& columnOffset,
+                            std::vector<Eigen::Triplet<double>>& tripletList);
+
+    /**
+     * addKnownTermKnotPosition is an helper function to generate a 2-d vector,
+     * This vector is the known term used to compute the intermediate velocity and acceleration.
+     */
+    void addKnownTermKnotPosition(const std::size_t& knotIndex,
+                                  const std::size_t& coordinateIndex,
+                                  Eigen::Ref<Eigen::VectorXd> b);
+
+    /**
+     * addKnownTermNextKnot is an helper function to generate a 2-d vector,
+     * This vector is the known term used to compute the intermediate velocity and acceleration.
+     */
+    void addKnownTermNextKnot(const std::size_t& knotIndex,
+                              const std::size_t& coordinateIndex,
+                              Eigen::Ref<Eigen::VectorXd> b);
+
+    /**
+     * addKnownTermPreviousKnot is an helper function to generate a 2-d vector,
+     * This vector is the known term used to compute the intermediate velocity and acceleration.
+     */
+    void addKnownTermPreviousKnot(const std::size_t& knotIndex,
+                                  const std::size_t& coordinateIndex,
+                                  Eigen::Ref<Eigen::VectorXd> b);
+
+    /**
+     * Compute the intermediate velocity and accelerations.
+     */
+    void computeIntermediateVelocitiesAndAccelaration();
+
+    /**
+     * Function to set the coefficients of the polynomials
+     */
+    void setPolynomialCoefficients(Polynomial& poly);
+
+    /**
+     * This function is the entry point to compute the coefficients of the spline
+     */
+    bool computeCoefficients();
+};
+
+QuinticSpline::QuinticSpline()
+{
+    m_pimpl = std::make_unique<Impl>();
+}
+
+QuinticSpline::~QuinticSpline() = default;
+
+bool QuinticSpline::setInitialConditions(Eigen::Ref<const Eigen::VectorXd> velocity,
+                                               Eigen::Ref<const Eigen::VectorXd> acceleration)
+{
+    if (velocity.size() != acceleration.size())
+    {
+        std::cerr << "[QuinticSpline::setInitialConditions] The size of the velocity should be "
+                     "equal to the one of the acceleration."
+                  << std::endl;
+        return false;
+    }
+
+    m_pimpl->initialCondition.velocity = velocity;
+    m_pimpl->initialCondition.acceleration = acceleration;
+
+    // The initial conditions changed. The coefficients are outdated.
+    m_pimpl->areCoefficientsComputed = false;
+
+    return true;
+}
+
+bool QuinticSpline::setFinalConditions(Eigen::Ref<const Eigen::VectorXd> velocity,
+                                       Eigen::Ref<const Eigen::VectorXd> acceleration)
+{
+    if (velocity.size() != acceleration.size())
+    {
+        std::cerr << "[QuinticSpline::setFinalConditions] The size of the velocity should be equal "
+                     "to the one of the acceleration."
+                  << std::endl;
+        return false;
+    }
+
+    m_pimpl->finalCondition.velocity = velocity;
+    m_pimpl->finalCondition.acceleration = acceleration;
+
+    // The final conditions changed. The coefficients are outdated.
+    m_pimpl->areCoefficientsComputed = false;
+
+    return true;
+}
+
+bool QuinticSpline::setKnots(const std::vector<Eigen::VectorXd>& position,
+                             const std::vector<double>& time)
+{
+    if (position.size() < 2)
+    {
+        std::cerr << "[QuinticSpline::setKnots] The number of knots has to be greater equal 2."
+                  << std::endl;
+        return false;
+    }
+
+    if (time.size() != position.size())
+    {
+        std::cerr << "[QuinticSpline::setKnots] The number of points has to be equal to the length "
+                     "of the time vector."
+                  << std::endl;
+        return false;
+    }
+
+    m_pimpl->knots.resize(time.size());
+
+    const std::size_t sizeOfVectors = position[0].size();
+
+    m_pimpl->knots[0].timeInstant = time[0];
+    m_pimpl->knots[0].position = position[0];
+    m_pimpl->knots[0].velocity.resize(sizeOfVectors);
+    m_pimpl->knots[0].acceleration.resize(sizeOfVectors);
+
+    for (std::size_t i = 1; i < m_pimpl->knots.size(); i++)
+    {
+        if (position[i].size() != sizeOfVectors)
+        {
+            std::cerr << "[QuinticSpline::setKnots] The size of the knot number " << i
+                      << " in different from the one expected. Expected: " << sizeOfVectors
+                      << " Retrieved: " << position[i].size() << "." << std::endl;
+            return false;
+        }
+
+        m_pimpl->knots[i].timeInstant = time[i];
+        m_pimpl->knots[i].position = position[i];
+        m_pimpl->knots[i].velocity.resize(sizeOfVectors);
+        m_pimpl->knots[i].acceleration.resize(sizeOfVectors);
+    }
+
+    // The knots changed. The coefficients are outdated.
+    m_pimpl->areCoefficientsComputed = false;
+
+    return true;
+}
+
+bool QuinticSpline::Impl::computePhasesDuration()
+{
+    for (std::size_t i = 0; i < knots.size() - 1; i++)
+    {
+        polynomials[i].duration = knots[i + 1].timeInstant - knots[i].timeInstant;
+
+        // This is required or stability purposes, the matrix below may not be invertible
+        if (polynomials[i].duration == 0)
+        {
+            std::cerr << "[QuinticSpline::Impl::computePhasesDuration] Two consecutive points have "
+                         "the same time coordinate."
+                      << std::endl;
+            return false;
+        }
+
+        if (polynomials[i].duration == 0)
+        {
+            std::cerr << "[QuinticSpline::Impl::computePhasesDuration] The input points are "
+                         "expected to be consecutive, strictly increasing in the time variable."
+                      << std::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+bool QuinticSpline::Impl::computeCoefficients()
+{
+    // check if the user already sets the knots
+    if (knots.empty())
+    {
+        std::cerr << "[QuinticSpline::Impl::computeCoefficients] Please set the knots before "
+                     "computing the coefficients."
+                  << std::endl;
+        return false;
+    }
+
+    // the number of polynomials is equal to the number of knots - -1
+    this->polynomials.resize(knots.size() - 1);
+
+    // set the velocity and acceleration boundary conditions
+    if(!this->setBoundaryVelocitiesAndAccelaration())
+    {
+        std::cerr << "[QuinticSpline::Impl::computeCoefficients] Unable to set the boundary "
+                     "conditions related to the velocity and acceleration."
+                  << std::endl;
+        return false;
+    }
+
+    // compute the duration of each phase (sub-trajectory)
+    if (!this->computePhasesDuration())
+    {
+        std::cerr << "[QuinticSpline::Impl::computeCoefficients] Unable to compute the phase "
+                     "duration."
+                  << std::endl;
+        return false;
+    }
+
+    // populate the polynomials vector with the knots
+    for(int i = 0; i < polynomials.size(); i++)
+    {
+        polynomials[i].initialPoint = &(knots[i]);
+        polynomials[i].finalPoint = &(knots[i + 1]);
+    }
+
+    // intermediate conditions have to be computed only if the knots are greater than equal 3
+    if (knots.size() > 2)
+    {
+        this->computeIntermediateVelocitiesAndAccelaration();
+    }
+
+    // populate the coefficients of each polynomial
+    for (auto& poly : polynomials)
+    {
+        this->setPolynomialCoefficients(poly);
+    }
+
+    // the coefficients have been computed
+    areCoefficientsComputed = true;
+
+    return true;
+}
+
+bool QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration()
+{
+    // this is an internal function and it is called only after setting the knots. However
+    // the following assert checks that the number of knots is at least 1
+    assert(!knots.empty());
+
+    const int knotSize = knots.front().position.size();
+
+    if (knotSize != initialCondition.velocity.size())
+    {
+        std::cerr << "[QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration] The size of the "
+                     "initial velocity is different from the expected one. Expected: "
+                  << knotSize << ", Retrieved: " << initialCondition.velocity.size() << "."
+                  << std::endl;
+        return false;
+    }
+
+    if (knotSize != initialCondition.acceleration.size())
+    {
+        std::cerr << "[QuinticSpline::Impl::setBoundaryVelocitiesAndAccelaration] The size of the "
+                     "initial acceleration is different from the expected one. Expected: "
+                  << knotSize << ", Retrieved: " << initialCondition.acceleration.size() << "."
+                  << std::endl;
+        return false;
+    }
+
+    if (knotSize != finalCondition.velocity.size())
+    {
+        std::cerr << "[QuinticSpline::setBoundaryVelocitiesAndAccelaration] The size of the "
+                     "final velocity is different from the expected one. Expected: "
+                  << knotSize << ", Retrieved: " << finalCondition.velocity.size() << "."
+                  << std::endl;
+        return false;
+    }
+
+    if (knotSize != finalCondition.acceleration.size())
+    {
+        std::cerr << "[QuinticSpline::setBoundaryVelocitiesAndAccelaration] The size of the "
+                     "final acceleration is different from the expected one. Expected: "
+                  << knotSize << ", Retrieved: " << finalCondition.acceleration.size() << "."
+                  << std::endl;
+        return false;
+    }
+
+    // store the boundary conditions
+    knots.front().velocity = initialCondition.velocity;
+    knots.front().acceleration = initialCondition.acceleration;
+
+    knots.back().velocity = finalCondition.velocity;
+    knots.back().acceleration = finalCondition.acceleration;
+
+    return true;
+}
+
+void QuinticSpline::Impl::addTripletCurrentKnot(const int& knotIndex,
+                                                const int& rowOffset,
+                                                const int& columnOffset,
+                                                std::vector<Eigen::Triplet<double>>& tripletList)
+{
+    const auto& poly = polynomials;
+
+    // The following triplets represent this matrix
+    // /    /   1      1\          /   1      1\ \
+    // | 12 |------ - --|      -3  |------ + --| |
+    // |    | 2        2|          |T        T | |
+    // |    |T        T |          \ i - 1    i/ |
+    // |    \ i - 1    i/                        |
+    // |                                         |
+    // |                                         |
+    // |    /   1      1\         / 1      1  \  |
+    // | 16 |------ + --|       3 |-- - ------|  |
+    // |    | 3        3|         | 2    2    |  |
+    // |    |T        T |         |T    T     |  |
+    // \    \ i - 1    i/         \ i    i - 1/  /
+
+    tripletList.push_back({rowOffset,
+                           columnOffset,
+                           12 * (1 / std::pow(poly[knotIndex - 1].duration, 2)
+                                 - 1 / std::pow(poly[knotIndex].duration, 2))});
+
+    tripletList.push_back({rowOffset,
+                           columnOffset + 1,
+                           -3 * (1 / poly[knotIndex - 1].duration + 1 / poly[knotIndex].duration)});
+
+    tripletList.push_back({rowOffset + 1,
+                           columnOffset,
+                           16 * (1 / std::pow(poly[knotIndex - 1].duration, 3)
+                                 + 1 / std::pow(poly[knotIndex].duration, 3))});
+
+    tripletList.push_back({rowOffset + 1,
+                           columnOffset + 1,
+                           3 * (-1 / std::pow(poly[knotIndex - 1].duration, 2)
+                                + 1 / std::pow(poly[knotIndex].duration, 2))});
+}
+
+void QuinticSpline::Impl::addTripletPreviousKnot(const int& knotIndex,
+                                                 const int& rowOffset,
+                                                 const int& columnOffset,
+                                                 std::vector<Eigen::Triplet<double>>& tripletList)
+{
+    const auto& poly = polynomials;
+
+    // The following triplets represent this matrix
+    // /    8          1    \
+    // | ------     ------  |
+    // |  2                 |
+    // | T           T      |
+    // |  i - 1       i - 1 |
+    // |                    |
+    // |                    |
+    // |   14          2    |
+    // | ------     ------  |
+    // |  3          2      |
+    // | T          T       |
+    // \  i - 1      i - 1  /
+
+    tripletList.push_back({rowOffset, columnOffset, 8 / std::pow(poly[knotIndex - 1].duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly[knotIndex - 1].duration});
+    tripletList.push_back(
+        {rowOffset + 1, columnOffset, 14 / std::pow(poly[knotIndex - 1].duration, 3)});
+    tripletList.push_back(
+        {rowOffset + 1, columnOffset + 1, 2 / std::pow(poly[knotIndex - 1].duration, 2)});
+}
+
+void QuinticSpline::Impl::addTripletNextKnot(const int& knotIndex,
+                                             const int& rowOffset,
+                                             const int& columnOffset,
+                                             std::vector<Eigen::Triplet<double>>& tripletList)
+{
+    const auto& poly = polynomials;
+
+    // The following triplets represent this matrix
+    // /    8          1    \
+    // | - ---        ---   |
+    // |    2               |
+    // |   T           T    |
+    // |    i           i   |
+    // |                    |
+    // |                    |
+    // |  14           2    |
+    // |  --         - ---  |
+    // |   3            2   |
+    // |  T            T    |
+    // \   i            i   /
+
+    tripletList.push_back({rowOffset, columnOffset, -8 / std::pow(poly[knotIndex].duration, 2)});
+    tripletList.push_back({rowOffset, columnOffset + 1, 1 / poly[knotIndex].duration});
+    tripletList.push_back(
+        {rowOffset + 1, columnOffset, 14 / std::pow(poly[knotIndex].duration, 3)});
+    tripletList.push_back(
+        {rowOffset + 1, columnOffset + 1, -2 / std::pow(poly[knotIndex].duration, 2)});
+}
+
+void QuinticSpline::Impl::addKnownTermKnotPosition(const std::size_t& knotIndex,
+                                             const std::size_t& coordinateIndex,
+                                             Eigen::Ref<Eigen::VectorXd> b)
+{
+    const auto& poly = polynomials;
+
+    const auto& i = knotIndex;
+    const auto& j = coordinateIndex;
+
+    b[0] += 20
+            * (1 / std::pow(poly[i - 1].duration, 3)
+                   * (knots[i].position[j] - knots[i - 1].position[j])
+               + 1 / std::pow(poly[i].duration, 3)
+                     * (knots[i].position[j] - knots[i + 1].position[j]));
+
+    b[1] += 30
+            * (1 / std::pow(poly[i - 1].duration, 4)
+                   * (knots[i].position[j] - knots[i - 1].position[j])
+               - 1 / std::pow(poly[i].duration, 4)
+                     * (knots[i].position[j] - knots[i + 1].position[j]));
+}
+
+void QuinticSpline::Impl::addKnownTermNextKnot(const std::size_t& knotIndex,
+                                               const std::size_t& coordinateIndex,
+                                               Eigen::Ref<Eigen::VectorXd> b)
+{
+    const auto& poly = polynomials;
+
+    const auto& i = knotIndex;
+    const auto& j = coordinateIndex;
+
+    Eigen::Matrix2d tempMatrix;
+    tempMatrix << -8 / std::pow(poly[i].duration, 2), 1 / poly[i].duration,
+                  14 / std::pow(poly[i].duration, 3), -2 / std::pow(poly[i].duration, 2);
+
+    Eigen::Vector2d tempVector;
+    tempVector << knots[i + 1].velocity[j], knots[i + 1].acceleration[j];
+    b -= tempMatrix * tempVector;
+}
+
+void QuinticSpline::Impl::addKnownTermPreviousKnot(const std::size_t& knotIndex,
+                                                   const std::size_t& coordinateIndex,
+                                                   Eigen::Ref<Eigen::VectorXd> b)
+{
+    const auto& poly = polynomials;
+
+    const auto& i = knotIndex;
+    const auto& j = coordinateIndex;
+
+    Eigen::Matrix2d tempMatrix;
+    tempMatrix << 8 / std::pow(poly[i - 1].duration, 2), 1 / poly[i - 1].duration,
+                 14 / std::pow(poly[i - 1].duration, 3), 2 / std::pow(poly[i - 1].duration, 2);
+
+    Eigen::Vector2d tempVector;
+    tempVector << knots[i - 1].velocity[j], knots[i - 1].acceleration[j];
+    b -= tempMatrix * tempVector;
+}
+
+void QuinticSpline::Impl::setPolynomialCoefficients(Polynomial& poly)
+{
+    const auto& T = poly.duration;
+
+    const auto& x0 = poly.initialPoint->position;
+    const auto& dx0 = poly.initialPoint->velocity;
+    const auto& ddx0 = poly.initialPoint->acceleration;
+
+    const auto& xT = poly.finalPoint->position;
+    const auto& dxT = poly.finalPoint->velocity;
+    const auto& ddxT = poly.finalPoint->acceleration;
+
+    poly.a0 = x0;
+    poly.a1 = dx0;
+    poly.a2 = ddx0 / 2.0;
+    poly.a3 = 1.0 / (T * T * T)
+              * (x0 * 2.0E+1 - xT * 2.0E+1 + T * dx0 * 1.2E+1 + T * dxT * 8.0 + (T * T) * ddx0 * 3.0
+                 - (T * T) * ddxT)
+              * (-1.0 / 2.0);
+    poly.a4 = (1.0 / (T * T * T * T)
+               * (x0 * 3.0E+1 - xT * 3.0E+1 + T * dx0 * 1.6E+1 + T * dxT * 1.4E+1
+                  + (T * T) * ddx0 * 3.0 - (T * T) * ddxT * 2.0))
+              / 2.0;
+    poly.a5 = 1.0 / (T * T * T * T * T)
+              * (x0 * 1.2E+1 - xT * 1.2E+1 + T * dx0 * 6.0 + T * dxT * 6.0 + (T * T) * ddx0
+                 - (T * T) * ddxT)
+              * (-1.0 / 2.0);
+}
+
+void QuinticSpline::Impl::computeIntermediateVelocitiesAndAccelaration()
+{
+    // here we assume that at least 3 points has been defined
+    const std::size_t numberOfInteriorKnots = knots.size() - 2;
+
+    Eigen::SparseMatrix<double> A(2 * numberOfInteriorKnots, 2 * numberOfInteriorKnots);
+    std::vector<Eigen::Triplet<double>> tripletsList;
+
+    std::size_t numberOfExpectedTriplets = 4;
+    if(numberOfInteriorKnots  > 1)
+    {
+        numberOfExpectedTriplets = 2 * (6 * (numberOfInteriorKnots - 2) + 2 * 4);
+    }
+    tripletsList.reserve(numberOfExpectedTriplets);
+
+    for (int i = 0; i < numberOfInteriorKnots; i++)
+    {
+        const int absoluteKnotIndex = i + 1;
+
+        // in this case there is only one interior knot A will be a 2
+        if (i == 0 && (i + 1) == numberOfInteriorKnots)
+        {
+            this->addTripletCurrentKnot(absoluteKnotIndex, 0, 0, tripletsList);
+        }
+        else if (i == 0)
+        {
+            this->addTripletCurrentKnot(absoluteKnotIndex, i * 2, 0, tripletsList);
+            this->addTripletNextKnot(absoluteKnotIndex, i * 2, 2, tripletsList);
+
+        }
+
+        else if (i + 1 == numberOfInteriorKnots)
+        {
+            this->addTripletPreviousKnot(absoluteKnotIndex, i * 2, 2 * (i - 1), tripletsList);
+            this->addTripletCurrentKnot(absoluteKnotIndex, i * 2, 2 * (i - 1) + 2, tripletsList);
+        } else
+        {
+            this->addTripletPreviousKnot(absoluteKnotIndex, i * 2, 2 * (i - 1), tripletsList);
+            this->addTripletCurrentKnot(absoluteKnotIndex, i * 2, 2 * (i - 1) + 2, tripletsList);
+            this->addTripletNextKnot(absoluteKnotIndex, i * 2, 2 * (i - 1) + 2 + 2, tripletsList);
+        }
+    }
+
+    A.setFromTriplets(tripletsList.begin(), tripletsList.end());
+
+    // compute first coordinate
+    Eigen::VectorXd b(A.rows());
+    for (size_t j = 0; j < knots.front().position.size(); j++)
+    {
+        b.setZero();
+        for (size_t i = 0; i < numberOfInteriorKnots; i++)
+        {
+            const int absoluteKnotIndex = i + 1;
+
+            if (i == 0 && (i + 1) == numberOfInteriorKnots)
+            {
+                this->addKnownTermKnotPosition(absoluteKnotIndex, j, b.head<2>());
+                this->addKnownTermNextKnot(absoluteKnotIndex, j, b.head<2>());
+                this->addKnownTermPreviousKnot(absoluteKnotIndex, j, b.head<2>());
+
+            } else if (i == 0)
+            {
+                this->addKnownTermKnotPosition(absoluteKnotIndex, j, b.head<2>());
+                this->addKnownTermPreviousKnot(absoluteKnotIndex, j, b.head<2>());
+
+            } else if (i + 1 == numberOfInteriorKnots)
+            {
+                this->addKnownTermNextKnot(absoluteKnotIndex, j, b.segment<2>(i * 2));
+                this->addKnownTermKnotPosition(absoluteKnotIndex, j, b.segment<2>(i * 2));
+            }
+
+            else
+            {
+                this->addKnownTermKnotPosition(absoluteKnotIndex, j, b.segment<2>(i * 2));
+            }
+        }
+
+        Eigen::SparseQR<Eigen::SparseMatrix<double>,
+                        Eigen::COLAMDOrdering<Eigen::SparseMatrix<double>::StorageIndex>>
+            qrDecomposition;
+        qrDecomposition.compute(A);
+        Eigen::VectorXd solution = qrDecomposition.solve(b);
+
+        for(size_t i = 0; i < numberOfInteriorKnots; i++)
+        {
+            const int absoluteKnotIndex = i + 1;
+
+            knots[absoluteKnotIndex].velocity[j] = solution[i * 2];
+            knots[absoluteKnotIndex].acceleration[j] = solution[i * 2 + 1];
+        }
+    }
+}
+
+void QuinticSpline::Impl::getPositionAtTime(const double& t,
+                                            const Polynomial& poly,
+                                            Eigen::Ref<Eigen::VectorXd> position)
+{
+    // improve the readability of the code
+    const auto& a0 = poly.a0;
+    const auto& a1 = poly.a1;
+    const auto& a2 = poly.a2;
+    const auto& a3 = poly.a3;
+    const auto& a4 = poly.a4;
+    const auto& a5 = poly.a5;
+
+    position = a0
+             + a1 * t
+             + a2 * std::pow(t, 2)
+             + a3 * std::pow(t, 3)
+             + a4 * std::pow(t, 4)
+             + a5 * std::pow(t, 5);
+}
+
+void QuinticSpline::Impl::getVelocityAtTime(const double& t,
+                                            const Polynomial& poly,
+                                            Eigen::Ref<Eigen::VectorXd> velocity)
+{
+    // improve the readability of the code
+    const auto& a0 = poly.a0;
+    const auto& a1 = poly.a1;
+    const auto& a2 = poly.a2;
+    const auto& a3 = poly.a3;
+    const auto& a4 = poly.a4;
+    const auto& a5 = poly.a5;
+
+    velocity = a1
+             + 2 * a2 * t
+             + 3 * a3 * std::pow(t, 2)
+             + 4 * a4 * std::pow(t, 3)
+             + 5 * a5 * std::pow(t, 4);
+}
+
+void QuinticSpline::Impl::getAccelerationAtTime(const double& t,
+                                                const Polynomial& poly,
+                                                Eigen::Ref<Eigen::VectorXd> acceleration)
+{
+    // improve the readability of the code
+    const auto& a0 = poly.a0;
+    const auto& a1 = poly.a1;
+    const auto& a2 = poly.a2;
+    const auto& a3 = poly.a3;
+    const auto& a4 = poly.a4;
+    const auto& a5 = poly.a5;
+
+    acceleration = 2 * a2
+                 + 2 * 3 * a3 * t
+                 + 3 * 4 * a4 * std::pow(t, 2)
+                 + 4 * 5 * a5 * std::pow(t, 3);
+}
+
+bool QuinticSpline::evaluatePoint(const double& t,
+                                  Eigen::Ref<Eigen::VectorXd> position,
+                                  Eigen::Ref<Eigen::VectorXd> velocity,
+                                  Eigen::Ref<Eigen::VectorXd> acceleration)
+{
+
+    if (!m_pimpl->areCoefficientsComputed)
+    {
+        if (!m_pimpl->computeCoefficients())
+        {
+            std::cerr << "[QuinticSpline::evaluatePoint] Unable to compute the coefficients of the "
+                         "spline."
+                      << std::endl;
+            return false;
+        }
+    }
+
+    if (t < m_pimpl->polynomials.front().initialPoint->timeInstant)
+    {
+        position = m_pimpl->knots.front().position;
+        velocity = m_pimpl->knots.front().velocity;
+        acceleration = m_pimpl->knots.front().acceleration;
+
+        return true;
+    }
+
+    if (t >= m_pimpl->polynomials.back().finalPoint->timeInstant)
+    {
+        position = m_pimpl->knots.back().position;
+        velocity = m_pimpl->knots.back().velocity;
+        acceleration = m_pimpl->knots.back().acceleration;
+
+        return true;
+    }
+
+    const auto poly = std::find_if(m_pimpl->polynomials.begin(),
+                                   m_pimpl->polynomials.end(),
+                                   [&t](const auto& p) {
+                                       return ((t >= p.initialPoint->timeInstant)
+                                               && (t < p.finalPoint->timeInstant));
+                                   });
+
+    if (poly == m_pimpl->polynomials.end())
+    {
+        std::cerr << "[QuinticSpline::evaluatePoint] Unable to find the sub-trajectory."
+                  << std::endl;
+        return false;
+    }
+
+    m_pimpl->getPositionAtTime(t - poly->initialPoint->timeInstant, *poly, position);
+    m_pimpl->getVelocityAtTime(t - poly->initialPoint->timeInstant, *poly, velocity);
+    m_pimpl->getAccelerationAtTime(t - poly->initialPoint->timeInstant, *poly, acceleration);
+
+    return true;
+}

--- a/src/Planners/tests/CMakeLists.txt
+++ b/src/Planners/tests/CMakeLists.txt
@@ -21,3 +21,8 @@ add_bipedal_test(
   NAME TimeVaryingDCMPlanner
   SOURCES TimeVaryingDCMPlannerTest.cpp
   LINKS BipedalLocomotion::Planners)
+
+add_bipedal_test(
+  NAME QuinticSpline
+  SOURCES QuinticSplineTest.cpp
+  LINKS BipedalLocomotion::Planners)

--- a/src/Planners/tests/QuinticSplineTest.cpp
+++ b/src/Planners/tests/QuinticSplineTest.cpp
@@ -96,4 +96,40 @@ TEST_CASE("Quintic spline")
                    + 5 * 4 * coefficients[5] * std::pow(t, 3);
         REQUIRE(expected.isApprox(acceleration,  1e-5));
     }
+
+    SECTION("Advance capabilities")
+    {
+        REQUIRE_FALSE(spline.isValid());
+        REQUIRE(spline.setAdvanceTimeStep(dTCheckPoints));
+
+        REQUIRE(spline.isValid());
+
+        for (std::size_t i = 0; i < pointsToCheckNumber; i++)
+        {
+            double t = dTCheckPoints * i + initTime;
+            const auto& traj = spline.get();
+
+            // check position
+            expected = coefficients[0] + coefficients[1] * t + coefficients[2] * std::pow(t, 2)
+                       + coefficients[3] * std::pow(t, 3) + coefficients[4] * std::pow(t, 4)
+                       + coefficients[5] * std::pow(t, 5);
+
+            REQUIRE(expected.isApprox(traj.position, 1e-5));
+
+            // check velocity
+            expected = coefficients[1] + 2 * coefficients[2] * t
+                       + 3 * coefficients[3] * std::pow(t, 2) + 4 * coefficients[4] * std::pow(t, 3)
+                       + 5 * coefficients[5] * std::pow(t, 4);
+            REQUIRE(expected.isApprox(traj.velocity, 1e-5));
+
+            // check acceleration
+            expected = 2 * coefficients[2] + 3 * 2 * coefficients[3] * t
+                       + 4 * 3 * coefficients[4] * std::pow(t, 2)
+                       + 5 * 4 * coefficients[5] * std::pow(t, 3);
+            REQUIRE(expected.isApprox(traj.acceleration, 1e-5));
+
+            // advance the spline
+            REQUIRE(spline.advance());
+        }
+    }
 }

--- a/src/Planners/tests/QuinticSplineTest.cpp
+++ b/src/Planners/tests/QuinticSplineTest.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file QuinticSplineTest.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <array>
+#include <vector>
+
+// Catch2
+#include <catch2/catch.hpp>
+
+#include <BipedalLocomotion/Planners/QuinticSpline.h>
+
+using namespace BipedalLocomotion::Planners;
+
+
+TEST_CASE("Quintic spline")
+{
+    const std::size_t numberOfPoints = 100;
+    constexpr double initTime = 0.32;
+    constexpr double finalTime = 2.64;
+
+    constexpr double dT = (finalTime - initTime) / (static_cast<double>(numberOfPoints - 1));
+    std::array<Eigen::Vector4d, 6> coefficients;
+    for(auto& coeff: coefficients)
+    {
+        coeff.setRandom();
+    }
+
+    std::vector<Eigen::VectorXd> knots;
+    std::vector<double> time;
+    for (std::size_t i = 0; i < numberOfPoints; i++)
+    {
+        time.push_back(dT * i + initTime);
+        knots.push_back(coefficients[0] + coefficients[1] * time.back()
+                        + coefficients[2] * std::pow(time.back(), 2)
+                        + coefficients[3] * std::pow(time.back(), 3)
+                        + coefficients[4] * std::pow(time.back(), 4)
+                        + coefficients[5] * std::pow(time.back(), 5));
+    }
+
+    Eigen::Vector4d initVelocity = coefficients[1] + 2 * coefficients[2] * initTime
+                                   + 3 * coefficients[3] * std::pow(initTime, 2)
+                                   + 4 * coefficients[4] * std::pow(initTime, 3)
+                                   + 5 * coefficients[5] * std::pow(initTime, 4);
+
+    Eigen::Vector4d initAcceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * initTime
+                                       + 4 * 3 * coefficients[4] * std::pow(initTime, 2)
+                                       + 5 * 4 * coefficients[5] * std::pow(initTime, 3);
+
+    Eigen::Vector4d finalVelocity = coefficients[1] + 2 * coefficients[2] * finalTime
+                                    + 3 * coefficients[3] * std::pow(finalTime, 2)
+                                    + 4 * coefficients[4] * std::pow(finalTime, 3)
+                                    + 5 * coefficients[5] * std::pow(finalTime, 4);
+
+    Eigen::Vector4d finalAcceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * finalTime
+                                        + 4 * 3 * coefficients[4] * std::pow(finalTime, 2)
+                                        + 5 * 4 * coefficients[5] * std::pow(finalTime, 3);
+
+    QuinticSpline spline;
+    REQUIRE(spline.setKnots(knots, time));
+
+    REQUIRE(spline.setInitialConditions(initVelocity, initAcceleration));
+    REQUIRE(spline.setFinalConditions(finalVelocity, finalAcceleration));
+
+    constexpr std::size_t pointsToCheckNumber = 1e4;
+
+    constexpr double dTCheckPoints
+        = (finalTime - initTime) / (static_cast<double>(pointsToCheckNumber));
+
+    Eigen::Vector4d expected, position, velocity, acceleration;
+
+    for (std::size_t i = 0; i < pointsToCheckNumber; i++)
+    {
+        double t = dTCheckPoints * i + initTime;
+
+        REQUIRE(spline.evaluatePoint(t, position, velocity, acceleration));
+
+        // check position
+        expected = coefficients[0] + coefficients[1] * t + coefficients[2] * std::pow(t, 2)
+                   + coefficients[3] * std::pow(t, 3) + coefficients[4] * std::pow(t, 4)
+                   + coefficients[5] * std::pow(t, 5);
+
+        REQUIRE(expected.isApprox(position, 1e-5));
+
+        // check velocity
+        expected = coefficients[1] + 2 * coefficients[2] * t + 3 * coefficients[3] * std::pow(t, 2)
+                   + 4 * coefficients[4] * std::pow(t, 3) + 5 * coefficients[5] * std::pow(t, 4);
+        REQUIRE(expected.isApprox(velocity,  1e-5));
+
+        // check acceleration
+        expected = 2 * coefficients[2] + 3 * 2 * coefficients[3] * t
+                   + 4 * 3 * coefficients[4] * std::pow(t, 2)
+                   + 5 * 4 * coefficients[5] * std::pow(t, 3);
+        REQUIRE(expected.isApprox(acceleration,  1e-5));
+    }
+}


### PR DESCRIPTION
This PR introduces the `QuinticSpline` class. This class can be seen as an extension of the `iDynTree::CubicSpline` class. The main difference between this class and the `iDynTree` one is the order of the polynomials used in the spline. Using a 5th order spline guarantees to generate a trajectory that minimizes the jerk. (I will add further details for the latest statement later)

