### PR TITLE
Use booleans instead of int as configuration parameters in YarpSensorBridge class

### DIFF
--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
@@ -164,24 +164,23 @@ struct YarpSensorBridge::Impl
         auto ptr = handler.lock();
         if (ptr == nullptr)
         {
-            std::cerr << logPrefix << "The handler is not pointing to an already initialized memory."
+            std::cerr << logPrefix
+                      << "The handler is not pointing to an already initialized memory."
                       << std ::endl;
             return false;
         }
 
-        int success;
-        if (ptr->getParameter(enableStreamString, success))
+        enableStreamFlag = false;
+        if (ptr->getParameter(enableStreamString, enableStreamFlag) && enableStreamFlag)
         {
-            enableStreamFlag = static_cast<bool>(success);
-            if (enableStreamFlag)
+            auto groupHandler = ptr->getGroup(streamGroupString);
+            if (!(this->*loader)(groupHandler, metaData))
             {
-                auto groupHandler = ptr->getGroup(streamGroupString);
-                if (! (this->*loader)(groupHandler, metaData) )
-                {
-                    std::cerr << logPrefix << streamGroupString << " group could not be initialized from the configuration file."
-                              << std ::endl;
-                    return false;
-                }
+                std::cerr << logPrefix << streamGroupString
+                          << " group could not be initialized from the configuration file."
+                          << std::endl;
+
+                return false;
             }
         }
 
@@ -1704,5 +1703,3 @@ struct YarpSensorBridge::Impl
 }
 }
 #endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_IMPL_H
-
-

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -30,9 +30,13 @@ bool YarpSensorBridge::initialize(std::weak_ptr<IParametersHandler> handler)
         return false;
     }
 
-    int temp;
-    ptr->getParameter("check_for_nan", temp);
-    m_pimpl->checkForNAN = static_cast<bool>(temp);
+
+    if(!ptr->getParameter("check_for_nan", m_pimpl->checkForNAN))
+    {
+        std::cerr << logPrefix << "Unable to get check_for_nan."
+                  << std ::endl;
+        return false;
+    }
 
     bool ret{true};
     ret = m_pimpl->subConfigLoader("stream_joint_states", "RemoteControlBoardRemapper",


### PR DESCRIPTION
Associated issue  #121 (point 1)