### PR TITLE
Improve performances TimeVaryingDCMPlanner

### DIFF
--- a/src/Planners/include/BipedalLocomotion/Planners/DCMPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/DCMPlanner.h
@@ -31,6 +31,7 @@ struct DCMPlannerState
     Eigen::Vector3d vrpPosition; /**< Position of the virtual repellent point (VRP) expressed
                                     w.r.t. the inertial frame */
     double omega;/**< Value of the parameter omega */
+    double omegaDot;/**< Value of the parameter omega dot */
 };
 
 /**

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -512,6 +512,7 @@ struct TimeVaryingDCMPlanner::Impl
         this->opti.set_value(this->optiParameters.dcmRefererenceTraj, initialValueDCM);
 
         this->opti.set_initial(this->optiVariables.dcm, initialValueDCM);
+        this->opti.set_initial(this->optiVariables.vrp, initialValueDCM(Sl(), Sl(0, -1)));
         this->opti.set_initial(this->optiVariables.omega, initialValueOmega);
         this->opti.set_initial(this->optiVariables.omegaDot,
                                casadi::DM::zeros(1, omegaDot.columns()));

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -532,9 +532,9 @@ struct TimeVaryingDCMPlanner::Impl
 
         trajectory.omega = static_cast<double>(optiSolution.omega(0, this->trajectoryIndex));
 
-        const double omegaDot = static_cast<double>(optiSolution.omegaDot(0, this->trajectoryIndex));
+        trajectory.omegaDot = static_cast<double>(optiSolution.omegaDot(0, this->trajectoryIndex));
 
-        trajectory.dcmVelocity = (trajectory.omega - omegaDot / trajectory.omega)
+        trajectory.dcmVelocity = (trajectory.omega - trajectory.omegaDot / trajectory.omega)
                                  * (trajectory.dcmPosition - trajectory.vrpPosition);
     }
 };

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -433,7 +433,7 @@ struct TimeVaryingDCMPlanner::Impl
                     std::advance(contactIt, 1);
                     const Eigen::Vector3d p2 = contactIt->second->pose.translation();
 
-                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2;
+                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2.0;
                     desiredDCMPosition(2) += averageDCMHeight;
 
                     dcmKnots.emplace_back(desiredDCMPosition);
@@ -450,7 +450,7 @@ struct TimeVaryingDCMPlanner::Impl
                     std::advance(contactIt, 1);
                     const Eigen::Vector3d p2 = contactIt->second->pose.translation();
 
-                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2;
+                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2.0;
                     desiredDCMPosition(2) += averageDCMHeight;
 
                     dcmKnots.emplace_back(desiredDCMPosition);

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -266,11 +266,14 @@ struct TimeVaryingDCMPlanner::Impl
             // system dynamics
             this->opti.subject_to(casadi::MX::vertcat({dcm(Sl(), i + 1), omega(Sl(), i + 1)})
                                   == casadi::MX::vertcat({dcmNextStep, omegaNextStep}));
-
-            // omega has to be positive
-            this->opti.subject_to(omega(Sl(), i) > 0);
-            this->opti.subject_to(casadi::MX::pow(omega(Sl(), i), 2) - omegaDot(Sl(), i) > 0);
         }
+
+        // omega^2 - omegaDot has to be positive
+        this->opti.subject_to(casadi::MX::pow(omega(Sl(), Sl(0, -1)), 2) - omegaDot
+                              > casadi::DM::zeros(omegaDot.rows(), omegaDot.columns()));
+
+        // omega has to be positive
+        this->opti.subject_to(omega > casadi::DM::zeros(omega.rows(), omega.columns()));
 
         this->optiParameters.dcmRefererenceTraj = this->opti.parameter(this->dcmVectorSize, horizonSampling + 1);
 

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -429,12 +429,11 @@ struct TimeVaryingDCMPlanner::Impl
                         (contactPhaseListIt->endTime + contactPhaseListIt->beginTime) / 2);
 
                     auto contactIt = contactPhaseListIt->activeContacts.cbegin();
-                    Eigen::Vector3d p1 = contactIt->second->pose.translation();
+                    const Eigen::Vector3d p1 = contactIt->second->pose.translation();
                     std::advance(contactIt, 1);
-                    Eigen::Vector3d p2 = contactIt->second->pose.translation();
+                    const Eigen::Vector3d p2 = contactIt->second->pose.translation();
 
-                    Eigen::Vector3d desiredDCMPosition;
-                    desiredDCMPosition = (p1 + p2) / 2;
+                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2;
                     desiredDCMPosition(2) += averageDCMHeight;
 
                     dcmKnots.emplace_back(desiredDCMPosition);
@@ -447,12 +446,11 @@ struct TimeVaryingDCMPlanner::Impl
                 {
                     timeKnots.push_back(contactPhaseListIt->endTime);
                     auto contactIt = contactPhaseListIt->activeContacts.cbegin();
-                    Eigen::Vector3d p1 = contactIt->second->pose.translation();
+                    const Eigen::Vector3d p1 = contactIt->second->pose.translation();
                     std::advance(contactIt, 1);
-                    Eigen::Vector3d p2 = contactIt->second->pose.translation();
+                    const Eigen::Vector3d p2 = contactIt->second->pose.translation();
 
-                    Eigen::Vector3d desiredDCMPosition;
-                    desiredDCMPosition = (p1 + p2) / 2;
+                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2;
                     desiredDCMPosition(2) += averageDCMHeight;
 
                     dcmKnots.emplace_back(desiredDCMPosition);


### PR DESCRIPTION
This PR attempts to reduce the memory allocation (and in general improve the performances) in the `TimeVaryingDCMPlanner`, in details:
- https://github.com/dic-iit/bipedal-locomotion-framework/commit/a333d3fb631b91510d0e22ba1b21819320f6e28e Introduces the `QuinticSpline` instead of the `iDynTree::CubicSpline`, here thanks to the usage of the `Eigen::Ref<>` + `Eigen::Map<>` it was possible to directly use `casadi::DM` objects as input of the `QuinticSpline::evaluatePoint()` method. 
- https://github.com/dic-iit/bipedal-locomotion-framework/commit/0681b2d52dcc3698407ba0127be967cdc7def7be add `omega dot` as a state of the Planner.
- I noticed that building the constraints in a `for loop`  is time-consuming (for casadi), in https://github.com/dic-iit/bipedal-locomotion-framework/commit/5a4218a120f300091a900b5158a9e224e1e552bc the initialization of the constraints for `omega` and `omega dot` is now added outside a for loop.
- https://github.com/dic-iit/bipedal-locomotion-framework/commit/7540dcdd03e3c624f3095961fac6292b27cb80d9 I also add an initial guess for the `vrp`. 

I'm pretty sure we can improve the optimization of this part of the code, for instance by using the `casadi mapaccum` feature but I didn't find any documentation on how to use this feature in `c++`

CC casadi users @S-Dafarra @Giulero 