### PR TITLE
Bump CMake minimum version for LAST_EXT option in get_file_component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 ## MAIN project
 project(BipedalLocomotionFramework


### PR DESCRIPTION
`LAST_EXT` option in `get_file_component` is available only from CMake v3.14, See https://cmake.org/cmake/help/v3.14/command/get_filename_component.html

and https://cmake.org/cmake/help/v3.13/command/get_filename_component.html for comparison.

This is used in https://github.com/dic-iit/bipedal-locomotion-framework/blob/26f45d714097ad3fe299025122cae1864cbef497/cmake/AddBipedalLocomotionLibrary.cmake#L102
