### PR TITLE
Add Ref class to GeneriContainer::Vector

### DIFF
--- a/src/GenericContainer/include/BipedalLocomotion/GenericContainer/TemplateHelpers.h
+++ b/src/GenericContainer/include/BipedalLocomotion/GenericContainer/TemplateHelpers.h
@@ -258,6 +258,26 @@ struct is_specialization<Ref<Args...>, Ref> : std::true_type
 {
 };
 
+template<typename T, typename = void >
+struct is_data_const : std::false_type
+{
+};
+
+template <typename T>
+    struct is_data_const<T,
+                     std::enable_if_t<is_data_available<T>::value,
+                                      std::enable_if_t<std::is_const_v<decltype(std::declval<T>().data())>>>> : std::true_type
+{
+};
+
+
+template <typename Container>
+struct is_container_const
+{
+    static constexpr bool value = std::is_const_v<Container> ||
+                                  is_data_const<Container>::value;
+};
+
 } // namespace BipedalLocomotion
 
 #endif // BIPEDAL_LOCOMOTION_TEMPLATEHELPERS_H

--- a/src/GenericContainer/include/BipedalLocomotion/GenericContainer/TemplateHelpers.h
+++ b/src/GenericContainer/include/BipedalLocomotion/GenericContainer/TemplateHelpers.h
@@ -258,11 +258,17 @@ struct is_specialization<Ref<Args...>, Ref> : std::true_type
 {
 };
 
+/**
+ * is_data_const is a template metafunction to detect if the output of T.data() is const.
+ */
 template<typename T, typename = void >
 struct is_data_const : std::false_type
 {
 };
 
+/**
+ * is_data_const is a template metafunction to detect if the output of T.data() is const.
+ */
 template <typename T>
     struct is_data_const<T,
                      std::enable_if_t<is_data_available<T>::value,
@@ -270,7 +276,10 @@ template <typename T>
 {
 };
 
-
+/**
+ * is_container_const is a struct containing a boolean value.
+ * If the container is either const itself, or if the output of Container.data() is const, then value is true.
+ */
 template <typename Container>
 struct is_container_const
 {

--- a/src/GenericContainer/include/BipedalLocomotion/GenericContainer/Vector.h
+++ b/src/GenericContainer/include/BipedalLocomotion/GenericContainer/Vector.h
@@ -218,11 +218,12 @@ public:
      *
      * @warning It performs memory allocation if this is resizable and the sizes are different.
      */
-    void operator=(const Vector<T>& other)
+    Vector<T>& operator=(const Vector<T>& other)
     {
         bool ok = clone(other);
         assert(ok);
         unused(ok);
+        return *this;
     }
 
     /**
@@ -233,11 +234,12 @@ public:
      *
      * @warning It performs memory allocation if this is resizable and the sizes are different.
      */
-    void operator=(iDynTree::Span<T> other)
+    Vector<T>& operator=(iDynTree::Span<T> other)
     {
         bool ok = clone(other);
         assert(ok);
         unused(ok);
+        return *this;
     }
 
     /**
@@ -248,11 +250,12 @@ public:
      *
      * @warning It performs memory allocation if this is resizable and the sizes are different.
      */
-    void operator=(Vector<T>&& other)
+    Vector<T>& operator=(Vector<T>&& other)
     {
         bool ok = clone(other);
         assert(ok);
         unused(ok);
+        return *this;
     }
 
     /**
@@ -942,6 +945,16 @@ public:
     }
 
    ~Ref() = default;
+
+   Vector<T> & operator=(const Ref& other)
+   {
+       return static_cast<BipedalLocomotion::GenericContainer::Vector<T>&>(*this) = other;
+   }
+
+   Vector<T> & operator=(Ref&& other)
+   {
+       return static_cast<BipedalLocomotion::GenericContainer::Vector<T>&>(*this) = other;
+   }
 
 };
 

--- a/src/GenericContainer/include/BipedalLocomotion/GenericContainer/Vector.h
+++ b/src/GenericContainer/include/BipedalLocomotion/GenericContainer/Vector.h
@@ -158,13 +158,39 @@ public:
     }
 
     /**
-     * @brief Copies the content of the vecto
+     * @brief Copies the content of the vector
      * @param other Vector from which to copy
      * @return true in case of success. False if the two have different size and this is not resizable.
      *
      * @warning It performs memory allocation if this is resizable and the sizes are different.
      */
     bool clone(const Vector<T>& other)
+    {
+        if (size() != other.size())
+        {
+            if (!resizeVector(other.size()))
+            {
+                std::cerr << "[GenericContainer::Vector] Failed to resize. Copy aborted" << std::endl;
+                return false;
+            }
+        }
+
+        for (index_type i = 0; i < size(); ++i)
+        {
+            this->operator[](i) = other[i];
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Copies the content of the vector
+     * @param other Span from which to copy
+     * @return true in case of success. False if the two have different size and this is not resizable.
+     *
+     * @warning It performs memory allocation if this is resizable and the sizes are different.
+     */
+    bool clone(iDynTree::Span<T> other)
     {
         if (size() != other.size())
         {
@@ -192,6 +218,21 @@ public:
      * @warning It performs memory allocation if this is resizable and the sizes are different.
      */
     void operator=(const Vector<T>& other)
+    {
+        bool ok = clone(other);
+        assert(ok);
+        unused(ok);
+    }
+
+    /**
+     * @brief operator = Copies the content
+     * @param other Vector from which to copy
+     *
+     * It calls clone(). There is an assert on its return value.
+     *
+     * @warning It performs memory allocation if this is resizable and the sizes are different.
+     */
+    void operator=(iDynTree::Span<T> other)
     {
         bool ok = clone(other);
         assert(ok);

--- a/src/GenericContainer/tests/GenericContainerTest.cpp
+++ b/src/GenericContainer/tests/GenericContainerTest.cpp
@@ -26,10 +26,9 @@ void foo(GenericContainer::Vector<double>::Ref test)
     return;
 }
 
-void fooConst(GenericContainer::Vector<const double>::Ref test)
+void fooConst(const GenericContainer::Vector<const double>::Ref test)
 {
     test.data();
-//    test.resize(5);
     return;
 }
 

--- a/src/GenericContainer/tests/GenericContainerTest.cpp
+++ b/src/GenericContainer/tests/GenericContainerTest.cpp
@@ -678,7 +678,36 @@ TEST_CASE("GenericContainer::Vector")
         foo(idynFixVec);
         iDynTree::VectorDynSize idynVec;
         foo(idynVec);
+        fooConst(idynVec);
         foo(GenericContainer::make_vector(idynVec, GenericContainer::VectorResizeMode::Fixed));
+    }
+
+    SECTION("Copy of Refs")
+    {
+        iDynTree::VectorDynSize vector(5);
+        iDynTree::getRandomVector(vector);
+        GenericContainer::Vector<double>::Ref container(vector);
+
+        std::vector<double> copiedIn;
+        copiedIn.resize(5);
+        GenericContainer::Vector<double> containerToBeCopied(copiedIn); // copied in is automatically casted to a span
+
+        containerToBeCopied = container; //Ref = Vector
+
+        for (long i = 0; i < container.size(); ++i)
+        {
+            REQUIRE(vector[i] == copiedIn[i]);
+        }
+
+        Eigen::VectorXd otherCopiedIn;
+        GenericContainer::Vector<double>::Ref otherContainerToBeCopied(otherCopiedIn);
+
+        otherContainerToBeCopied = container;
+
+        for (long i = 0; i < container.size(); ++i)
+        {
+            REQUIRE(vector[i] == otherCopiedIn[i]);
+        }
     }
 
 }

--- a/src/GenericContainer/tests/GenericContainerTest.cpp
+++ b/src/GenericContainer/tests/GenericContainerTest.cpp
@@ -20,15 +20,16 @@
 
 using namespace BipedalLocomotion;
 
-void foo(GenericContainer::Vector<int>::Ref test)
+void foo(GenericContainer::Vector<double>::Ref test)
 {
     test.data();
     return;
 }
 
-void fooConst(const GenericContainer::Vector<const int>& test)
+void fooConst(GenericContainer::Vector<const double>::Ref test)
 {
     test.data();
+//    test.resize(5);
     return;
 }
 
@@ -649,10 +650,35 @@ TEST_CASE("GenericContainer::Vector")
         REQUIRE(d.isApprox(GenericContainer::to_eigen(c)));
     }
 
-    SECTION("Generic input to function")
+    SECTION("Refs")
     {
         std::vector<int> vec(5);
+        GenericContainer::Vector<int>::Ref stdRef(vec);
+        const std::vector<int>& cvec = vec;
+        GenericContainer::Vector<const int>::Ref stdConstRef(cvec);
+        Eigen::Vector2d eigenVec;
+        GenericContainer::Vector<double>::Ref eigenRef(eigenVec);
+        iDynTree::VectorFixSize<3> idynFixVec;
+        GenericContainer::Vector<double>::Ref idynFix(idynFixVec);
+        iDynTree::VectorDynSize idynVec;
+        GenericContainer::Vector<double>::Ref idyn(idynVec);
+        const iDynTree::VectorDynSize& idynConstVec = idynVec;
+        GenericContainer::Vector<const double>::Ref idynConst(idynConstVec);
+    }
+
+    SECTION("Generic input to function")
+    {
+        std::vector<double> vec(5);
         foo(vec);
+        const std::vector<double>& cvec = vec;
+        fooConst(cvec);
+        Eigen::Vector2d eigenVec;
+        foo(eigenVec);
+        iDynTree::VectorFixSize<3> idynFixVec;
+        foo(idynFixVec);
+        iDynTree::VectorDynSize idynVec;
+        foo(idynVec);
+        foo(GenericContainer::make_vector(idynVec, GenericContainer::VectorResizeMode::Fixed));
     }
 
 }

--- a/src/GenericContainer/tests/GenericContainerTest.cpp
+++ b/src/GenericContainer/tests/GenericContainerTest.cpp
@@ -53,10 +53,17 @@ TEST_CASE("GenericContainer::Vector")
 
         std::vector<double> copiedIn;
         copiedIn.resize(5);
-        GenericContainer::Vector containerToBeCopied(iDynTree::make_span(copiedIn));
+        GenericContainer::Vector<double> containerToBeCopied(copiedIn); // copied in is automatically casted to a span
 
         containerToBeCopied = container;
 
+        for (long i = 0; i < container.size(); ++i)
+        {
+            REQUIRE(vector[i] == copiedIn[i]);
+        }
+
+        iDynTree::getRandomVector(vector);
+        containerToBeCopied = vector; //vector is automatically turned into a span
         for (long i = 0; i < container.size(); ++i)
         {
             REQUIRE(vector[i] == copiedIn[i]);
@@ -629,5 +636,4 @@ TEST_CASE("GenericContainer::Vector")
 
         REQUIRE(d.isApprox(GenericContainer::to_eigen(c)));
     }
-
 }

--- a/src/GenericContainer/tests/GenericContainerTest.cpp
+++ b/src/GenericContainer/tests/GenericContainerTest.cpp
@@ -20,6 +20,18 @@
 
 using namespace BipedalLocomotion;
 
+void foo(GenericContainer::Vector<int>::Ref test)
+{
+    test.data();
+    return;
+}
+
+void fooConst(const GenericContainer::Vector<const int>& test)
+{
+    test.data();
+    return;
+}
+
 TEST_CASE("GenericContainer::Vector")
 {
     SECTION("Constructible")
@@ -636,4 +648,11 @@ TEST_CASE("GenericContainer::Vector")
 
         REQUIRE(d.isApprox(GenericContainer::to_eigen(c)));
     }
+
+    SECTION("Generic input to function")
+    {
+        std::vector<int> vec(5);
+        foo(vec);
+    }
+
 }


### PR DESCRIPTION
The class ``Ref`` is used as a substitution to a classical reference to a Vector. The advantage of using this, is that custom vectors (all those supported by ``GenericContainer::Vector``) can be implicitly casted to ``Ref``.
``Ref`` does not allocate any memory in construction, hence can be used as a parameter to be passed by copy. The operator ``=`` clones the content.                                                                      
``Ref`` inherits ``Vector<T>``, hence it can be used as it was a ``Vector<T>``.      

This goes in the direction of fixing #95, at least to simplify the use of ``GenericContainer::Vector<double>`` in public interfaces.                          