### PR TITLE
Add RobotInterface library and a SensorBridge interface class

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ The **BipedalLocomotionFramework** project is a _suite_ of libraries for achievi
 - [**BipedalLocomotion::ParametersHandler**](./src/ParametersHandler): Library for
   retrieving parameters from configuration files and not only
 - [**BipedalLocomotion::Estimators**](./src/Estimators): Library containing observers
-- [**BipedalLocomotion::FloatingBaseEstimators**](./src/Estimators): Library containing floating base estimators 
+- [**BipedalLocomotion::FloatingBaseEstimators**](./src/Estimators): Library containing floating base estimators
 - [**BipedalLocomotion::Planner**](./src/Planner): Library containing planner useful for locomotion
+- [**BipedalLocomotion::RobotInterface**](./src/RobotInterface): Library containing generic interface classes to adapt to various IO data formats
 
 
 # :page_facing_up: Dependencies
@@ -54,6 +55,12 @@ file. Please note that the indicated version is the the minimum required version
     - For using it:
       - [`iDynTree`](https://github.com/robotology/idyntree) (version 0.11.105)
       - [`Qhull`](https://github.com/qhull/qhull) (version 8.0.0)
+    - For testing:
+      - [`Catch2`](https://github.com/catchorg/Catch2)
+
+- `RobotInterface` requires:
+    - For using it:
+      - [`ParametersHandler`](./src/ParametersHandler)
     - For testing:
       - [`Catch2`](https://github.com/catchorg/Catch2)
 

--- a/cmake/BipedalLocomotionFrameworkFindDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkFindDependencies.cmake
@@ -174,3 +174,8 @@ framework_dependent_option(FRAMEWORK_COMPILE_System
 framework_dependent_option(FRAMEWORK_COMPILE_AutoDiffCppAD
   "Compile CppAD-Eigen wrapper?" ON
   "FRAMEWORK_USE_cppad" OFF)
+
+  framework_dependent_option(FRAMEWORK_COMPILE_RobotInterface
+  "Compile RobotInterface libraries?" ON
+  "" OFF)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,3 +10,5 @@ add_subdirectory(System)
 add_subdirectory(Planners)
 add_subdirectory(ContactModels)
 add_subdirectory(AutoDiff)
+add_subdirectory(RobotInterface)
+

--- a/src/RobotInterface/CMakeLists.txt
+++ b/src/RobotInterface/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+if (FRAMEWORK_COMPILE_RobotInterface)
+
+set(H_PREFIX include/BipedalLocomotion/RobotInterface)
+
+add_bipedal_locomotion_library(
+    NAME                   RobotInterface
+    PUBLIC_HEADERS         ${H_PREFIX}/ISensorBridge.h
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler Eigen3::Eigen
+    SUBDIRECTORIES    tests
+    IS_INTERFACE)
+endif()

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -1,0 +1,372 @@
+/**
+ * @file ISensorBridge.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_ISENSOR_BRIDGE_H
+#define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_ISENSOR_BRIDGE_H
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+
+using namespace BipedalLocomotion::ParametersHandler;
+using Vector12d = Eigen::Matrix<double, 12, 1>;
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+
+namespace BipedalLocomotion
+{
+namespace RobotInterface
+{
+
+/**
+ * Sensor bridge options
+ */
+struct SensorBridgeOptions
+{
+    bool isKinematicsEnabled{false}; /**< flag to connect kinematics measurement sources */
+    bool isIMUEnabled{false}; /**< flag to connect IMU measurement sources */
+    bool isLinearAccelerometerEnabled{false}; /**< flag to connect linear accelerometer measurement sources */
+    bool isGyroscopeEnabled{false}; /**< flag to connect gyroscope measurement sources */
+    bool isMagnetometerEnabled{false}; /**< flag to connect magnetometer measurement sources */
+    bool isSixAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
+    bool isThreeAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
+    bool isCartesianWrenchEnabled{false}; /**< flag to connect cartesian wrench measurement sources */
+    bool isCameraEnabled{false}; /**< flag to connect camera sources */
+
+    size_t nrJoints{0}; /**< number of joints available through Kinematics stream, to be configured at initialization */
+    std::unordered_map<std::string, std::pair<int, int> > imgDimensions; /**< dimensions of the camera images available through camera streams, to be configured at initialization */
+};
+
+/**
+ *  Sensor lists
+ */
+struct SensorLists
+{
+    std::vector<std::string> jointsList; /**< list of joints attached to the bridge */
+    std::vector<std::string> IMUsList;   /**< list of IMUs attached to the bridge */
+    std::vector<std::string> linearAccelerometersList; /**< list of linear accelerometers attached to the bridge */
+    std::vector<std::string> gyroscopesList; /**< list of gyroscopes attached to the bridge */
+    std::vector<std::string> orientationSensorsList; /**< list of orientation sensors attached to the bridge */
+    std::vector<std::string> magnetometersList; /**< list of magnetometers attached to the bridge */
+    std::vector<std::string> sixAxisForceTorqueSensorsList; /**< list of six axis force torque sensors attached to the bridge */
+    std::vector<std::string> threeAxisForceTorqueSensorsList; /**< list of three axis force torque sensors attached to the bridge */
+    std::vector<std::string> cartesianWrenchesList; /**< list of cartesian wrench streams attached to the bridge */
+    std::vector<std::string> rgbCamerasList; /**< list of rgb cameras attached to the bridge */
+    std::vector<std::string> depthCamerasList; /**< list of depth cameras attached to the bridge */
+};
+
+/**
+ * Sensor bridge interface.
+ */
+class ISensorBridge
+{
+public:
+    using unique_ptr = std::unique_ptr<ISensorBridge>;
+
+    using shared_ptr = std::shared_ptr<ISensorBridge>;
+
+    using weak_ptr = std::weak_ptr<ISensorBridge>;
+
+    /**
+     * Initialize estimator
+     * @param[in] handler Parameters handler
+     */
+    virtual bool initialize(std::weak_ptr<IParametersHandler> handler) = 0;
+
+    /**
+     * Get joints list
+     * @param[out] jointsList list of joints attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getJointsList(std::vector<std::string>& jointsList) = 0;
+
+    /**
+     * Get imu sensors
+     * @param[out] IMUsList list of IMUs attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getIMUsList(std::vector<std::string>& IMUsList) = 0;
+
+    /**
+     * Get linear accelerometers
+     * @param[out] linearAccelerometersList list of linear accelerometers attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList) = 0;
+
+    /**
+     * Get gyroscopes
+     * @param[out] gyroscopesList list of gyroscopes attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getGyroscopesList(std::vector<std::string>& gyroscopesList) = 0;
+
+    /**
+     * Get orientation sensors
+     * @param[out] orientationSensorsList list of orientation sensors attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getOrientationSensorsList(std::vector<std::string>& orientationSensorsList) = 0;
+
+    /**
+     * Get magnetometers sensors
+     * @param[out] magnetometersList list of magnetometers attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getMagnetometersList(std::vector<std::string>& magnetometersList) = 0;
+
+    /**
+     * Get 6 axis FT sensors
+     * @param[out] sixAxisForceTorqueSensorsList list of 6 axis force torque sensors attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList) = 0;
+
+    /**
+     * Get 6 axis FT sensors
+     * @param[out] threeAxisForceTorqueSensorsList list of 3 axis force torque sensors attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList) = 0;
+
+   /**
+     * Get cartesian wrenches
+     * @param[out] cartesianWrenchesList list of cartesian wrenches attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList) = 0;
+
+    /**
+     * Get rgb cameras
+     * @param[out] rgbCamerasList list of rgb cameras attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) = 0;
+
+    /**
+     * Get depth cameras
+     * @param[out] depthCamerasList list of depth cameras attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    virtual bool getDepthCamerasList(std::vector<std::string>& depthCamerasList) = 0;
+
+    /**
+     * Get joint position  in radians
+     * @param[in] jointName name of the joint
+     * @param[out] jointPosition joint position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getJointPosition(const std::string& jointName,
+                                  double& jointPosition,
+                                  double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get all joints' positions in radians
+     * @param[out] parameter all joints' position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "jointPositions" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
+                                   double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get joint velocity in rad/s
+     * @param[in] jointName name of the joint
+     * @param[out] jointVelocity joint velocity in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getJointVelocity(const std::string& jointName,
+                                  double& jointVelocity,
+                                  double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get all joints' velocities in rad/s
+     * @param[out] parameter all joints' velocities in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "jointVelocties" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
+                                    double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get IMU measurement
+     * The serialization of measurments is as follows,
+     *   (rpy acc omega mag)
+     *  - rpy in radians Roll-Pitch-Yaw Euler angles
+     *  - acc in m/s^2 linear accelerometer measurements
+     *  - omega in rad/s gyroscope measurements
+     *  - mag in tesla magnetometer measurements
+     * @param[in] imuName name of the IMU
+     * @param[out] imuMeasurement imu measurement of size 12
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getIMUMeasurement(const std::string& imuName,
+                                   Eigen::Ref<Vector12d> imuMeasurement,
+                                   double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get linear accelerometer measurement in m/s^2
+     * @param[in] accName name of the linear accelerometer
+     * @param[out] accMeasurement linear accelerometer measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getLinearAccelerometerMeasurement(const std::string& accName,
+                                                   Eigen::Ref<Eigen::Vector3d> accMeasurement,
+                                                   double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get gyroscope measurement in rad/s
+     * @param[in] gyroName name of the gyroscope
+     * @param[out] gyroMeasurement gyroscope measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getGyroscopeMeasure(const std::string& gyroName,
+                                     Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
+                                     double* receiveTimeInSeconds = nullptr) = 0;
+
+   /**
+     * Get orientation sensor measurement in radians as roll pitch yaw Euler angles
+     * @param[in] rpyName name of the orientation sensor
+     * @param[out] rpyMeasurement rpy measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getOrientationSensorMeasurement(const std::string& rpyName,
+                                                 Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
+                                                 double* receiveTimeInSeconds = nullptr) = 0;
+
+   /**
+     * Get magentometer measurement in tesla
+     * @param[in] magName name of the magnetometer
+     * @param[out] magMeasurement magnetometer measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMagnetometerMeasurement(const std::string& magName,
+                                            Eigen::Ref<Eigen::Vector3d> magMeasurement,
+                                            double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get six axis force torque measurement
+     * @param[in] ftName name of the FT sensor
+     * @param[out] ftMeasurement FT measurements of size 6 containing 3d forces and 3d torques
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
+                                                  Eigen::Ref<Vector6d> ftMeasurement,
+                                                  double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get three axis force-torque measurement containing normal force (N) and tangential moments (Nm)
+     * @param[in] ftName name of the FT sensor
+     * @param[out] ftMeasurement FT measurements of size 3 containing tau_x tau_y and fz
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
+                                                    Eigen::Ref<Eigen::Vector3d> ftMeasurement,
+                                                    double* receiveTimeInSeconds = nullptr) = 0;
+
+   /**
+     * Get 6D end effector wrenches in N and Nm for forces and torques respectively
+     * @param[in] cartesianWrenchName name of the end effector wrench
+     * @param[out] cartesianWrenchMeasurement end effector wrench measurement of size 6
+     * @param[out] rreceiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getCartesianWrench(const std::string& cartesianWrenchName,
+                                    Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
+                                    double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get color image from the camera
+     * @param[in] camName name of the camera
+     * @param[out] colorImg image as Eigen matrix object
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "colorImg" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getColorImage(const std::string& camName,
+                               Eigen::Ref<Eigen::MatrixXd> colorImg,
+                               double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Get depth image
+     * @param[in] camName name of the gyroscope
+     * @param[out] depthImg depth image as a Eigen matrix object
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "depthImg" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getDepthImage(const std::string& camName,
+                               Eigen::Ref<Eigen::MatrixXd> depthImg,
+                               double* receiveTimeInSeconds = nullptr) = 0;
+
+    /**
+     * Destructor
+     */
+    virtual ~ISensorBridge() = default;
+
+protected:
+    /**
+     * Helper method to maintain SensorBridgeOptions struct by populating it from the configuration parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the implementation
+     * if the user chooses to not use the method, the implementation must simply contain "return true;"
+     *
+     * @param[in] handler  Parameters handler
+     * @param[in] sensorBridgeOptions SensorBridgeOptions to hold the bridge options for streaming sensor measurements
+     */
+    virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                                      SensorBridgeOptions& sensorBridgeOptions) { return true; };
+
+    /**
+     * Helper method to maintain SensorLists struct by populating it from the configuration parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the implementation
+     * if the user chooses to not use the method, the implementation must simply contain "return true;"
+     *
+     * @param[in] handler  Parameters handler
+     * @param[in] sensorBridgeOptions configured object of SensorBridgeOptions
+     * @param[in] sensorLists SensorLists object holding list of connected sensor devices
+     */
+    virtual bool populateSensorListsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                               const SensorBridgeOptions& sensorBridgeOptions,
+                                               SensorLists& sensorLists) { return true; };
+
+
+};
+} // namespace RobotInterface
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_ISENSOR_BRIDGE_H

--- a/src/RobotInterface/tests/CMakeLists.txt
+++ b/src/RobotInterface/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+add_subdirectory(DummyImplementation)
+

--- a/src/RobotInterface/tests/DummyImplementation/CMakeLists.txt
+++ b/src/RobotInterface/tests/DummyImplementation/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+add_bipedal_test(
+  NAME DummySensorBridge
+  SOURCES DummySensorBridge.h DummySensorBridgeTest.cpp
+  LINKS BipedalLocomotion::RobotInterface)

--- a/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
+++ b/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
@@ -1,0 +1,243 @@
+/**
+ * @file DummySensorBridge.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_DUMMY_SENSOR_BRIDGE_H
+#define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_DUMMY_SENSOR_BRIDGE_H
+
+#include <BipedalLocomotion/RobotInterface/ISensorBridge.h>
+#include <vector>
+#include <string>
+#include <iostream>
+
+namespace BipedalLocomotion
+{
+namespace RobotInterface
+{
+class DummySensorBridge : public ISensorBridge
+{
+public:
+    virtual bool initialize(std::weak_ptr<IParametersHandler> handler) override
+    {
+        if (!populateSensorBridgeOptionsFromConfig(handler, m_options))
+        {
+            std::cerr << "[DummySensorBridge::initialize] could not configure sensor bridge options" << std::endl;
+            return false;
+        }
+
+        if (!populateSensorListsFromConfig(handler, m_options, m_lists))
+        {
+            std::cerr << "[DummySensorBridge::initialize] could not configure sensor lists" << std::endl;
+            return false;
+        }
+
+        m_initialized = true;
+        return true;
+    };
+
+    virtual bool getJointsList(std::vector<std::string>& jointsList) override
+    {
+        jointsList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getIMUsList(std::vector<std::string>& IMUsList) override
+    {
+        IMUsList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList) override
+    {
+        linearAccelerometersList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getGyroscopesList(std::vector<std::string>& gyroscopesList) override
+    {
+        gyroscopesList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getOrientationSensorsList(std::vector<std::string>& orientationSensorsList) override
+    {
+        orientationSensorsList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getMagnetometersList(std::vector<std::string>& magnetometersList) override
+    {
+        magnetometersList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList) override
+    {
+        sixAxisForceTorqueSensorsList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList) override
+    {
+        threeAxisForceTorqueSensorsList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList) override
+    {
+        cartesianWrenchesList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) override
+    {
+        rgbCamerasList = std::vector<std::string>{""};
+        return true;
+    };
+    virtual bool getDepthCamerasList(std::vector<std::string>& depthCamerasList) override
+    {
+        depthCamerasList = std::vector<std::string>{""};
+        return true;
+    };
+
+    virtual bool getJointPosition(const std::string& jointName,
+                                  double& jointPosition,
+                                  double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
+                                   double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getJointVelocity(const std::string& jointName,
+                                  double& jointVelocity,
+                                  double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
+                                    double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getIMUMeasurement(const std::string& imuName,
+                                   Eigen::Ref<Vector12d> imuMeasurement,
+                                   double* receiveTimeInSeconds = nullptr) override { return true; };
+
+    virtual bool getLinearAccelerometerMeasurement(const std::string& accName,
+                                                   Eigen::Ref<Eigen::Vector3d> accMeasurement,
+                                                   double* receiveTimeInSeconds = nullptr) override
+    {
+        if (!m_initialized)
+        {
+            std::cerr << "[DummySensorBridge::getLinearAccelerometerMeasurement] Please intialize te SensorBridge before calling this method."
+                << std::endl;
+            return false;
+        }
+
+        if (!m_options.isLinearAccelerometerEnabled)
+        {
+            std::cerr << "[DummySensorBridge::getLinearAccelerometerMeasurement] Stream not enabled."
+                << std::endl;
+            return false;
+        }
+
+        // get the sensor from the attached streams and pass the measurement
+
+        // pass dummy measurements now
+        accMeasurement << 0, 0, -9.8;
+        *receiveTimeInSeconds = 10.0;
+        return true;
+    };
+
+    virtual bool getGyroscopeMeasure(const std::string& gyroName,
+                                     Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
+                                     double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getOrientationSensorMeasurement(const std::string& rpyName,
+                                                 Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
+                                                 double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getMagnetometerMeasurement(const std::string& magName,
+                                            Eigen::Ref<Eigen::Vector3d> magMeasurement,
+                                            double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
+                                                  Eigen::Ref<Vector6d> ftMeasurement,
+                                                  double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
+                                                    Eigen::Ref<Eigen::Vector3d> ftMeasurement,
+                                                    double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getCartesianWrench(const std::string& cartesianWrenchName,
+                                    Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
+                                    double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getColorImage(const std::string& camName,
+                               Eigen::Ref<Eigen::MatrixXd> colorImg,
+                               double* receiveTimeInSeconds = nullptr) override { return true; };
+    virtual bool getDepthImage(const std::string& camName,
+                               Eigen::Ref<Eigen::MatrixXd> depthImg,
+                               double* receiveTimeInSeconds = nullptr) override { return true; };
+protected:
+    virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                                      SensorBridgeOptions& sensorBridgeOptions) override
+    {
+        auto handle = handler.lock();
+        if (handle == nullptr)
+        {
+            std::cerr << "[DummySensorBridge::initialize] The parameter handler has expired. Please check its scope."
+            << std::endl;
+            return false;
+        }
+
+        auto optionsHandler = handle->getGroup("Options");
+        auto options = optionsHandler.lock();
+        if (options == nullptr)
+        {
+            std::cerr << "[DummySensorBridge::initialize] Could not load required group \"Options\"."
+            << std::endl;
+            return false;
+        }
+
+        if (!options->getParameter("streamLinearAccelerometerMeasurements", sensorBridgeOptions.isLinearAccelerometerEnabled))
+        {
+            std::cerr << "[DummySensorBridge::initialize] The parameter handler could not find \" streamLinearAccelerometerMeasurements \" in the configuration file."
+            << std::endl;
+            return false;
+        }
+        return true;
+    };
+
+    virtual bool populateSensorListsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                               const SensorBridgeOptions& sensorBridgeOptions,
+                                               SensorLists& sensorLists) override
+    {
+        auto handle = handler.lock();
+        if (handle == nullptr)
+        {
+            std::cerr << "[DummySensorBridge::initialize] The parameter handler has expired. Please check its scope."
+            << std::endl;
+            return false;
+        }
+
+        auto sourceHandler = handle->getGroup("Sources");
+        auto source = sourceHandler.lock();
+        if (source == nullptr)
+        {
+            std::cerr << "[DummySensorBridge::initialize] Could not load required group \"Sources\"."
+            << std::endl;
+            return false;
+        }
+
+        if (sensorBridgeOptions.isLinearAccelerometerEnabled)
+        {
+            if (!source->getParameter("LinearAccelerometers", sensorLists.linearAccelerometersList, GenericContainer::VectorResizeMode::Resizable))
+            {
+                std::cerr << "[DummySensorBridge::initialize] The parameter handler could not find \" LinearAccelerometers \" in the configuration file."
+                << std::endl;
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+private:
+    bool m_initialized{false};
+    SensorBridgeOptions m_options;
+    SensorLists m_lists;
+};
+
+} // namespace BipedalLocomotion
+} // namespace RobotInterface
+
+#endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_DUMMY_SENSOR_BRIDGE_H

--- a/src/RobotInterface/tests/DummyImplementation/DummySensorBridgeTest.cpp
+++ b/src/RobotInterface/tests/DummyImplementation/DummySensorBridgeTest.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file DummySensorBridgeTest.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+
+// Catch2
+#include <catch2/catch.hpp>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include "DummySensorBridge.h"
+#include <iostream>
+#include <vector>
+using namespace BipedalLocomotion::RobotInterface;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion;
+
+bool populateConfig(std::weak_ptr<IParametersHandler> handler)
+{
+    auto handle = handler.lock();
+    if (handle == nullptr) {return false;}
+
+    auto optionsGroup = std::make_shared<StdImplementation>();
+    handle->setGroup("Options", optionsGroup);
+    optionsGroup->setParameter("streamLinearAccelerometerMeasurements", true);
+
+    auto sourcesGroup = std::make_shared<StdImplementation>();
+    handle->setGroup("Sources", sourcesGroup);
+    IParametersHandler::shared_ptr sourcesHandler = sourcesGroup;
+    sourcesHandler->setParameter("LinearAccelerometers", std::vector<std::string>{"dummy"} );
+
+    return true;
+}
+
+TEST_CASE("Test Sensor Bridge Interface")
+{
+    std::shared_ptr<StdImplementation> originalHandler = std::make_shared<StdImplementation>();
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    // Populate the input configuration to be passed to the estimator
+    REQUIRE(populateConfig(parameterHandler));
+
+    std::shared_ptr<DummySensorBridge> dummyBridge = std::make_shared<DummySensorBridge>();
+    REQUIRE(dummyBridge->initialize(parameterHandler));
+
+    double accRecvTime;
+    Eigen::Vector3d acc;
+    std::string someName{"dummy"};
+    REQUIRE(dummyBridge->getLinearAccelerometerMeasurement(someName, acc, &accRecvTime));
+    REQUIRE(acc(2) == -9.8);
+    REQUIRE(accRecvTime == 10.0);
+}


### PR DESCRIPTION
This PR,
- Adds `RobotInterface` library to the Framework
- Adds `ISensorBridge` interface class to `RobotInterface` library
~~- Adds OpenCV as a dependency for handling `cv::Mat` within the `ISensorBridge` class~~
- Adds a trivial `DummySensorBridge` test implementation to depict the use of the `ISensorBridge` interface