### PR TITLE
Bugfix in Yarp iRobotControl implementation

### DIFF
--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpRobotControl.h
@@ -44,6 +44,14 @@ public:
     /**
      * Initialize the Interface
      * @param handler pointer to a parameter handler interface
+     * @note the following parameters are required by the class
+     * |             Parameter name             |   Type   |                                          Description                                         | Mandatory |
+     * |:--------------------------------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
+     * |            `reading_timeout`           |   `int`  |    Timeout used while reading from the YARP interfaces in microseconds. (Positive Number)    |     No    |
+     * |         `max_reading_attempts`         |   `int`  |      Max number of attempts used for reading from the YARP interfaces. (Positive Number)     |     No    |
+     * |         `positioning_duration`         | `double` | Duration of the trajectory generated when the joint is controlled in position mode [seconds] |    Yes    |
+     * |         `positioning_tolerance`        | `double` |                    Max Admissible error for position control joint [rad]                     |    Yes    |
+     * | `position_direct_max_admissible_error` | `double` |                 Max admissible error for position direct control joint [rad]                 |    Yes    |
      * @return True/False in case of success/failure.
      */
     bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler) final;

--- a/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpRobotControl.cpp
@@ -307,7 +307,31 @@ struct YarpRobotControl::Impl
         // store the polydriver
         this->robotDevice = robotDevice;
 
-        return this->getControlModes();
+        if (!this->getControlModes())
+        {
+            std::cerr << errorPrefix << "Unable to get the control modes." << std::endl;
+            return false;
+        }
+
+        // clear all the stored control modes
+        this->desiredJointValuesAndMode.index[IRobotControl::ControlMode::Position].clear();
+        this->desiredJointValuesAndMode.index[IRobotControl::ControlMode::PositionDirect].clear();
+        this->desiredJointValuesAndMode.index[IRobotControl::ControlMode::Velocity].clear();
+        this->desiredJointValuesAndMode.index[IRobotControl::ControlMode::Torque].clear();
+
+        // store the joint associated to a specific control mode
+        for (std::size_t i = 0; i < this->actuatedDOFs; i++)
+        {
+            this->desiredJointValuesAndMode.index[this->controlModes[i]].push_back(i);
+        }
+
+        // resize the desired joint value vector associated to each control mode
+        for (const auto& [mode, indeces] : this->desiredJointValuesAndMode.index)
+        {
+            this->desiredJointValuesAndMode.value[mode].resize(indeces.size());
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
This PR fixes two bugs in the `yarp` implementation of the `iRobotControl` class.
- https://github.com/dic-iit/bipedal-locomotion-framework/pull/118/commits/8fc2bef8a813d078c64852ec13ca00d3a6e099c3 fixes #115 I followed what @diegoferigo implemented in [wb-toolbox](https://github.com/robotology/wb-toolbox/blob/4278d56dc16e4a76e0b4ef6b872bc3e26c43e451/toolbox/base/src/RobotInterface.cpp#L83).
- https://github.com/dic-iit/bipedal-locomotion-framework/pull/118/commits/8c17556b6a2b8bbe8a5372c0d6060860c3c7e540 resets the vectors containing the desired joint values and the associated control modes when the interface is initialized. 