### PR TITLE
YarpSensorBridge Implementation

### DIFF
--- a/src/RobotInterface/YarpImplementation/CMakeLists.txt
+++ b/src/RobotInterface/YarpImplementation/CMakeLists.txt
@@ -6,9 +6,10 @@ if(FRAMEWORK_COMPILE_YarpImplementation)
 
   add_bipedal_locomotion_library(
     NAME                   RobotInterfaceYarpImplementation
-    SOURCES                src/YarpRobotControl.cpp
-    PUBLIC_HEADERS         include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::RobotInterface YARP::YARP_dev
+    SOURCES                src/YarpRobotControl.cpp src/YarpSensorBridge.cpp
+    PUBLIC_HEADERS         include/BipedalLocomotion/RobotInterface/YarpRobotControl.h include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+    PRIVATE_HEADERS        include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::RobotInterface BipedalLocomotion::System YARP::YARP_dev
     INSTALLATION_FOLDER    RobotInterface)
 
 endif()

--- a/src/RobotInterface/YarpImplementation/CMakeLists.txt
+++ b/src/RobotInterface/YarpImplementation/CMakeLists.txt
@@ -9,7 +9,7 @@ if(FRAMEWORK_COMPILE_YarpImplementation)
     SOURCES                src/YarpRobotControl.cpp src/YarpSensorBridge.cpp
     PUBLIC_HEADERS         include/BipedalLocomotion/RobotInterface/YarpRobotControl.h include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
     PRIVATE_HEADERS        include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::RobotInterface BipedalLocomotion::System YARP::YARP_dev
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::RobotInterface BipedalLocomotion::System YARP::YARP_dev YARP::YARP_os YARP::YARP_sig
     INSTALLATION_FOLDER    RobotInterface)
 
 endif()

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -150,11 +150,11 @@ public:
     bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) final;
 
     /**
-     * Get depth cameras
-     * @param[out] depthCamerasList list of depth cameras attached to the bridge
+     * Get RGBD cameras
+     * @param[out] rgbdCamerasList list of depth cameras attached to the bridge
      * @return  true/false in case of success/failure
      */
-    bool getDepthCamerasList(std::vector<std::string>& depthCamerasList) final;
+    bool getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList) final;
 
     /**
      * Get joint position  in radians

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -1,0 +1,369 @@
+/**
+ * @file YarpSensorBridge.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_H
+#define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_H
+
+// std
+#include <memory>
+
+// YARP
+#include <yarp/dev/PolyDriverList.h>
+
+#include <BipedalLocomotion/System/Advanceable.h>
+#include <BipedalLocomotion/RobotInterface/ISensorBridge.h>
+
+namespace BipedalLocomotion
+{
+namespace RobotInterface
+{
+
+
+/**
+ * YarpSensorBridge Yarp implementation of the ISensorBridge interface
+ * Currently available interfaces
+ * - Remapped Remote Control Board for joint states
+ * - Inertial Measurement Units through generic sensor interface and remapped multiple analog sensor interface
+ * - Whole Body Dynamics Estimated end effector wrenches through a generic sensor interface
+ * - Force Torque Sensors through analog sensor interface and remapped multiple analog sensor interface
+ * - Depth Cameras through RGBD sensor interface
+ * - Camera images through OpenCV Grabber interface
+ *
+ */
+class YarpSensorBridge : public ISensorBridge,
+                         public BipedalLocomotion::System::Advanceable<SensorBridgeMetaData>
+{
+public:
+    /**
+     * Constructor
+     */
+    YarpSensorBridge();
+
+    /**
+     * Destructor
+     */
+    ~YarpSensorBridge();
+
+    /**
+     * Initialize estimator
+     * @param[in] handler Parameters handler
+     */
+    bool initialize(std::weak_ptr<IParametersHandler> handler) final;
+
+    /**
+     * Set the list of device drivers from which the sensor measurements need to be streamed
+     * @param deviceDriversList device drivers holding the pointer to sensor interfaces
+     * @return True/False in case of success/failure.
+     */
+    bool setDriversList(const yarp::dev::PolyDriverList& deviceDriversList);
+
+    /**
+     * @brief Advance the internal state. This may change the value retrievable from get().
+     * @return True if the advance is successful.
+     */
+    bool advance() final;
+
+    /**
+     * @brief Determines the validity of the object retrieved with get()
+     * @return True if the object is valid, false otherwise.
+     */
+    bool isValid() const final;
+
+    /**
+     * @brief Get the object.
+     * @return a const reference of the requested object.
+     */
+    const SensorBridgeMetaData& get() const final;
+
+    /**
+     * Get joints list
+     * @param[out] jointsList list of joints attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getJointsList(std::vector<std::string>& jointsList) final;
+
+    /**
+     * Get imu sensors
+     * @param[out] IMUsList list of IMUs attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getIMUsList(std::vector<std::string>& IMUsList) final;
+
+    /**
+     * Get linear accelerometers
+     * @param[out] linearAccelerometersList list of linear accelerometers attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList) final;
+
+    /**
+     * Get gyroscopes
+     * @param[out] gyroscopesList list of gyroscopes attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getGyroscopesList(std::vector<std::string>& gyroscopesList) final;
+
+    /**
+     * Get orientation sensors
+     * @param[out] orientationSensorsList list of orientation sensors attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getOrientationSensorsList(std::vector<std::string>& orientationSensorsList) final;
+
+    /**
+     * Get magnetometers sensors
+     * @param[out] magnetometersList list of magnetometers attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getMagnetometersList(std::vector<std::string>& magnetometersList) final;
+
+    /**
+     * Get 6 axis FT sensors
+     * @param[out] sixAxisForceTorqueSensorsList list of 6 axis force torque sensors attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList) final;
+
+    /**
+     * Get 6 axis FT sensors
+     * @param[out] threeAxisForceTorqueSensorsList list of 3 axis force torque sensors attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList) final;
+
+   /**
+     * Get cartesian wrenches
+     * @param[out] cartesianWrenchesList list of cartesian wrenches attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList) final;
+
+    /**
+     * Get rgb cameras
+     * @param[out] rgbCamerasList list of rgb cameras attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) final;
+
+    /**
+     * Get depth cameras
+     * @param[out] depthCamerasList list of depth cameras attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getDepthCamerasList(std::vector<std::string>& depthCamerasList) final;
+
+    /**
+     * Get joint position  in radians
+     * @param[in] jointName name of the joint
+     * @param[out] jointPosition joint position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getJointPosition(const std::string& jointName,
+                          double& jointPosition,
+                          double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get all joints' positions in radians
+     * @param[out] parameter all joints' position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "jointPositions" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
+                           double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get joint velocity in rad/s
+     * @param[in] jointName name of the joint
+     * @param[out] jointVelocity joint velocity in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getJointVelocity(const std::string& jointName,
+                          double& jointVelocity,
+                          double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get all joints' velocities in rad/s
+     * @param[out] parameter all joints' velocities in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "jointVelocties" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
+                            double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get IMU measurement
+     * The serialization of measurments is as follows,
+     *   (rpy acc omega mag)
+     *  - rpy in radians Roll-Pitch-Yaw Euler angles
+     *  - acc in m/s^2 linear accelerometer measurements
+     *  - omega in rad/s gyroscope measurements
+     *  - mag in tesla magnetometer measurements
+     * @param[in] imuName name of the IMU
+     * @param[out] imuMeasurement imu measurement of size 12
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getIMUMeasurement(const std::string& imuName,
+                           Eigen::Ref<Vector12d> imuMeasurement,
+                           double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get linear accelerometer measurement in m/s^2
+     * @param[in] accName name of the linear accelerometer
+     * @param[out] accMeasurement linear accelerometer measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getLinearAccelerometerMeasurement(const std::string& accName,
+                                           Eigen::Ref<Eigen::Vector3d> accMeasurement,
+                                           double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get gyroscope measurement in rad/s
+     * @param[in] gyroName name of the gyroscope
+     * @param[out] gyroMeasurement gyroscope measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getGyroscopeMeasure(const std::string& gyroName,
+                             Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
+                             double* receiveTimeInSeconds = nullptr) final;
+
+   /**
+     * Get orientation sensor measurement in radians as roll pitch yaw Euler angles
+     * @param[in] rpyName name of the orientation sensor
+     * @param[out] rpyMeasurement rpy measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getOrientationSensorMeasurement(const std::string& rpyName,
+                                         Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
+                                         double* receiveTimeInSeconds = nullptr) final;
+
+   /**
+     * Get magentometer measurement in tesla
+     * @param[in] magName name of the magnetometer
+     * @param[out] magMeasurement magnetometer measurements of size 3
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getMagnetometerMeasurement(const std::string& magName,
+                                    Eigen::Ref<Eigen::Vector3d> magMeasurement,
+                                    double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get six axis force torque measurement
+     * @param[in] ftName name of the FT sensor
+     * @param[out] ftMeasurement FT measurements of size 6 containing 3d forces and 3d torques
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
+                                          Eigen::Ref<Vector6d> ftMeasurement,
+                                          double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get three axis force-torque measurement containing normal force (N) and tangential moments (Nm)
+     * @param[in] ftName name of the FT sensor
+     * @param[out] ftMeasurement FT measurements of size 3 containing tau_x tau_y and fz
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
+                                            Eigen::Ref<Eigen::Vector3d> ftMeasurement,
+                                            double* receiveTimeInSeconds = nullptr) final;
+
+   /**
+     * Get 6D end effector wrenches in N and Nm for forces and torques respectively
+     * @param[in] cartesianWrenchName name of the end effector wrench
+     * @param[out] cartesianWrenchMeasurement end effector wrench measurement of size 6
+     * @param[out] rreceiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getCartesianWrench(const std::string& cartesianWrenchName,
+                            Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
+                            double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get color image from the camera
+     * @param[in] camName name of the camera
+     * @param[out] colorImg image as Eigen matrix object
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "colorImg" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getColorImage(const std::string& camName,
+                       Eigen::Ref<Eigen::MatrixXd> colorImg,
+                       double* receiveTimeInSeconds = nullptr) final;
+
+    /**
+     * Get depth image
+     * @param[in] camName name of the gyroscope
+     * @param[out] depthImg depth image as a Eigen matrix object
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "depthImg" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getDepthImage(const std::string& camName,
+                       Eigen::Ref<Eigen::MatrixXd> depthImg,
+                       double* receiveTimeInSeconds = nullptr) final;
+
+protected:
+    /**
+     * Helper method to maintain SensorBridgeOptions struct by populating it from the configuration parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the implementation
+     * if the user chooses to not use the method, the implementation must simply contain "return true;"
+     *
+     * @param[in] handler  Parameters handler
+     * @param[in] sensorBridgeOptions SensorBridgeOptions to hold the bridge options for streaming sensor measurements
+     */
+    bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                               SensorBridgeOptions& sensorBridgeOptions) final;
+
+    /**
+     * Helper method to maintain SensorLists struct by populating it from the configuration parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the implementation
+     * if the user chooses to not use the method, the implementation must simply contain "return true;"
+     *
+     * @param[in] handler  Parameters handler
+     * @param[in] sensorBridgeOptions configured object of SensorBridgeOptions
+     * @param[in] sensorLists SensorLists object holding list of connected sensor devices
+     */
+     bool populateSensorListsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                        const SensorBridgeOptions& sensorBridgeOptions,
+                                        SensorLists& sensorLists) final;
+private:
+    /** Private implementation */
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl;
+};
+
+} // namespace RobotInterface
+} // namespace BipedalLocomotion
+
+
+#endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_H

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
@@ -1,0 +1,1042 @@
+/**
+ * @file YarpSensorBridgeImpl.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_IMPL_H
+#define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_IMPL_H
+
+#include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
+#include <BipedalLocomotion/GenericContainer/Vector.h>
+
+// YARP Sensor Interfaces
+#include <yarp/dev/IAnalogSensor.h>
+#include <yarp/dev/IGenericSensor.h>
+#include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
+
+// YARP Camera Interfaces
+#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IRGBDSensor.h>
+
+// YARP Control Board Interfaces
+#include <yarp/dev/IEncodersTimed.h>
+#include <yarp/dev/IAxisInfo.h>
+
+// std
+#include <set>
+#include <algorithm>
+
+using namespace BipedalLocomotion::RobotInterface;
+using namespace BipedalLocomotion::GenericContainer;
+
+namespace BipedalLocomotion
+{
+namespace RobotInterface
+{
+
+struct YarpSensorBridge::Impl
+{
+    /**
+     * Struct holding remapped remote control board interfaces
+     */
+    struct
+    {
+        yarp::dev::IEncodersTimed* encoders;
+        yarp::dev::IAxisInfo* axis;
+    } controlBoardRemapperInterfaces;
+
+    /**
+     * Struct holding remapped MAS interfaces -inertial sensors related
+     */
+    struct
+    {
+        yarp::dev::IThreeAxisLinearAccelerometers* accelerometers;
+        yarp::dev::IThreeAxisGyroscopes* gyroscopes;
+        yarp::dev::IThreeAxisMagnetometers* magnetometers;
+        yarp::dev::IOrientationSensors* orientationSensors;
+    } wholeBodyMASInertialsInterface;
+
+    /**
+     * Struct holding remapped MAS interfaces - FT sensors related
+     */
+    struct
+    {
+        yarp::dev::ISixAxisForceTorqueSensors* sixAxisFTSensors;
+    } wholeBodyMASForceTorquesInterface;
+
+    std::unordered_map<std::string, yarp::dev::IGenericSensor*> wholeBodyAnalogIMUInterface; /** < map  of IMU sensors attached through generic sensor interfaces */
+    std::unordered_map<std::string, yarp::dev::IGenericSensor*> wholeBodyCartesianWrenchInterface; /** < map  of cartesian wrench streams attached through generic sensor interfaces */
+    std::unordered_map<std::string, yarp::dev::IAnalogSensor*> wholeBodyAnalogSixAxisFTSensorsInterface; /** < map  of six axis force torque sensors attached through analog sensor interfaces */
+    std::unordered_map<std::string, yarp::dev::IFrameGrabberImage*> wholeBodyFrameGrabberInterface; /** < map of cameras attached through frame grabber interfaces */
+    std::unordered_map<std::string, yarp::dev::IRGBDSensor*> wholeBodyRGBDInterface; /** < map of cameras attached through RGBD interfaces */
+
+    /**
+     * Struct holding measurements polled from remapped remote control board interfaces
+     */
+    struct
+    {
+        Eigen::VectorXd remappedJointIndices;
+        Eigen::VectorXd jointPositions;
+        Eigen::VectorXd jointVelocities;
+        double receivedTimeInSeconds;
+    } controlBoardRemapperMeasures;
+
+    std::unordered_map<std::string, Vector12d> wholeBodyIMUMeasures; /** < map holding analog IMU sensor measurements */
+    std::unordered_map<std::string, Vector6d> wholeBodyFTMeasures; /** < map holding six axis force torque measures */
+    std::unordered_map<std::string, Eigen::Vector3d> wholeBodyInertialMeasures; /** < map holding three axis inertial sensor measures */
+    std::unordered_map<std::string, Vector6d> wholeBodyCartesianWrenchMeasures; /** < map holding cartesian wrench measures */
+    std::unordered_map<std::string, Eigen::MatrixXd> wholeBodyCameraImages; /** < map holding images **/
+
+    const int nrChannelsInYARPGenericIMUSensor{12};
+    const int nrChannelsInYARPGenericCartesianWrench{6};
+    const int nrChannelsInYARPAnalogSixAxisFTSensor{6};
+
+    SensorBridgeMetaData metaData; /**< struct holding meta data **/
+    bool bridgeInitialized{false}; /**< flag set to true if the bridge is successfully initialized */
+    bool driversAttached{false}; /**< flag set to true if the bridge is successfully attached to required device drivers */
+    bool sensorDryRunEnabled{false}; /**< flag to enable running a test stream of sensor interfaces after attaching to the device drivers */
+
+
+    using SubConfigLoader = bool (YarpSensorBridge::Impl::*)(std::weak_ptr<IParametersHandler>,
+                                                             SensorBridgeMetaData&);
+
+    /**
+     * Checks is a stream is enabled in configuration and
+     * loads the relevant stream group from configuration
+     */
+    bool subConfigLoader(const std::string& enableStreamString,
+                         const std::string& streamGroupString,
+                         const SubConfigLoader loader,
+                         std::weak_ptr<IParametersHandler> handler,
+                         SensorBridgeMetaData& metaData,
+                         bool& enableStreamFlag)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::subConfigLoader] ";
+
+        auto ptr = handler.lock();
+        if (ptr == nullptr)
+        {
+            std::cerr << logPrefix << "The handler is not pointing to an already initialized memory."
+                      << std ::endl;
+            return false;
+        }
+
+        int success;
+        if (ptr->getParameter(enableStreamString, success))
+        {
+            enableStreamFlag = static_cast<bool>(success);
+            if (enableStreamFlag)
+            {
+                auto groupHandler = ptr->getGroup(streamGroupString);
+                if (! (this->*loader)(groupHandler, metaData) )
+                {
+                    std::cerr << logPrefix << streamGroupString << " group could not be initialized from the configuration file."
+                              << std ::endl;
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Configure remote control board remapper meta data
+     * Related to kinematics and other joint/motor relevant quantities
+     */
+    bool configureRemoteControlBoardRemapper(std::weak_ptr<IParametersHandler> handler,
+                                             SensorBridgeMetaData& metaData)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::configureRemoteControlBoardRemapper] ";
+        auto ptr = handler.lock();
+        if (ptr == nullptr) { return false; }
+
+        if (!ptr->getParameter("joints_list", metaData.sensorsList.jointsList, VectorResizeMode::Resizable))
+        {
+            std::cerr << logPrefix << " Required parameter \"joints_list\" not available in the configuration"
+                      << std::endl;
+            return false;
+        }
+
+        metaData.bridgeOptions.nrJoints = metaData.sensorsList.jointsList.size();
+        return true;
+    }
+
+    /**
+     * Configure inertial sensors meta data
+     */
+    bool configureInertialSensors(std::weak_ptr<IParametersHandler> handler,
+                                  SensorBridgeMetaData& metaData)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::configureInertialSensors] ";
+        auto ptr = handler.lock();
+        if (ptr == nullptr) { return false; }
+
+        if (ptr->getParameter("imu_list", metaData.sensorsList.IMUsList, VectorResizeMode::Resizable))
+        {
+            metaData.bridgeOptions.isIMUEnabled = true;
+        }
+
+        if (ptr->getParameter("accelerometer_list", metaData.sensorsList.linearAccelerometersList, VectorResizeMode::Resizable))
+        {
+            metaData.bridgeOptions.isLinearAccelerometerEnabled = true;
+        }
+
+        if (ptr->getParameter("gyroscopes_list", metaData.sensorsList.gyroscopesList, VectorResizeMode::Resizable))
+        {
+            metaData.bridgeOptions.isGyroscopeEnabled = true;
+        }
+
+        if (ptr->getParameter("orientation_sensors_list", metaData.sensorsList.orientationSensorsList, VectorResizeMode::Resizable))
+        {
+            metaData.bridgeOptions.isOrientationSensorEnabled = true;
+        }
+
+        if (ptr->getParameter("magnetometers_list", metaData.sensorsList.magnetometersList, VectorResizeMode::Resizable))
+        {
+            metaData.bridgeOptions.isMagnetometerEnabled = true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Configure six axis force torque sensors meta data
+     */
+    bool configureSixAxisForceTorqueSensors(std::weak_ptr<IParametersHandler> handler,
+                                            SensorBridgeMetaData& metaData)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::configureSixAxisForceTorqueSensors] ";
+        auto ptr = handler.lock();
+        if (ptr == nullptr) { return false; }
+
+        if (!ptr->getParameter("sixaxis_forcetorque_sensors_list", metaData.sensorsList.sixAxisForceTorqueSensorsList, VectorResizeMode::Resizable))
+        {
+            std::cerr << logPrefix << " Required parameter \"sixaxis_forcetorque_sensors_list\" not available in the configuration"
+                      << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Configure cartesian wrenches meta data
+     */
+    bool configureCartesianWrenches(std::weak_ptr<IParametersHandler> handler,
+                                    SensorBridgeMetaData& metaData)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::configureCartesianWrenchSensors] ";
+        auto ptr = handler.lock();
+        if (ptr == nullptr) { return false; }
+
+        if (!ptr->getParameter("cartesian_wrenches_list", metaData.sensorsList.cartesianWrenchesList, VectorResizeMode::Resizable))
+        {
+            std::cerr << logPrefix << " Required parameter \"cartesian_wrenches_list\" not available in the configuration"
+                      << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Configure cameras meta data
+     */
+    bool configureCameras(std::weak_ptr<IParametersHandler> handler,
+                          SensorBridgeMetaData& metaData)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::configureCameras] ";
+        auto ptr = handler.lock();
+        if (ptr == nullptr) { return false; }
+
+        if (ptr->getParameter("rgb_cameras_list", metaData.sensorsList.rgbCamerasList, VectorResizeMode::Resizable))
+        {
+            metaData.bridgeOptions.isCameraEnabled = true;
+
+            std::vector<int> rgbWidth, rgbHeight;
+            if (ptr->getParameter("rgb_image_width", rgbWidth, VectorResizeMode::Resizable))
+            {
+                std::cerr << logPrefix << " Required parameter \"rgb_image_width\" not available in the configuration"
+                      << std::endl;
+                return false;
+            }
+
+            if (ptr->getParameter("rgb_image_height", rgbHeight, VectorResizeMode::Resizable))
+            {
+                std::cerr << logPrefix << " Required parameter \"rgb_image_height\" not available in the configuration"
+                      << std::endl;
+                return false;
+            }
+
+            if ( (rgbWidth.size() != metaData.sensorsList.rgbCamerasList.size()) ||
+                (rgbHeight.size() != metaData.sensorsList.rgbCamerasList.size()) )
+            {
+                std::cerr << logPrefix << " Parameters list size mismatch" << std::endl;
+                return false;
+            }
+
+            for (int idx = 0; idx < rgbHeight.size(); idx++)
+            {
+                std::pair<int, int> imgDimensions(rgbWidth[idx], rgbHeight[idx]);
+                auto cameraName{metaData.sensorsList.rgbCamerasList[idx]};
+                metaData.bridgeOptions.imgDimensions[cameraName] = imgDimensions;
+            }
+        }
+
+        if (ptr->getParameter("depth_cameras_list", metaData.sensorsList.depthCamerasList, VectorResizeMode::Resizable))
+        {
+            metaData.bridgeOptions.isCameraEnabled = true;
+
+            std::vector<int> depthCamWidth, depthCamHeight;
+            if (ptr->getParameter("depth_image_width", depthCamWidth, VectorResizeMode::Resizable))
+            {
+                std::cerr << logPrefix << " Required parameter \"depth_image_width\" not available in the configuration"
+                          << std::endl;
+                return false;
+            }
+
+            if (ptr->getParameter("depth_image_height", depthCamHeight, VectorResizeMode::Resizable))
+            {
+                std::cerr << logPrefix << " Required parameter \"depth_image_height\" not available in the configuration"
+                          << std::endl;
+                return false;
+            }
+
+            if ( (depthCamWidth.size() != metaData.sensorsList.depthCamerasList.size()) ||
+                (depthCamHeight.size() != metaData.sensorsList.depthCamerasList.size()) )
+            {
+                std::cerr << logPrefix << " Parameters list size mismatch" << std::endl;
+                return false;
+            }
+
+            for (int idx = 0; idx < depthCamHeight.size(); idx++)
+            {
+                std::pair<int, int> imgDimensions(depthCamWidth[idx], depthCamHeight[idx]);
+                auto cameraName{metaData.sensorsList.depthCamerasList[idx]};
+                metaData.bridgeOptions.imgDimensions[cameraName] = imgDimensions;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Attach device with IGenericSensor or IAnalogSensor interfaces
+     * Important assumptions here,
+     * - Any generic sensor with 12 channels is a IMU sensor
+     * - Any generic sensor with 6 channels is a cartesian wrench sensor
+     * - Any analog sensor with 6 channels is a six axis force torque sensor
+     */
+    template <typename SensorType>
+    bool attachGenericOrAnalogSensor(const yarp::dev::PolyDriverList& devList,
+                                     const std::string& sensorName,
+                                     const int& nrChannelsInSensor,
+                                     std::unordered_map<std::string, SensorType*>& sensorMap)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachGenericOrAnalogSensor] ";
+        for (int devIdx = 0; devIdx < devList.size(); devIdx++)
+        {
+            if (sensorName != devList[devIdx]->key)
+            {
+                continue;
+            }
+
+            SensorType* sensorInterface{nullptr};
+            if (devList[devIdx]->poly->view(sensorInterface))
+            {
+                if (sensorInterface == nullptr)
+                {
+                    std::cerr << logPrefix << sensorName << " Could not view interface." << std::endl;
+                    return false;
+                }
+
+                int nrChannels;
+                if constexpr (std::is_same_v<SensorType, yarp::dev::IAnalogSensor>)
+                {
+                    nrChannels = sensorInterface->getChannels();
+                }
+                else if constexpr (std::is_same_v<SensorType, yarp::dev::IGenericSensor>)
+                {
+                    sensorInterface->getChannels(&nrChannels);
+                }
+
+                if (nrChannels != nrChannelsInSensor)
+                {
+                    std::cerr << logPrefix << sensorName << " Mismatch in the expected number of channels in the sensor stream." << std::endl;
+                    return false;
+                }
+
+                sensorMap[devList[devIdx]->key] = sensorInterface;
+            }
+            else
+            {
+                std::cerr << logPrefix << sensorName << " Could not view interface." << std::endl;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template <typename SensorType>
+    bool attachAllGenericOrAnalogSensors(const yarp::dev::PolyDriverList& devList,
+                                         std::unordered_map<std::string, SensorType*>& sensorMap,
+                                         const int& nrChannelsInSensor,
+                                         const std::vector<std::string>& sensorList,
+                                         std::string_view interfaceType)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachAllGenericOrAnalogSensors] ";
+
+        bool allSensorsAttachedSuccesful{true};
+        for (auto genericSensorCartesianWrench : sensorList)
+        {
+            if (!attachGenericOrAnalogSensor(devList,
+                                             genericSensorCartesianWrench,
+                                             nrChannelsInSensor,
+                                             sensorMap))
+            {
+                allSensorsAttachedSuccesful = false;
+                break;
+            }
+        }
+
+        if (!allSensorsAttachedSuccesful ||
+            (sensorMap.size() != sensorList.size()) )
+        {
+            std::cerr << logPrefix << " Could not attach all desired " << interfaceType << " ." << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Attach Remapped Multiple Analog Sensor Interfaces and check available sensors
+     */
+    template <typename MASSensorType>
+    bool attachAndCheckMASSensors(const yarp::dev::PolyDriverList& devList,
+                                  MASSensorType* sensorInterface,
+                                  const std::vector<std::string>& sensorList,
+                                  const std::string_view interfaceName)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachAndCheckMASSensors] ";
+        if (!attachRemappedMASSensor(devList, sensorInterface))
+        {
+            std::cerr << logPrefix << " Could not find " << interfaceName << " interface." << std::endl;
+            return false;
+        }
+
+        if (!checkAttachedMASSensors(devList, sensorInterface, sensorList))
+        {
+            std::cerr << logPrefix << " Could not find atleast one of the required sensors." << std::endl;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Attach Remapped Multiple Analog Sensor Interfaces
+     * Looks for a specific MAS Sensor interface in the attached MAS Remapper
+     */
+    template <typename MASSensorType>
+    bool attachRemappedMASSensor(const yarp::dev::PolyDriverList& devList,
+                                 MASSensorType* masSensorInterface)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachRemappedMASSensor] ";
+        bool broken{false};
+        for (int devIdx = 0; devIdx < devList.size(); devIdx++)
+        {
+            MASSensorType* sensorInterface{nullptr};
+            devList[devIdx]->poly->view(sensorInterface);
+            if (sensorInterface == nullptr)
+            {
+                continue;
+            }
+
+            // break out of the loop if we find relevant MAS interface
+            masSensorInterface = sensorInterface;
+            broken = true;
+            break;
+        }
+
+        if (!broken || masSensorInterface == nullptr)
+        {
+            std::cerr << logPrefix << " Could not view interface." << std::endl;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Check if all the desired MAS sensors are availabled in the attached MAS interface
+     */
+    template <typename MASSensorType>
+    bool checkAttachedMASSensors(const yarp::dev::PolyDriverList& devList,
+                                 MASSensorType* sensorInterface,
+                                 const std::vector<std::string>& sensorList)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::checkAttachedMASSensors] ";
+
+        auto nrSensors{getNumberOfMASSensors(sensorInterface)};
+        if (nrSensors != sensorList.size())
+        {
+            std::cerr << logPrefix << "Expecting the same number of MAS sensors attached to the Bridge as many mentioned in the initialization step" << std::endl;
+            return false;
+        }
+
+        for (const auto& masSensorName : sensorList)
+        {
+            bool sensorFound{false};
+            for (size_t attachedIdx = 0; attachedIdx < nrSensors; attachedIdx++)
+            {
+                std::string attachedSensorName;
+                if (!getMASSensorName(sensorInterface, attachedIdx, attachedSensorName))
+                {
+                    continue;
+                }
+
+                if (attachedSensorName == masSensorName)
+                {
+                    sensorFound = true;
+                    break;
+                }
+            }
+
+            if (!sensorFound)
+            {
+                 std::cerr << logPrefix << "Bridge could not attach to MAS Sensor " << masSensorName << "." << std::endl;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     *  Get number of MAS Sensors
+     */
+    template <typename MASSensorType>
+    size_t getNumberOfMASSensors(MASSensorType* sensorInterface)
+    {
+        if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisGyroscopes>)
+        {
+            return sensorInterface->getNrOfThreeAxisGyroscopes();
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisLinearAccelerometers>)
+        {
+            return sensorInterface->getNrOfThreeAxisLinearAccelerometers();
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisMagnetometers>)
+        {
+            return sensorInterface->getNrOfThreeAxisMagnetometers();
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IOrientationSensors>)
+        {
+            return sensorInterface->getNrOfOrientationSensors();
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::ISixAxisForceTorqueSensors>)
+        {
+            return sensorInterface->getNrOfSixAxisForceTorqueSensors();
+        }
+
+        return 0;
+    }
+
+    /**
+     *  Get name of MAS Sensors
+     */
+    template <typename MASSensorType>
+    bool getMASSensorName(MASSensorType* sensorInterface,
+                          const size_t& sensIdx,
+                          std::string& sensorName)
+    {
+        if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisGyroscopes>)
+        {
+            return sensorInterface->getThreeAxisGyroscopeName(sensIdx, sensorName);
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisLinearAccelerometers>)
+        {
+            return sensorInterface->getThreeAxisLinearAccelerometerName(sensIdx, sensorName);
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisMagnetometers>)
+        {
+            return sensorInterface->getThreeAxisMagnetometerName(sensIdx, sensorName);
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IOrientationSensors>)
+        {
+            return sensorInterface->getOrientationSensorName(sensIdx, sensorName);
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::ISixAxisForceTorqueSensors>)
+        {
+            return sensorInterface->getSixAxisForceTorqueSensorName(sensIdx, sensorName);
+        }
+        return true;
+    }
+
+    /**
+     * Get all sensor names in a MAS Inerface
+     */
+    template <typename MASSensorType>
+    std::vector<std::string> getAllSensorsInMASInterface(MASSensorType* sensorInterface)
+    {
+        std::vector<std::string> availableSensorNames;
+        if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisGyroscopes>)
+        {
+            auto nrSensors = sensorInterface->getNrOfThreeAxisGyroscopes();
+            for (size_t sensIdx = 0; sensIdx < nrSensors; sensIdx++)
+            {
+                std::string sensName;
+                sensorInterface->getThreeAxisGyroscopeName(sensIdx, sensName);
+                availableSensorNames.push_back(sensName);
+            }
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisLinearAccelerometers>)
+        {
+            auto nrSensors = sensorInterface->getNrOfThreeAxisLinearAccelerometers();
+            for (size_t sensIdx = 0; sensIdx < nrSensors; sensIdx++)
+            {
+                std::string sensName;
+                sensorInterface->getThreeAxisLinearAccelerometerName(sensIdx, sensName);
+                availableSensorNames.push_back(sensName);
+            }
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IThreeAxisMagnetometers>)
+        {
+            auto nrSensors = sensorInterface->getNrOfThreeAxisMagnetometers();
+            for (size_t sensIdx = 0; sensIdx < nrSensors; sensIdx++)
+            {
+                std::string sensName;
+                sensorInterface->getThreeAxisMagnetometerName(sensIdx, sensName);
+                availableSensorNames.push_back(sensName);
+            }
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::IOrientationSensors>)
+        {
+            auto nrSensors = sensorInterface->getNrOfOrientationSensors();
+            for (size_t sensIdx = 0; sensIdx < nrSensors; sensIdx++)
+            {
+                std::string sensName;
+                sensorInterface->getOrientationSensorName(sensIdx, sensName);
+                availableSensorNames.push_back(sensName);
+            }
+        }
+        else if constexpr (std::is_same_v<MASSensorType, yarp::dev::ISixAxisForceTorqueSensors>)
+        {
+            auto nrSensors = sensorInterface->getNrOfSixAxisForceTorqueSensors();
+            for (size_t sensIdx = 0; sensIdx < nrSensors; sensIdx++)
+            {
+                std::string sensName;
+                sensorInterface->getSixAxisForceTorqueSensorName(sensIdx, sensName);
+                availableSensorNames.push_back(sensName);
+            }
+        }
+        return availableSensorNames;
+    }
+
+    /**
+     * Attach cameras
+     */
+    template <typename CameraType>
+    bool attachCamera(const yarp::dev::PolyDriverList& devList,
+                      const std::string sensorName,
+                      std::unordered_map<std::string, CameraType* >& sensorMap)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachCamera] ";
+        for (int devIdx = 0; devIdx < devList.size(); devIdx++)
+        {
+            if (sensorName != devList[devIdx]->key)
+            {
+                continue;
+            }
+
+            CameraType* cameraInterface{nullptr};
+            if (devList[devIdx]->poly->view(cameraInterface))
+            {
+                if (cameraInterface == nullptr)
+                {
+                    std::cerr << logPrefix << " Could not view interface." << std::endl;
+                    return false;
+                }
+                sensorMap[devList[devIdx]->key] = cameraInterface;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check if sensor is available in the relevant sensor map
+     */
+    template <typename SensorType>
+    bool checkSensor(const std::unordered_map<std::string, SensorType* >& sensorMap,
+                     const std::string& sensorName)
+    {
+        if (sensorMap.find(sensorName) == sensorMap.end())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the bridge is successfully initialized and attached to required device drivers
+     */
+    bool checkValid(const std::string_view methodName)
+    {
+        if (!(bridgeInitialized && driversAttached))
+        {
+            std::cerr << methodName << " SensorBridge is not ready. Please initialize and set drivers list.";
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     *  Attach generic IMU sensor types and MAS inertials
+     */
+    bool attachAllInertials(const yarp::dev::PolyDriverList& devList)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachAllInertials] ";
+        if (metaData.bridgeOptions.isIMUEnabled)
+        {
+            // check if a generic sensor has 12 channels implying it is a IMU sensor through a GenericSensor Interfaces
+            std::string_view interfaceType{"Generic IMU Interface"};
+            if (!attachAllGenericOrAnalogSensors(devList,
+                                                 wholeBodyAnalogIMUInterface,
+                                                 nrChannelsInYARPGenericIMUSensor,
+                                                 metaData.sensorsList.IMUsList,
+                                                 interfaceType))
+            {
+                return false;
+            }
+        }
+
+        if (metaData.bridgeOptions.isLinearAccelerometerEnabled)
+        {
+            std::string_view interfaceType{"IThreeAxisLinearAccelerometers"};
+            if (!attachAndCheckMASSensors(devList, wholeBodyMASInertialsInterface.accelerometers, metaData.sensorsList.linearAccelerometersList, interfaceType))
+            {
+                return false;
+            }
+        }
+
+        if (metaData.bridgeOptions.isGyroscopeEnabled)
+        {
+            std::string_view interfaceType{"IThreeAxisGyroscopes"};
+            if (!attachAndCheckMASSensors(devList, wholeBodyMASInertialsInterface.gyroscopes, metaData.sensorsList.gyroscopesList, interfaceType))
+            {
+                return false;
+            }
+        }
+
+        if (metaData.bridgeOptions.isOrientationSensorEnabled)
+        {
+            std::string_view interfaceType{"IOrientationSensors"};
+            if (!attachAndCheckMASSensors(devList, wholeBodyMASInertialsInterface.orientationSensors, metaData.sensorsList.orientationSensorsList, interfaceType))
+            {
+                return false;
+            }
+        }
+
+        if (metaData.bridgeOptions.isMagnetometerEnabled)
+        {
+            std::string_view interfaceType{"IThreeAxisMagnetometers"};
+            if (!attachAndCheckMASSensors(devList, wholeBodyMASInertialsInterface.magnetometers, metaData.sensorsList.magnetometersList, interfaceType))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Attach a remapped control board and check the availability of desired interface
+     * Further, resize joint data buffers and check if
+     * the control board joints list and the desired joints list match
+     * Also, maintain a remapping index buffer for adapting to arbitrary joint list serializations
+     */
+    bool attachRemappedRemoteControlBoard(const yarp::dev::PolyDriverList& devList)
+    {
+        if (!metaData.bridgeOptions.isKinematicsEnabled)
+        {
+            // do nothing
+            return true;
+        }
+
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachRemappedRemoteControlBoard] ";
+        // expects only one remotecontrolboard device attached to it, if found break!
+        // if there multiple remote control boards, then  use a remapper to create a single remotecontrolboard
+        bool ok{true};
+        for (int devIdx = 0; devIdx < devList.size(); devIdx++)
+        {
+            ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.axis);
+            ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.encoders);
+            if (ok)
+            {
+                break;
+            }
+        }
+
+        if (!ok)
+        {
+            std::cerr << logPrefix << " Could not find a remapped remote control board with the desired interfaces" << std::endl;
+            return false;
+        }
+
+        resetControlBoardBuffers();
+        if (!compareControlBoardJointsList())
+        {
+            std::cerr << logPrefix << " Could not attach to remapped control board interface" << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * resize and set control board buffers to zero
+     */
+    void resetControlBoardBuffers()
+    {
+        // firstly resize all the controlboard data buffers
+        controlBoardRemapperMeasures.remappedJointIndices.resize(metaData.bridgeOptions.nrJoints);
+        controlBoardRemapperMeasures.jointPositions.resize(metaData.bridgeOptions.nrJoints);
+        controlBoardRemapperMeasures.jointVelocities.resize(metaData.bridgeOptions.nrJoints);
+
+        // zero buffers
+        controlBoardRemapperMeasures.remappedJointIndices.setZero();
+        controlBoardRemapperMeasures.jointPositions.setZero();
+        controlBoardRemapperMeasures.jointVelocities.setZero();
+    }
+
+    /**
+     * check and match control board joints with the sensorbridge joints list
+     */
+    bool compareControlBoardJointsList()
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::compareControlBoardJointsList] ";
+        // get the names of all the joints available in the attached remote control board remapper
+        std::vector<std::string> controlBoardJoints;
+        int controlBoardDOFs;
+        controlBoardRemapperInterfaces.encoders->getAxes(&controlBoardDOFs);
+        for (int DOF = 0; DOF < controlBoardDOFs; DOF++)
+        {
+            std::string joint;
+            controlBoardRemapperInterfaces.axis->getAxisName(DOF, joint);
+            controlBoardJoints.push_back(joint);
+        }
+
+        // check if the joints in the desired joint list are available in the controlboard joints list
+        // if available get the control board index at which the desired joint is available
+        // this is required in order to remap the control board joints on to the desired joints
+        // this needs to be optimized with better STL algorithms
+        bool jointFound{false};
+        for (int desiredDOF = 0; desiredDOF < metaData.sensorsList.jointsList.size(); desiredDOF++)
+        {
+            jointFound = false;
+            for (int DOF = 0; DOF < controlBoardDOFs; DOF++)
+            {
+                if (metaData.sensorsList.jointsList[desiredDOF] == controlBoardJoints[DOF])
+                {
+                    controlBoardRemapperMeasures.remappedJointIndices[desiredDOF] = DOF;
+                    jointFound = true;
+                    break;
+                }
+            }
+
+            if (!jointFound)
+            {
+                std::cerr << logPrefix << " Could not find a desired joint from the configuration in the attached control board remapper." << std::endl;
+                return false;
+            }
+        }
+
+        if (!jointFound)
+        {
+            return false;
+        }
+
+        std::cout << logPrefix << "Found all joints with the remapped index " << std::endl;
+        for (int idx =0; idx < controlBoardRemapperMeasures.remappedJointIndices.size(); idx++)
+        {
+            std::cout << logPrefix << "Remapped Index: " << controlBoardRemapperMeasures.remappedJointIndices[idx]
+                                   << " , Joint name:  " << controlBoardJoints[controlBoardRemapperMeasures.remappedJointIndices[idx]]
+                                   << std::endl;
+        }
+        return true;
+    }
+
+    bool attachAllSixAxisForceTorqueSensors(const yarp::dev::PolyDriverList& devList)
+    {
+        if (!metaData.bridgeOptions.isSixAxisForceTorqueSensorEnabled)
+        {
+            // do nothing
+            return true;
+        }
+
+        std::vector<std::string> analogFTSensors;
+        // attach MAS sensors
+        if (attachRemappedMASSensor(devList,
+                                    wholeBodyMASForceTorquesInterface.sixAxisFTSensors))
+        {
+            // get MAS FT sensor names
+            auto MASFTs = getAllSensorsInMASInterface(wholeBodyMASForceTorquesInterface.sixAxisFTSensors);
+            auto copySensorsList = metaData.sensorsList.sixAxisForceTorqueSensorsList;
+
+            // compare with sensorList - those not available in the MAS interface list
+            // are assumed to be analog FT sensors
+            std::sort(MASFTs.begin(), MASFTs.end());
+            std::sort(copySensorsList.begin(), copySensorsList.end());
+            std::set_intersection(MASFTs.begin(), MASFTs.end(),
+                                  copySensorsList.begin(), copySensorsList.end(),
+                                  std::back_inserter(analogFTSensors));
+        }
+        else
+        {
+            // if there are no MAS FT sensors then all the FT sensors in the configuration
+            // are analog FT sensors
+            analogFTSensors = metaData.sensorsList.sixAxisForceTorqueSensorsList;
+        }
+
+        // check if a generic sensor has 12 channels implying it is a IMU sensor through a GenericSensor Interfaces
+        std::string_view interfaceType{"Analog Six Axis FT Interface"};
+        if (!attachAllGenericOrAnalogSensors(devList,
+                                             wholeBodyAnalogSixAxisFTSensorsInterface,
+                                             nrChannelsInYARPAnalogSixAxisFTSensor,
+                                             analogFTSensors,
+                                             interfaceType))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Attach to cartesian wrench interface
+     */
+    bool attachCartesianWrenchInterface(const yarp::dev::PolyDriverList& devList)
+    {
+        if (!metaData.bridgeOptions.isCartesianWrenchEnabled)
+        {
+            // do nothing
+            return true;
+        }
+
+        if (metaData.bridgeOptions.isCartesianWrenchEnabled)
+        {
+            // check if a generic sensor has 6 channels implying it is a cartesian wrench sensor through a GenericSensor Interfaces
+            std::string_view interfaceType{"Cartesian Wrench Interface"};
+            if (!attachAllGenericOrAnalogSensors(devList,
+                                                 wholeBodyCartesianWrenchInterface,
+                                                 nrChannelsInYARPGenericCartesianWrench,
+                                                 metaData.sensorsList.cartesianWrenchesList,
+                                                 interfaceType))
+            {
+                return false;
+            }
+
+        }
+        return true;
+    }
+
+    /**
+     * Attach all cameras
+     */
+    bool attachAllCameras(const yarp::dev::PolyDriverList& devList)
+    {
+        if (!metaData.bridgeOptions.isCameraEnabled)
+        {
+            // do nothing
+            return true;
+        }
+
+        std::string_view interfaceType{"RGB Cameras"};
+        if (!attachAllCamerasOfSpecificType(devList,
+                                            metaData.sensorsList.rgbCamerasList,
+                                            metaData.bridgeOptions.imgDimensions,
+                                            interfaceType,
+                                            wholeBodyFrameGrabberInterface,
+                                            wholeBodyCameraImages))
+        {
+            return false;
+        }
+
+        std::string_view interfaceTypeDepth = "Depth Cameras";
+        if (!attachAllCamerasOfSpecificType(devList,
+                                            metaData.sensorsList.depthCamerasList,
+                                            metaData.bridgeOptions.imgDimensions,
+                                            interfaceTypeDepth,
+                                            wholeBodyRGBDInterface,
+                                            wholeBodyCameraImages))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Attach all cameras of specific type and resize image buffers
+     */
+    template <typename CameraType>
+    bool attachAllCamerasOfSpecificType(const yarp::dev::PolyDriverList& devList,
+                                        const std::vector<std::string>& camList,
+                                        const std::unordered_map<std::string, std::pair<int, int> >& imgDimensionsMap,
+                                        std::string_view interfaceType,
+                                        std::unordered_map<std::string, CameraType* >& sensorMap,
+                                        std::unordered_map<std::string, Eigen::MatrixXd>& imgBuffersMap)
+    {
+        constexpr std::string_view logPrefix = "[YarpSensorBridge::Impl::attachAllCamerasOfSpecificType] ";
+        for (auto cam : camList)
+        {
+            if (!attachCamera(devList, cam, sensorMap))
+            {
+                return false;
+            }
+        }
+
+        if (sensorMap.size() != camList.size())
+        {
+            std::cout << logPrefix << " could not attach all desired rgb cameras " << interfaceType  << "." << std::endl;
+            return false;
+        }
+
+        if (!resizeImageBuffers(camList,
+                                imgDimensionsMap,
+                                imgBuffersMap))
+        {
+            std::cout << logPrefix << " Failed to resize camera buffers of type " << interfaceType  << "." << std::endl;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Resize image buffers
+     */
+    bool resizeImageBuffers(const std::vector<std::string>& camList,
+                            const std::unordered_map<std::string, std::pair<int, int> >& imgDimensionsMap,
+                            std::unordered_map<std::string, Eigen::MatrixXd>& imgBuffersMap)
+    {
+        for (const auto& cam : camList)
+        {
+            auto iter = imgDimensionsMap.find(cam);
+            if (iter == imgDimensionsMap.end())
+            {
+                return false;
+            }
+
+            auto imgDim = iter->second;
+            imgBuffersMap[cam].resize(imgDim.first, imgDim.second);
+        }
+        return true;
+    }
+};
+
+}
+}
+#endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_IMPL_H
+
+

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -176,13 +176,13 @@ bool YarpSensorBridge::getRGBCamerasList(std::vector<std::string>& rgbCamerasLis
     return true;
 }
 
-bool YarpSensorBridge::getDepthCamerasList(std::vector<std::string>& depthCamerasList)
+bool YarpSensorBridge::getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList)
 {
-    if (!m_pimpl->checkValid("[YarpSensorBridge::getDepthCamerasList]"))
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getRGBDCamerasList]"))
     {
         return false;
     }
-    depthCamerasList = m_pimpl->metaData.sensorsList.depthCamerasList;
+    rgbdCamerasList = m_pimpl->metaData.sensorsList.rgbdCamerasList;
     return true;
 }
 

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -1,0 +1,312 @@
+/**
+ * @file YarpSensorBridge.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h>
+
+
+YarpSensorBridge::YarpSensorBridge() : m_pimpl(std::make_unique<Impl>())
+{
+};
+
+YarpSensorBridge::~YarpSensorBridge() = default;
+
+bool YarpSensorBridge::initialize(std::weak_ptr<IParametersHandler> handler)
+{
+    constexpr std::string_view errorPrefix = "[YarpSensorBridge::initialize] ";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        std::cerr << errorPrefix << "The handler is not pointing to an already initialized memory."
+                  << std ::endl;
+        return false;
+    }
+
+    int temp;
+    ptr->getParameter("sensor_dry_run", temp);
+    m_pimpl->sensorDryRunEnabled = static_cast<bool>(temp);
+
+    bool ret{true};
+    ret = ret && m_pimpl->subConfigLoader("stream_joint_states", "RemoteControlBoardRemapper",
+                                          &YarpSensorBridge::Impl::configureRemoteControlBoardRemapper,
+                                          handler,
+                                          m_pimpl->metaData,
+                                          m_pimpl->metaData.bridgeOptions.isKinematicsEnabled);
+
+    bool useInertialSensors{false};
+    ret = ret && m_pimpl->subConfigLoader("stream_inertials", "InertialSensors",
+                                          &YarpSensorBridge::Impl::configureInertialSensors,
+                                          handler,
+                                          m_pimpl->metaData,
+                                          useInertialSensors);
+
+    ret = ret && m_pimpl->subConfigLoader("stream_forcetorque_sensors", "SixAxisForceTorqueSensors",
+                                          &YarpSensorBridge::Impl::configureSixAxisForceTorqueSensors,
+                                          handler,
+                                          m_pimpl->metaData,
+                                          m_pimpl->metaData.bridgeOptions.isSixAxisForceTorqueSensorEnabled);
+
+    ret = ret && m_pimpl->subConfigLoader("stream_cartesian_wrenches", "CartesianWrenches",
+                                          &YarpSensorBridge::Impl::configureCartesianWrenches,
+                                          handler,
+                                          m_pimpl->metaData,
+                                          m_pimpl->metaData.bridgeOptions.isCartesianWrenchEnabled);
+
+    bool useCameras{false};
+    ret = ret && m_pimpl->subConfigLoader("stream_cameras", "Cameras",
+                                          &YarpSensorBridge::Impl::configureCameras,
+                                          handler,
+                                          m_pimpl->metaData,
+                                          useCameras);
+
+
+    m_pimpl->bridgeInitialized = true;
+    return true;
+}
+
+bool YarpSensorBridge::setDriversList(const yarp::dev::PolyDriverList& deviceDriversList)
+{
+    m_pimpl->driversAttached = true;
+    return true;
+}
+
+bool YarpSensorBridge::advance()
+{
+    return true;
+}
+
+bool YarpSensorBridge::isValid() const
+{
+    return m_pimpl->checkValid("[YarpSensorBridge::isValid]");
+}
+
+const SensorBridgeMetaData& YarpSensorBridge::get() const { return m_pimpl->metaData; }
+
+bool YarpSensorBridge::getJointsList(std::vector<std::string>& jointsList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getJointsList]"))
+    {
+        return false;
+    }
+    jointsList = m_pimpl->metaData.sensorsList.jointsList;
+    return true;
+}
+
+bool YarpSensorBridge::getIMUsList(std::vector<std::string>& IMUsList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getIMUsList]"))
+    {
+        return false;
+    }
+    IMUsList = m_pimpl->metaData.sensorsList.IMUsList;
+    return true;
+}
+
+bool YarpSensorBridge::getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getLinearAccelerometersList]"))
+    {
+        return false;
+    }
+    linearAccelerometersList = m_pimpl->metaData.sensorsList.linearAccelerometersList;
+    return true;
+}
+
+bool YarpSensorBridge::getGyroscopesList(std::vector<std::string>& gyroscopesList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getGyroscopesList]"))
+    {
+        return false;
+    }
+    gyroscopesList = m_pimpl->metaData.sensorsList.gyroscopesList;
+    return true;
+}
+
+bool YarpSensorBridge::getOrientationSensorsList(std::vector<std::string>& orientationSensorsList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getOrientationSensorsList]"))
+    {
+        return false;
+    }
+    orientationSensorsList = m_pimpl->metaData.sensorsList.orientationSensorsList;
+    return true;
+}
+
+bool YarpSensorBridge::getMagnetometersList(std::vector<std::string>& magnetometersList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getMagnetometersList]"))
+    {
+        return false;
+    }
+    magnetometersList = m_pimpl->metaData.sensorsList.magnetometersList;
+    return true;
+}
+
+bool YarpSensorBridge::getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getSixAxisForceTorqueSensorsList]"))
+    {
+        return false;
+    }
+    sixAxisForceTorqueSensorsList = m_pimpl->metaData.sensorsList.sixAxisForceTorqueSensorsList;
+    return true;
+}
+
+bool YarpSensorBridge::getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getCartesianWrenchesList]"))
+    {
+        return false;
+    }
+    cartesianWrenchesList = m_pimpl->metaData.sensorsList.cartesianWrenchesList;
+    return true;
+}
+
+bool YarpSensorBridge::getRGBCamerasList(std::vector<std::string>& rgbCamerasList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getRGBCamerasList]"))
+    {
+        return false;
+    }
+    rgbCamerasList = m_pimpl->metaData.sensorsList.rgbCamerasList;
+    return true;
+}
+
+bool YarpSensorBridge::getDepthCamerasList(std::vector<std::string>& depthCamerasList)
+{
+    if (!m_pimpl->checkValid("[YarpSensorBridge::getDepthCamerasList]"))
+    {
+        return false;
+    }
+    depthCamerasList = m_pimpl->metaData.sensorsList.depthCamerasList;
+    return true;
+}
+
+bool YarpSensorBridge::getJointPosition(const std::string& jointName,
+                                        double& jointPosition,
+                                        double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
+                                         double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getJointVelocity(const std::string& jointName,
+                                        double& jointVelocity,
+                                        double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+
+bool YarpSensorBridge::getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
+                                          double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getIMUMeasurement(const std::string& imuName,
+                                         Eigen::Ref<Vector12d> imuMeasurement,
+                                         double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getLinearAccelerometerMeasurement(const std::string& accName,
+                                                         Eigen::Ref<Eigen::Vector3d> accMeasurement,
+                                                         double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getGyroscopeMeasure(const std::string& gyroName,
+                                           Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
+                                           double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+
+bool YarpSensorBridge::getOrientationSensorMeasurement(const std::string& rpyName,
+                                                       Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
+                                                       double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getMagnetometerMeasurement(const std::string& magName,
+                                                  Eigen::Ref<Eigen::Vector3d> magMeasurement,
+                                                  double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getSixAxisForceTorqueMeasurement(const std::string& ftName,
+                                                        Eigen::Ref<Vector6d> ftMeasurement,
+                                                        double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getCartesianWrench(const std::string& cartesianWrenchName,
+                                          Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
+                                          double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getColorImage(const std::string& camName,
+                                     Eigen::Ref<Eigen::MatrixXd> colorImg,
+                                     double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::getDepthImage(const std::string& camName,
+                                     Eigen::Ref<Eigen::MatrixXd> depthImg,
+                                     double* receiveTimeInSeconds)
+{
+    return true;
+}
+
+bool YarpSensorBridge::populateSensorBridgeOptionsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                                             SensorBridgeOptions& sensorBridgeOptions)
+{
+    constexpr std::string_view error = "[YarpSensorBridge::populateSensorBridgeOptionsFromConfig] Unused method.";
+    std::cerr << error <<  std::endl;
+    return false;
+}
+
+bool YarpSensorBridge::populateSensorListsFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                                     const SensorBridgeOptions& sensorBridgeOptions,
+                                                     SensorLists& sensorLists)
+{
+    constexpr std::string_view error = "[YarpSensorBridge::populateSensorListsFromConfig] Unused method.";
+    std::cerr << error <<  std::endl;
+    return false;
+}
+
+bool YarpSensorBridge::getThreeAxisForceTorqueMeasurement(const std::string& ftName,
+                                                          Eigen::Ref<Eigen::Vector3d> ftMeasurement,
+                                                          double* receiveTimeInSeconds)
+{
+    constexpr std::string_view error = "[YarpSensorBridge::getThreeAxisForceTorqueMeasurement] Currently unimplemented";
+    std::cerr << error <<  std::endl;
+    return false;
+}
+
+bool YarpSensorBridge::getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList)
+{
+    constexpr std::string_view error = "[YarpSensorBridge::getThreeAxisForceTorqueSensorsList] Currently unimplemented";
+    std::cerr << error <<  std::endl;
+
+    return false;
+}

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -35,6 +35,7 @@ struct SensorBridgeOptions
     bool isIMUEnabled{false}; /**< flag to connect IMU measurement sources */
     bool isLinearAccelerometerEnabled{false}; /**< flag to connect linear accelerometer measurement sources */
     bool isGyroscopeEnabled{false}; /**< flag to connect gyroscope measurement sources */
+    bool isOrientationSensorEnabled{false}; /**< flag to connect gyroscope measurement sources */
     bool isMagnetometerEnabled{false}; /**< flag to connect magnetometer measurement sources */
     bool isSixAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
     bool isThreeAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
@@ -61,6 +62,17 @@ struct SensorLists
     std::vector<std::string> cartesianWrenchesList; /**< list of cartesian wrench streams attached to the bridge */
     std::vector<std::string> rgbCamerasList; /**< list of rgb cameras attached to the bridge */
     std::vector<std::string> depthCamerasList; /**< list of depth cameras attached to the bridge */
+};
+
+
+/**
+ * Meta data struct to hold list of sensors and configured options
+ * available from the Sensor bridge interface
+ */
+struct SensorBridgeMetaData
+{
+  SensorLists sensorsList;
+  SensorBridgeOptions bridgeOptions;
 };
 
 /**

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -99,77 +99,77 @@ public:
      * @param[out] jointsList list of joints attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getJointsList(std::vector<std::string>& jointsList) = 0;
+    virtual bool getJointsList(std::vector<std::string>& jointsList) { return false; };
 
     /**
      * Get imu sensors
      * @param[out] IMUsList list of IMUs attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getIMUsList(std::vector<std::string>& IMUsList) = 0;
+    virtual bool getIMUsList(std::vector<std::string>& IMUsList) { return false; };
 
     /**
      * Get linear accelerometers
      * @param[out] linearAccelerometersList list of linear accelerometers attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList) = 0;
+    virtual bool getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList) { return false; };
 
     /**
      * Get gyroscopes
      * @param[out] gyroscopesList list of gyroscopes attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getGyroscopesList(std::vector<std::string>& gyroscopesList) = 0;
+    virtual bool getGyroscopesList(std::vector<std::string>& gyroscopesList) { return false; };
 
     /**
      * Get orientation sensors
      * @param[out] orientationSensorsList list of orientation sensors attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getOrientationSensorsList(std::vector<std::string>& orientationSensorsList) = 0;
+    virtual bool getOrientationSensorsList(std::vector<std::string>& orientationSensorsList) { return false; };
 
     /**
      * Get magnetometers sensors
      * @param[out] magnetometersList list of magnetometers attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getMagnetometersList(std::vector<std::string>& magnetometersList) = 0;
+    virtual bool getMagnetometersList(std::vector<std::string>& magnetometersList) { return false; };
 
     /**
      * Get 6 axis FT sensors
      * @param[out] sixAxisForceTorqueSensorsList list of 6 axis force torque sensors attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList) = 0;
+    virtual bool getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList) { return false; };
 
     /**
      * Get 6 axis FT sensors
      * @param[out] threeAxisForceTorqueSensorsList list of 3 axis force torque sensors attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList) = 0;
+    virtual bool getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList) { return false; };
 
    /**
      * Get cartesian wrenches
      * @param[out] cartesianWrenchesList list of cartesian wrenches attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList) = 0;
+    virtual bool getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList) { return false; };
 
     /**
      * Get rgb cameras
      * @param[out] rgbCamerasList list of rgb cameras attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) = 0;
+    virtual bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) { return false; };
 
     /**
      * Get RGBD cameras
      * @param[out] rgbdCamerasList list of rgbd cameras attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList) = 0;
+    virtual bool getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList) { return false; };
 
     /**
      * Get joint position  in radians
@@ -180,7 +180,7 @@ public:
      */
     virtual bool getJointPosition(const std::string& jointName,
                                   double& jointPosition,
-                                  double* receiveTimeInSeconds = nullptr) = 0;
+                                  double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get all joints' positions in radians
@@ -194,7 +194,7 @@ public:
      * @return true/false in case of success/failure
      */
     virtual bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
-                                   double* receiveTimeInSeconds = nullptr) = 0;
+                                   double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get joint velocity in rad/s
@@ -205,7 +205,7 @@ public:
      */
     virtual bool getJointVelocity(const std::string& jointName,
                                   double& jointVelocity,
-                                  double* receiveTimeInSeconds = nullptr) = 0;
+                                  double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get all joints' velocities in rad/s
@@ -219,7 +219,7 @@ public:
      * @return true/false in case of success/failure
      */
     virtual bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
-                                    double* receiveTimeInSeconds = nullptr) = 0;
+                                    double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get IMU measurement
@@ -236,7 +236,7 @@ public:
      */
     virtual bool getIMUMeasurement(const std::string& imuName,
                                    Eigen::Ref<Vector12d> imuMeasurement,
-                                   double* receiveTimeInSeconds = nullptr) = 0;
+                                   double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get linear accelerometer measurement in m/s^2
@@ -247,7 +247,7 @@ public:
      */
     virtual bool getLinearAccelerometerMeasurement(const std::string& accName,
                                                    Eigen::Ref<Eigen::Vector3d> accMeasurement,
-                                                   double* receiveTimeInSeconds = nullptr) = 0;
+                                                   double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get gyroscope measurement in rad/s
@@ -258,7 +258,7 @@ public:
      */
     virtual bool getGyroscopeMeasure(const std::string& gyroName,
                                      Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
-                                     double* receiveTimeInSeconds = nullptr) = 0;
+                                     double* receiveTimeInSeconds = nullptr) { return false; };
 
    /**
      * Get orientation sensor measurement in radians as roll pitch yaw Euler angles
@@ -269,7 +269,7 @@ public:
      */
     virtual bool getOrientationSensorMeasurement(const std::string& rpyName,
                                                  Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
-                                                 double* receiveTimeInSeconds = nullptr) = 0;
+                                                 double* receiveTimeInSeconds = nullptr) { return false; };
 
    /**
      * Get magentometer measurement in tesla
@@ -280,7 +280,7 @@ public:
      */
     virtual bool getMagnetometerMeasurement(const std::string& magName,
                                             Eigen::Ref<Eigen::Vector3d> magMeasurement,
-                                            double* receiveTimeInSeconds = nullptr) = 0;
+                                            double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get six axis force torque measurement
@@ -291,7 +291,7 @@ public:
      */
     virtual bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
                                                   Eigen::Ref<Vector6d> ftMeasurement,
-                                                  double* receiveTimeInSeconds = nullptr) = 0;
+                                                  double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get three axis force-torque measurement containing normal force (N) and tangential moments (Nm)
@@ -302,7 +302,7 @@ public:
      */
     virtual bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
                                                     Eigen::Ref<Eigen::Vector3d> ftMeasurement,
-                                                    double* receiveTimeInSeconds = nullptr) = 0;
+                                                    double* receiveTimeInSeconds = nullptr) { return false; };
 
    /**
      * Get 6D end effector wrenches in N and Nm for forces and torques respectively
@@ -313,7 +313,7 @@ public:
      */
     virtual bool getCartesianWrench(const std::string& cartesianWrenchName,
                                     Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
-                                    double* receiveTimeInSeconds = nullptr) = 0;
+                                    double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get color image from the camera
@@ -329,7 +329,7 @@ public:
      */
     virtual bool getColorImage(const std::string& camName,
                                Eigen::Ref<Eigen::MatrixXd> colorImg,
-                               double* receiveTimeInSeconds = nullptr) = 0;
+                               double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Get depth image
@@ -345,7 +345,7 @@ public:
      */
     virtual bool getDepthImage(const std::string& camName,
                                Eigen::Ref<Eigen::MatrixXd> depthImg,
-                               double* receiveTimeInSeconds = nullptr) = 0;
+                               double* receiveTimeInSeconds = nullptr) { return false; };
 
     /**
      * Destructor
@@ -376,6 +376,18 @@ protected:
     virtual bool populateSensorListsFromConfig(std::weak_ptr<IParametersHandler> handler,
                                                const SensorBridgeOptions& sensorBridgeOptions,
                                                SensorLists& sensorLists) { return true; };
+
+    /**
+     * Helper method to maintain SensorBridgeMetaData struct by populating it from the configuration parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the implementation
+     * if the user chooses to not use the method, the implementation must simply contain "return true;"
+     *
+     * @param[in] handler  Parameters handler
+     * @param[in] sensorBridgeMetaData configured object of SensorBridgeMetadata
+     * @param[in] sensorLists SensorLists object holding list of connected sensor devices
+     */
+    virtual bool populateSensorBridgeMetaDataFromConfig(std::weak_ptr<IParametersHandler> handler,
+                                                        SensorBridgeMetaData& sensorBridgeMetaData) { return true; };
 
 
 };

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -43,7 +43,8 @@ struct SensorBridgeOptions
     bool isCameraEnabled{false}; /**< flag to connect camera sources */
 
     size_t nrJoints{0}; /**< number of joints available through Kinematics stream, to be configured at initialization */
-    std::unordered_map<std::string, std::pair<int, int> > imgDimensions; /**< dimensions of the camera images available through camera streams, to be configured at initialization */
+    std::unordered_map<std::string, std::pair<int, int> > rgbImgDimensions; /**< dimensions of the images available through rgb camera streams, to be configured at initialization */
+    std::unordered_map<std::string, std::pair<int, int> > rgbdImgDimensions; /**< dimensions of the depth images available through rgbd camera streams, to be configured at initialization */
 };
 
 /**
@@ -61,7 +62,7 @@ struct SensorLists
     std::vector<std::string> threeAxisForceTorqueSensorsList; /**< list of three axis force torque sensors attached to the bridge */
     std::vector<std::string> cartesianWrenchesList; /**< list of cartesian wrench streams attached to the bridge */
     std::vector<std::string> rgbCamerasList; /**< list of rgb cameras attached to the bridge */
-    std::vector<std::string> depthCamerasList; /**< list of depth cameras attached to the bridge */
+    std::vector<std::string> rgbdCamerasList; /**< list of RGBD cameras attached to the bridge */
 };
 
 
@@ -164,11 +165,11 @@ public:
     virtual bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) = 0;
 
     /**
-     * Get depth cameras
-     * @param[out] depthCamerasList list of depth cameras attached to the bridge
+     * Get RGBD cameras
+     * @param[out] rgbdCamerasList list of rgbd cameras attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getDepthCamerasList(std::vector<std::string>& depthCamerasList) = 0;
+    virtual bool getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList) = 0;
 
     /**
      * Get joint position  in radians

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -17,7 +17,6 @@
 
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 
-using namespace BipedalLocomotion::ParametersHandler;
 using Vector12d = Eigen::Matrix<double, 12, 1>;
 using Vector6d = Eigen::Matrix<double, 6, 1>;
 
@@ -43,8 +42,8 @@ struct SensorBridgeOptions
     bool isCameraEnabled{false}; /**< flag to connect camera sources */
 
     size_t nrJoints{0}; /**< number of joints available through Kinematics stream, to be configured at initialization */
-    std::unordered_map<std::string, std::pair<int, int> > rgbImgDimensions; /**< dimensions of the images available through rgb camera streams, to be configured at initialization */
-    std::unordered_map<std::string, std::pair<int, int> > rgbdImgDimensions; /**< dimensions of the depth images available through rgbd camera streams, to be configured at initialization */
+    std::unordered_map<std::string, std::pair<std::size_t, std::size_t> > rgbImgDimensions; /**< dimensions of the images available through rgb camera streams, to be configured at initialization */
+    std::unordered_map<std::string, std::pair<std::size_t, std::size_t> > rgbdImgDimensions; /**< dimensions of the depth images available through rgbd camera streams, to be configured at initialization */
 };
 
 /**
@@ -92,7 +91,7 @@ public:
      * Initialize estimator
      * @param[in] handler Parameters handler
      */
-    virtual bool initialize(std::weak_ptr<IParametersHandler> handler) = 0;
+    virtual bool initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler) = 0;
 
     /**
      * Get joints list
@@ -361,7 +360,7 @@ protected:
      * @param[in] handler  Parameters handler
      * @param[in] sensorBridgeOptions SensorBridgeOptions to hold the bridge options for streaming sensor measurements
      */
-    virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<IParametersHandler> handler,
+    virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
                                                       SensorBridgeOptions& sensorBridgeOptions) { return true; };
 
     /**
@@ -373,7 +372,7 @@ protected:
      * @param[in] sensorBridgeOptions configured object of SensorBridgeOptions
      * @param[in] sensorLists SensorLists object holding list of connected sensor devices
      */
-    virtual bool populateSensorListsFromConfig(std::weak_ptr<IParametersHandler> handler,
+    virtual bool populateSensorListsFromConfig(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
                                                const SensorBridgeOptions& sensorBridgeOptions,
                                                SensorLists& sensorLists) { return true; };
 
@@ -386,7 +385,7 @@ protected:
      * @param[in] sensorBridgeMetaData configured object of SensorBridgeMetadata
      * @param[in] sensorLists SensorLists object holding list of connected sensor devices
      */
-    virtual bool populateSensorBridgeMetaDataFromConfig(std::weak_ptr<IParametersHandler> handler,
+    virtual bool populateSensorBridgeMetaDataFromConfig(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
                                                         SensorBridgeMetaData& sensorBridgeMetaData) { return true; };
 
 

--- a/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
+++ b/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
@@ -97,9 +97,9 @@ public:
         rgbCamerasList = std::vector<std::string>{""};
         return true;
     };
-    virtual bool getDepthCamerasList(std::vector<std::string>& depthCamerasList) override
+    virtual bool getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList) override
     {
-        depthCamerasList = std::vector<std::string>{""};
+        rgbdCamerasList = std::vector<std::string>{""};
         return true;
     };
 

--- a/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
+++ b/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
@@ -20,7 +20,7 @@ namespace RobotInterface
 class DummySensorBridge : public ISensorBridge
 {
 public:
-    virtual bool initialize(std::weak_ptr<IParametersHandler> handler) override
+    virtual bool initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler) override
     {
         if (!populateSensorBridgeOptionsFromConfig(handler, m_options))
         {
@@ -168,7 +168,7 @@ public:
                                Eigen::Ref<Eigen::MatrixXd> depthImg,
                                double* receiveTimeInSeconds = nullptr) override { return true; };
 protected:
-    virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<IParametersHandler> handler,
+    virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
                                                       SensorBridgeOptions& sensorBridgeOptions) override
     {
         auto handle = handler.lock();
@@ -197,7 +197,7 @@ protected:
         return true;
     };
 
-    virtual bool populateSensorListsFromConfig(std::weak_ptr<IParametersHandler> handler,
+    virtual bool populateSensorListsFromConfig(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
                                                const SensorBridgeOptions& sensorBridgeOptions,
                                                SensorLists& sensorLists) override
     {


### PR DESCRIPTION
This PR adds the YarpSensorBridge implementation that refactors out our traditional way of getting sensor measurements into a library. The current implementation supports measurements read from
- a remote control board remapper implementing encoders interface
- a multiple analog sensor remapper implementing accelerometers, gyroscopes, magnetometers, orientation sensors, and force-torque sensors interface
- generic IMU sensors through a server inertial
- analog FT sensors
- cartesian wrenches opened as generic sensors considered to have dimension size 6

It needs to be configured with a PolyDriverList of the relevant devices that are available in the network, and a configuration setup that informs the SensorBridge about the devices and the underlying sensor interfaces.

Implementation roadmap
- [X] Configure step
- [X] Attach drivers step
- [x] Read sensors
- [x] Advance and Getters (missing implementation for image getters, Eigen Ref conversions of YARP Image needs to be understood).
- [x] Integrated testing with a YARP device (reading one IMU, two cartesian wrenches, and a remote control board remapper takes about an average of 50 microseconds). The device closed without any segmentation faults. On comparing IMU measurements with ports and those given by the bridge, they matched (except for those converted to radians). Should I add the test device to BLF?


- **IMPORTANT CHANGE** In `ISensorBridge` Interface class, I made the getter implementations for the sensors as optional by changing them from being pure virtual functions to virtual functions. This allows the developer to decide what they want to implement rather than polluting their API with unnecessary and unused methods.

Points to discuss,
- P.S. The current monolithic Impl source code design could be further refactored into multiple Impl classes for each SensorTypes. However, for starters, let's begin with this.

- **Caution for a possible design flaw** I Inherited the `YarpSensorBridge` from the `Advanceable` class as well. However, I have a feeling that to poll the measurements at each advance step and have a huge set of measurements stored internally would be expensive than polling for the specific measurement whenever the user calls the getXXX() method on a very specific sensor of a specific measurement type.  Also since within the advance() step all the sensor reads are done serially (no sense of parallelism in internal reads as well), this might cause a huge overhead in the pipeline. I hope this doesn't turn out to be a huge design flaw in the future.  If it does, we might have to reuse the read individual sensor methods in either a parallel way or to call the individual sensor reads while the user calls the getters. 
**(Imagine a single instance of SensorBridge configured with all sensor interfaces including cameras and multiple interfaces!)**

- Dealing with YARP images, I am using internal storage of `yarp::sig::Image` and dynamic casting it to the derived classes of `yarp::sig::ImageOf<yarp::sig::PixelRgb>`, `yarp::sig::ImageOf<yarp::sig::PixelFloat>` and `yarp::sig::FlexImage` for reading RGB Images from `IFrameGrabber` interface, depth images from `IRGBDSensor` interface and RGB images from `IRGBDSensor` interface. We need to understand if it's a good way to do so.

