### PR TITLE
Enable cppad on Windows 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         # Install Catch2 and cppad
         cd C:/robotology/vcpkg
         git fetch
-        git checkout ${vcpkg_TAG}
+        git checkout $env:vcpkg_TAG
         ./bootstrap-vcpkg.bat
         ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports catch2:x64-windows cppad:x64-windows
         echo "::set-env name=cppad_DIR::C:/robotology/vcpkg/installed/x64-windows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.4.0
+  vcpkg_TAG: 222c35e3bcb8f28cd63fc526e591bb4ef6b99e4f
   YCM_TAG: v0.11.1
   YARP_TAG: 964bb26fa4791d83d72882711ea7509306248106
   iDynTree_TAG: v1.1.0
@@ -63,7 +64,7 @@ jobs:
         # Install Catch2 and cppad
         cd C:/robotology/vcpkg
         git fetch
-        git checkout 222c35e3bcb8f28cd63fc526e591bb4ef6b99e4f
+        git checkout ${vcpkg_TAG}
         ./bootstrap-vcpkg.bat
         ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports catch2:x64-windows cppad:x64-windows
         echo "::set-env name=cppad_DIR::C:/robotology/vcpkg/installed/x64-windows"
@@ -89,7 +90,7 @@ jobs:
       with:
         path: ${{ github.workspace }}/install/deps
         # Including ${{ runner.temp }} is a workaround taken from https://github.com/robotology/whole-body-estimators/pull/62 to fix macos configuration failure on https://github.com/dic-iit/bipedal-locomotion-framework/pull/45
-        key: source-deps-${{ runner.os }}-${{runner.temp}}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-catch2-${{ env.Catch2_TAG }}-qhull-${{ env.Qhull_TAG }}-casADi-${{ env.CasADi_TAG }}
+        key: source-deps-${{ runner.os }}-${{runner.temp}}-vcpkg-${{ env.vcpkg_TAG }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-ycm-${{ env.YCM_TAG }}-yarp-${{ env.YARP_TAG }}-iDynTree-${{ env.iDynTree_TAG }}-catch2-${{ env.Catch2_TAG }}-qhull-${{ env.Qhull_TAG }}-casADi-${{ env.CasADi_TAG }}
 
 
     - name: Source-based Dependencies [Windows]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,14 @@ jobs:
         # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
         echo "::set-env name=VCPKG_INSTALLATION_ROOT::C:/robotology/vcpkg"
 
-        # Install Catch2
+        # Install Catch2 and cppad
         cd C:/robotology/vcpkg
-        ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports catch2:x64-windows
+        git fetch
+        git checkout 222c35e3bcb8f28cd63fc526e591bb4ef6b99e4f
+        ./bootstrap-vcpkg.bat
+        ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports catch2:x64-windows cppad:x64-windows
+        echo "::set-env name=cppad_DIR::C:/robotology/vcpkg/installed/x64-windows"
+
 
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'

--- a/cmake/Findcppad.cmake
+++ b/cmake/Findcppad.cmake
@@ -73,7 +73,53 @@ if(NOT WIN32)
 
 # Windows platforms
 else()
-  message(WARNING "Windows is not supported yet.")
+
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+
+    if(cppad_FIND_VERSION)
+      if(cppad_FIND_VERSION_EXACT)
+        pkg_check_modules(_PC_cppad QUIET cppad=${cppad_FIND_VERSION})
+      else()
+        pkg_check_modules(_PC_cppad QUIET cppad>=${cppad_FIND_VERSION})
+      endif()
+    else()
+      pkg_check_modules(_PC_cppad QUIET cppad)
+    endif()
+
+    if(_PC_cppad_FOUND)
+      set(cppad_INCLUDE_DIRS ${_PC_cppad_INCLUDE_DIRS} CACHE PATH "cppad include directory")
+      set(cppad_DEFINITIONS ${_PC_cppad_CFLAGS} CACHE STRING "Additional compiler flags for cppad")
+
+      find_library(${_PC_cppad_LIBRARIES}_PATH
+        NAMES ${_PC_cppad_LIBRARIES}
+        PATHS ${_PC_cppad_LIBRARY_DIRS})
+
+      set(cppad_LIBRARIES ${${_PC_cppad_LIBRARIES}_PATH} CACHE PATH "cppad libraries" FORCE)
+
+    else()
+      set(cppad_DEFINITIONS "")
+    endif()
+
+  endif()
+
+  set(cppad_LINK_FLAGS "")
+
+  # If pkg-config fails, try to find the package using cppad_DIR
+  if(NOT _PC_cppad_FOUND)
+    set(cppad_DIR $ENV{cppad_DIR} CACHE PATH "Path to cppad build directory")
+
+    find_path(cppad_INCLUDE_DIRS
+      NAMES cppad.hpp PATH_SUFFIXES cppad PATHS ${cppad_DIR}/include/cppad)
+
+    find_library(cppad_LIBRARIES
+      NAMES cppad cppad_lib
+      PATHS ${cppad_DIR}/lib ${cppad_DIR}/lib/cppad)
+
+    set(cppad_DEFINITIONS "")
+    set(cppad_LINK_FLAGS "")
+  endif()
+
 endif()
 
 

--- a/src/AutoDiff/tests/CppADTest.cpp
+++ b/src/AutoDiff/tests/CppADTest.cpp
@@ -33,7 +33,7 @@ TEST_CASE("CppAD and Eigen")
     Eigen::Map<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> jacMatrix(jac.data());
 
     // Compute the analytic Jacobian
-    auto analyticJacobian = [&a, &b](const Eigen::Ref<Eigen::Vector3d>& x) -> Eigen::Matrix3d {
+    auto analyticJacobian = [&a, &b, &c](const Eigen::Ref<Eigen::Vector3d>& x) -> Eigen::Matrix3d {
         Eigen::Vector3d jacobian;
         jacobian = a + c * b * (b * x.array()).cos();
         return jacobian.asDiagonal();


### PR DESCRIPTION
Thanks to https://github.com/microsoft/vcpkg/pull/12560 installing `cppad` on windows becomes simple. This PR introduces the support to cppad on Windows.

Related issues #75 