### PR TITLE
Implement a 2-point minimum jerk trajectory generator in SO(3)

### DIFF
--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -16,7 +16,7 @@ if (FRAMEWORK_COMPILE_Planners)
 
   add_bipedal_locomotion_library(
     NAME                   Planners
-    PUBLIC_HEADERS         ${H_PREFIX}/ConvexHullHelper.h ${H_PREFIX}/DCMPlanner.h ${H_PREFIX}/TimeVaryingDCMPlanner.h ${H_PREFIX}/QuinticSpline.h
+    PUBLIC_HEADERS         ${H_PREFIX}/ConvexHullHelper.h ${H_PREFIX}/DCMPlanner.h ${H_PREFIX}/TimeVaryingDCMPlanner.h ${H_PREFIX}/QuinticSpline.h ${H_PREFIX}/SO3Planner.h ${H_PREFIX}/SO3Planner.tpp
     SOURCES                src/ConvexHullHelper.cpp  src/DCMPlanner.cpp src/TimeVaryingDCMPlanner.cpp src/QuinticSpline.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::System BipedalLocomotion::Contact
     PRIVATE_LINK_LIBRARIES Qhull::qhullcpp Qhull::qhullstatic_r casadi

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
@@ -52,12 +52,12 @@ public:
      * Set the rotation
      * @param initialRotation initial rotation $\f{}^{\mathcal{I}}R_{\mathcal{B}_0}$\f.
      * @param finalRotation final rotation $\f{}^{\mathcal{I}}R_{\mathcal{B}_T}$\f.
-     * @param T Trajectory duration in seconds.
+     * @param duration Trajectory duration in seconds.
      * @return True in case of success/false otherwise.
      */
     bool setRotations(const manif::SO3d& initialRotation,
                       const manif::SO3d& finalRotation,
-                      const double& T);
+                      const double& duration);
 
     /**
      * Get the trajectory at a given time

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
@@ -69,10 +69,11 @@ public:
      * (accordingly to the trivialization used).
      * @return True in case of success/false otherwise.
      */
+    template<class Derived>
     bool evaluatePoint(const double& time,
                        manif::SO3d& rotation,
-                       manif::SO3d::Tangent& velocity,
-                       manif::SO3d::Tangent& acceleraton) const;
+                       manif::SO3TangentBase<Derived>& velocity,
+                       manif::SO3TangentBase<Derived>& acceleration) const;
 };
 
 /**

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
@@ -1,0 +1,95 @@
+/**
+ * @file SO3Planner.h
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_H
+#define BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_H
+
+#include <manif/SO3.h>
+
+namespace BipedalLocomotion
+{
+namespace Planners
+{
+
+/**
+ * Representation used in the SO3Planner
+ */
+enum class Representation
+{
+    LeftTrivialized,
+    RightTrivialized
+};
+
+/**
+ * SO3Planner implements a minimum jerk trajectory planner for object belonging to SO(3). The
+ * planner assumes initial and final angular acceleration and velocity of the object equal to zero.
+ * The generated velocity and acceleration are written in the inertial or in body-fixed frame
+ * accordingly to the chosen representation.
+ * @tparam chosen representation:
+ * - The right trivialization planner generates a velocity and an acceleration expressed in the
+ * inertial frame.
+ * - The left trivialization planner generates a velocity and an acceleration expressed in the
+ * body-fixed frame.
+ */
+template <Representation representation> class SO3Planner
+{
+    /** Initial rotation from the inertial frame to the body frame. Namely
+     * $\f{}^{\mathcal{I}}R_{\mathcal{B}}$\f */
+    manif::SO3d m_initialRotation{manif::SO3d::Identity()};
+
+    /** Distance bewteen the initial rotation and the final one. The definition of the distance
+     * depends on the chosen Representation */
+    manif::SO3d::Tangent m_distance{manif::SO3d::Tangent::Zero()};
+
+    double m_T{1}; /**< Trajectory duration in seconds */
+
+public:
+    /**
+     * Set the rotation
+     * @param initialRotation initial rotation $\f{}^{\mathcal{I}}R_{\mathcal{B}_0}$\f.
+     * @param finalRotation final rotation $\f{}^{\mathcal{I}}R_{\mathcal{B}_T}$\f.
+     * @param T Trajectory duration in seconds.
+     * @return True in case of success/false otherwise.
+     */
+    bool setRotations(const manif::SO3d& initialRotation,
+                      const manif::SO3d& finalRotation,
+                      const double& T);
+
+    /**
+     * Get the trajectory at a given time
+     * @param time time, in seconds, at which the trajectory should be computed.
+     * @param rotation $\f{}^{\mathcal{I}}R_{\mathcal{B}}$\f.
+     * @param velocity angular velocity expressed in inertial or body fixed frame (accordingly to
+     * the trivialization used).
+     * @param acceleration angular acceleration expressed in inertial or body fixed frame
+     * (accordingly to the trivialization used).
+     * @return True in case of success/false otherwise.
+     */
+    bool evaluatePoint(const double& time,
+                       manif::SO3d& rotation,
+                       manif::SO3d::Tangent& velocity,
+                       manif::SO3d::Tangent& acceleraton) const;
+};
+
+/**
+ * The right trivialization planner generates a velocity and an acceleration expressed in the
+ * inertial frame.
+ */
+using SO3PlannerInertial = SO3Planner<Representation::RightTrivialized>;
+
+/**
+ * The left trivialization planner generates a velocity and an acceleration expressed in the
+ * body-fixed frame.
+ */
+using SO3PlannerBody = SO3Planner<Representation::LeftTrivialized>;
+
+} // namespace Planners
+} // namespace BipedalLocomotion
+
+#include <BipedalLocomotion/Planners/SO3Planner.tpp>
+
+#endif // BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_H

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
@@ -45,7 +45,7 @@ template <Representation representation> class SO3Planner
      * depends on the chosen Representation */
     manif::SO3d::Tangent m_distance{manif::SO3d::Tangent::Zero()};
 
-    double m_T{1}; /**< Trajectory duration in seconds */
+    double m_T{1.0}; /**< Trajectory duration in seconds */
 
 public:
     /**

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.h
@@ -18,17 +18,17 @@ namespace Planners
 {
 
 /**
- * Representation used in the SO3Planner
+ * Trivialization used in the SO3Planner
  */
-enum class Representation
+enum class LieGroupTrivialization
 {
-    LeftTrivialized,
-    RightTrivialized
+    Left,
+    Right
 };
 
 /**
  * SO3PlannerState contains the state of the planner. The velocity and the acceleration are
- * expressed in inertial/body frame depending on the Representation used by the planner.
+ * expressed in inertial/body frame depending on the Trivialization used by the planner.
  */
 struct SO3PlannerState
 {
@@ -43,14 +43,14 @@ struct SO3PlannerState
  * SO3Planner implements a minimum jerk trajectory planner for object belonging to SO(3). The
  * planner assumes initial and final angular acceleration and velocity of the object equal to zero.
  * The generated velocity and acceleration are written in the inertial or in body-fixed frame
- * accordingly to the chosen representation.
- * @tparam chosen representation:
+ * accordingly to the chosen trivialization.
+ * @tparam chosen trivialization:
  * - The right trivialization planner generates a velocity and an acceleration expressed in the
  * inertial frame.
  * - The left trivialization planner generates a velocity and an acceleration expressed in the
  * body-fixed frame.
  */
-template <Representation representation>
+template <LieGroupTrivialization trivialization>
 class SO3Planner : public System::Advanceable<SO3PlannerState>
 {
     /** Initial rotation from the inertial frame to the body frame. Namely
@@ -58,7 +58,7 @@ class SO3Planner : public System::Advanceable<SO3PlannerState>
     manif::SO3d m_initialRotation{manif::SO3d::Identity()};
 
     /** Distance bewteen the initial rotation and the final one. The definition of the distance
-     * depends on the chosen Representation */
+     * depends on the chosen Trivialization */
     manif::SO3d::Tangent m_distance{manif::SO3d::Tangent::Zero()};
 
     double m_T{1.0}; /**< Trajectory duration in seconds */
@@ -143,13 +143,13 @@ public:
  * The right trivialization planner generates a velocity and an acceleration expressed in the
  * inertial frame.
  */
-using SO3PlannerInertial = SO3Planner<Representation::RightTrivialized>;
+using SO3PlannerInertial = SO3Planner<LieGroupTrivialization::Right>;
 
 /**
  * The left trivialization planner generates a velocity and an acceleration expressed in the
  * body-fixed frame.
  */
-using SO3PlannerBody = SO3Planner<Representation::LeftTrivialized>;
+using SO3PlannerBody = SO3Planner<LieGroupTrivialization::Left>;
 
 } // namespace Planners
 } // namespace BipedalLocomotion

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
@@ -78,12 +78,12 @@ bool SO3Planner<representation>::evaluatePoint(const double& time,
     if constexpr (representation == Representation::RightTrivialized)
     {
         // please read this as R(t) = exp(displacementTangent) * initialRotation
-        rotation = displacementTangent + m_initialRotation;
+        rotation = displacementTangent.exp() * m_initialRotation;
     } else
     // Please read it as representation == Representation::LeftTrivialized
     {
         // please read this as R(t) = initialRotation * exp(displacementTangent)
-        rotation = m_initialRotation + displacementTangent;
+        rotation = m_initialRotation * displacementTangent.exp();
     }
 
     // compute velocity (it is expressed in body / inertial frame accordingly to the chosen representation)

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
@@ -48,10 +48,11 @@ bool SO3Planner<representation>::setRotations(const manif::SO3d& initialRotation
 }
 
 template <Representation representation>
+template <class Derived>
 bool SO3Planner<representation>::evaluatePoint(const double& time,
                                                manif::SO3d& rotation,
-                                               manif::SO3d::Tangent& velocity,
-                                               manif::SO3d::Tangent& acceleration) const
+                                               manif::SO3TangentBase<Derived>& velocity,
+                                               manif::SO3TangentBase<Derived>& acceleration) const
 {
     if (time < 0 || time > m_T)
     {

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
@@ -1,0 +1,95 @@
+/**
+ * @file SO3Planner.tpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_TPP
+#define BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_TPP
+
+#include <iostream>
+
+#include <manif/SO3.h>
+
+#include <BipedalLocomotion/Planners/SO3Planner.h>
+
+namespace BipedalLocomotion
+{
+namespace Planners
+{
+
+template <Representation representation>
+bool SO3Planner<representation>::setRotations(const manif::SO3d& initialRotation,
+                                              const manif::SO3d& finalRotation,
+                                              const double& T)
+{
+    if (T <= 0)
+    {
+        std::cerr << "[SO3Planner::setRotation] The trajectory duration must be a strictly "
+                     "positive number."
+                  << std::endl;
+        return false;
+    }
+
+    m_initialRotation = initialRotation;
+    m_T = T;
+
+    if constexpr (representation == Representation::RightTrivialized)
+    {
+        m_distance = (finalRotation * initialRotation.inverse()).log();
+    } else
+    // Please read it as representation == Representation::LeftTrivialized
+    {
+        m_distance = (initialRotation.inverse() * finalRotation).log();
+    }
+
+    return true;
+}
+
+template <Representation representation>
+bool SO3Planner<representation>::evaluatePoint(const double& time,
+                                               manif::SO3d& rotation,
+                                               manif::SO3d::Tangent& velocity,
+                                               manif::SO3d::Tangent& acceleration) const
+{
+    if (time < 0 || time > m_T)
+    {
+        std ::cerr << "[SO3Planner::evaluatePoint] The time has to be a real positive number "
+                      "between 0 and "
+                   << m_T << "." << std::endl;
+        return false;
+    }
+
+    const double& t = time;
+    const auto infinitesimalRotation = m_distance * (10 * std::pow(t / m_T, 3)
+                                                     - 15 * std::pow(t / m_T, 4)
+                                                     + 6 * std::pow(t / m_T, 5));
+
+    if constexpr (representation == Representation::RightTrivialized)
+    {
+        rotation = infinitesimalRotation + m_initialRotation;
+    } else
+    // Please read it as representation == Representation::LeftTrivialized
+    {
+        rotation = m_initialRotation + infinitesimalRotation;
+    }
+
+    velocity = m_distance
+        * (10 * 3 * std::pow(t, 2) / std::pow(m_T, 3)
+           - 15 * 4 * std::pow(t, 3) / std::pow(m_T, 4)
+           + 6 * 5 * std::pow(t, 4) / std::pow(m_T, 5));
+
+    acceleration
+        = m_distance
+          * (10 * 3 * 2 * t / std::pow(m_T, 3)
+             - 15 * 4 * 3 * std::pow(t, 2) / std::pow(m_T, 4)
+             + 6 * 5 * 4 * std::pow(t, 3) / std::pow(m_T, 5));
+
+    return true;
+}
+
+} // namespace Planners
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_PLANNERS_SO3_PLANNER_TPP

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
@@ -22,9 +22,9 @@ namespace Planners
 template <Representation representation>
 bool SO3Planner<representation>::setRotations(const manif::SO3d& initialRotation,
                                               const manif::SO3d& finalRotation,
-                                              const double& T)
+                                              const double& duration)
 {
-    if (T <= 0)
+    if (duration <= 0)
     {
         std::cerr << "[SO3Planner::setRotation] The trajectory duration must be a strictly "
                      "positive number."
@@ -33,7 +33,7 @@ bool SO3Planner<representation>::setRotations(const manif::SO3d& initialRotation
     }
 
     m_initialRotation = initialRotation;
-    m_T = T;
+    m_T = duration;
 
     if constexpr (representation == Representation::RightTrivialized)
     {

--- a/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
+++ b/src/Planners/include/BipedalLocomotion/Planners/SO3Planner.tpp
@@ -70,6 +70,8 @@ bool SO3Planner<representation>::evaluatePoint(const double& time,
     // - displacement_tangent = log(initialRotation.inverse() * finalRotation) * s(t) (in case of
     //                                                                                 Left
     //                                                                                 Trivialization)
+    // You can find the computation of s in "Modern Robotics: Mechanics, Planning, and Control"
+    // (Chapter 9.2)
     const double s = 10 * std::pow(t / m_T, 3)
                      - 15 * std::pow(t / m_T, 4)
                      + 6 * std::pow(t / m_T, 5);
@@ -86,13 +88,19 @@ bool SO3Planner<representation>::evaluatePoint(const double& time,
         rotation = m_initialRotation * displacementTangent.exp();
     }
 
-    // compute velocity (it is expressed in body / inertial frame accordingly to the chosen representation)
+    // compute velocity (it is expressed in body / inertial frame accordingly to the chosen
+    // representation)
+    // You can find the computation of sDot in "Modern Robotics: Mechanics, Planning, and Control"
+    // (Chapter 9.2)
     const double sDot = 10 * 3 * std::pow(t, 2) / std::pow(m_T, 3)
                         - 15 * 4 * std::pow(t, 3) / std::pow(m_T, 4)
                         + 6 * 5 * std::pow(t, 4) / std::pow(m_T, 5);
     velocity = m_distance * sDot;
 
-    // compute velocity (it is expressed in body / inertial frame accordingly to the chosen representation)
+    // compute acceleration (it is expressed in body / inertial frame accordingly to the chosen
+    // representation)
+    // You can find the computation of sDdot in "Modern Robotics: Mechanics,
+    // Planning, and Control" (Chapter 9.2)
     const double sDdot = 10 * 3 * 2 * t / std::pow(m_T, 3)
                          - 15 * 4 * 3 * std::pow(t, 2) / std::pow(m_T, 4)
                          + 6 * 5 * 4 * std::pow(t, 3) / std::pow(m_T, 5);

--- a/src/Planners/tests/CMakeLists.txt
+++ b/src/Planners/tests/CMakeLists.txt
@@ -26,3 +26,8 @@ add_bipedal_test(
   NAME QuinticSpline
   SOURCES QuinticSplineTest.cpp
   LINKS BipedalLocomotion::Planners)
+
+add_bipedal_test(
+  NAME SO3Planner
+  SOURCES SO3PlannerTest.cpp
+  LINKS BipedalLocomotion::Planners)

--- a/src/Planners/tests/SO3PlannerTest.cpp
+++ b/src/Planners/tests/SO3PlannerTest.cpp
@@ -5,6 +5,8 @@
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
 
+#include <Eigen/Geometry> // Required because of https://github.com/artivis/manif/issues/162
+
 // Catch2
 #include <catch2/catch.hpp>
 

--- a/src/Planners/tests/SO3PlannerTest.cpp
+++ b/src/Planners/tests/SO3PlannerTest.cpp
@@ -1,0 +1,95 @@
+/**
+ * @file SO3PlannerTest.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+// Catch2
+#include <catch2/catch.hpp>
+
+#include <BipedalLocomotion/Planners/SO3Planner.h>
+
+#include <manif/SO3.h>
+
+using namespace BipedalLocomotion::Planners;
+
+TEST_CASE("SO3 planner")
+{
+    manif::SO3d initialTranform = manif::SO3d::Random();
+    manif::SO3d finalTranform = manif::SO3d::Random();
+
+    constexpr double T = 1;
+    constexpr double dT = 1e-5;
+    constexpr std::size_t samples = T / dT;
+
+    constexpr double tolerance = 1e-4;
+
+    SECTION("Left - Trivialized [Body]")
+    {
+        SO3PlannerBody planner;
+        REQUIRE(planner.setRotations(initialTranform, finalTranform, T));
+
+        manif::SO3d rotation, predictedRotation;
+        manif::SO3d::Tangent velocity, predictedVelocity;
+        manif::SO3d::Tangent acceleration;
+        REQUIRE(planner.evaluatePoint(0, rotation, velocity, acceleration));
+        predictedRotation = rotation;
+        predictedVelocity = velocity;
+
+        REQUIRE(rotation.isApprox(initialTranform, tolerance));
+        REQUIRE(velocity.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+        REQUIRE(acceleration.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+
+        for (std::size_t i = 1; i < samples; i++)
+        {
+            // propagate the system
+            predictedRotation = rotation + (velocity * dT);
+            predictedVelocity = velocity + (acceleration * dT);
+
+            planner.evaluatePoint(i * dT, rotation, velocity, acceleration);
+
+            REQUIRE(predictedRotation.isApprox(rotation, tolerance));
+            REQUIRE(predictedVelocity.isApprox(velocity, tolerance));
+        }
+
+        planner.evaluatePoint(T, rotation, velocity, acceleration);
+        REQUIRE(rotation.isApprox(finalTranform, tolerance));
+        REQUIRE(velocity.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+        REQUIRE(acceleration.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+    }
+
+    SECTION("Right - Trivialized [Inertial]")
+    {
+        SO3PlannerInertial planner;
+        REQUIRE(planner.setRotations(initialTranform, finalTranform, T));
+
+        manif::SO3d rotation, predictedRotation;
+        manif::SO3d::Tangent velocity, predictedVelocity;
+        manif::SO3d::Tangent acceleration;
+        REQUIRE(planner.evaluatePoint(0, rotation, velocity, acceleration));
+        predictedRotation = rotation;
+        predictedVelocity = velocity;
+
+        REQUIRE(rotation.isApprox(initialTranform, tolerance));
+        REQUIRE(velocity.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+        REQUIRE(acceleration.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+
+        for (std::size_t i = 1; i < samples; i++)
+        {
+            // propagate the system
+            predictedRotation = (velocity * dT) + rotation;
+            predictedVelocity = velocity + (acceleration * dT);
+
+            planner.evaluatePoint(i * dT, rotation, velocity, acceleration);
+
+            REQUIRE(predictedRotation.isApprox(rotation, tolerance));
+            REQUIRE(predictedVelocity.isApprox(velocity, tolerance));
+        }
+
+        planner.evaluatePoint(T, rotation, velocity, acceleration);
+        REQUIRE(rotation.isApprox(finalTranform, tolerance));
+        REQUIRE(velocity.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+        REQUIRE(acceleration.isApprox(manif::SO3d::Tangent::Zero(), tolerance));
+    }
+}


### PR DESCRIPTION
~~**Disclaimer: this PR includes also the modification implemented in #82. This main introduction of this PR is:  https://github.com/dic-iit/bipedal-locomotion-framework/commit/9c3c9a0ad4e602381fdcfa588d4220fa9fb8fb5d https://github.com/dic-iit/bipedal-locomotion-framework/commit/9271e4354c571eb319464b394f87e5aba4980d41 https://github.com/dic-iit/bipedal-locomotion-framework/commit/dae089d5b2060eaab13cb56e7844dd179de8014a**~~

The PR implements a  2-point minimum jerk trajectory planner for SO(3) elements. The Planner extended the theory explained in [**Modern Robotics: Mechanics, Planning, and Control (Chapter 9.2)**](http://hades.mech.northwestern.edu/index.php/Modern_Robotics), and it introduces the possibility to generate the velocity/acceleration expressed not only in body frame but also in the inertial frame (i.e. left and right trivialization).


cc @xenvre 