### PR TITLE
General improvements of the TimeVarying DCM planner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   vcpkg_robotology_TAG: v0.4.0
-  vcpkg_TAG: 222c35e3bcb8f28cd63fc526e591bb4ef6b99e4f
+  vcpkg_TAG: 76a7e9248fb3c57350b559966dcaa2d52a5e4458
   YCM_TAG: v0.11.1
   YARP_TAG: 964bb26fa4791d83d72882711ea7509306248106
   iDynTree_TAG: v1.1.0

--- a/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
@@ -44,6 +44,18 @@ public:
     /**
      * Initialize the planner.
      * @param handler pointer to the parameter handler.
+     * @note the following parameters are required by the class
+     * |           Parameter Name          |    Type    |                                                                   Description                                                                  | Mandatory |
+     * |:---------------------------------:|:----------:|:----------------------------------------------------------------------------------------------------------------------------------------------:|:---------:|
+     * |          `linear_solver`          |  `string`  | Linear solver used by ipopt, the default value is mumps. Please check https://coin-or.github.io/Ipopt/#PREREQUISITES for the available solvers |     No    |
+     * |      `planner_sampling_time`      |  `double`  |                                                          Sampling time of the planner                                                          |    Yes    |
+     * |      `number_of_foot_corners`     |    `int`   |                                      Number of the corner of the polygon used to describe the foot. E.g. 4                                     |    Yes    |
+     * |         `foot_corner_<i>`         | `Vector3d` |             A 3d vector describing the position of the corner w.r.t. frame associated to the foot. `i = 0:number_of_foot_corners`.             |    Yes    |
+     * |         `omega_dot_weight`        |  `double`  |                                                   Weight associated to the $\f\dot{omega}$\f                                                   |    Yes    |
+     * |       `dcm_tracking_weight`       |  `double`  |                                                      Weight associated to the DCM tracking                                                     |    Yes    |
+     * | `omega_dot_rate_of_change_weight` |  `double`  |                                          Weight associated to the rate of change of $\f\dot{omega}$\f                                          |    Yes    |
+     * |    `vrp_rate_of_change_weight`    |  `double`  |                                               Weight associated to the rate of change of the VRP                                               |    Yes    |
+     * |    `dcm_rate_of_change_weight`    |  `double`  |                                               Weight associated to the rate of change of the DCM                                               |    Yes    |
      * @return true in case of success/false otherwise.
      */
      bool initialize(std::shared_ptr<ParametersHandler::IParametersHandler> handler) override;

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -569,6 +569,10 @@ bool TimeVaryingDCMPlanner::initialize(std::shared_ptr<ParametersHandler::IParam
         }
     }
 
+    // get the linear solver used by ipopt. This parameter is optional. The default value is mumps
+    std::string linearSolver;
+    if (handler->getParameter("linear_solver", linearSolver))
+        m_pimpl->optiSettings.ipoptLinearSolver = linearSolver;
 
     bool okCostFunctions = true;
     okCostFunctions &= handler->getParameter("omega_dot_weight", m_pimpl->optiSettings.omegaDotWeight);

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -175,6 +175,7 @@ struct TimeVaryingDCMPlanner::Impl
             casadiOptions["print_time"] = false;
         }
         ipoptOptions["linear_solver"] = this->optiSettings.ipoptLinearSolver;
+        casadiOptions["expand"] = true;
 
         this->opti.solver("ipopt", casadiOptions, ipoptOptions);
     }


### PR DESCRIPTION
This PR introduces some general improvements for the TimeVarying DCM planner. 
- https://github.com/dic-iit/bipedal-locomotion-framework/commit/5da3568d21c6f91dcf098ba8e899e5728b3ec0a9 convert the `Casadi::MX` element in `Casadi::SX` object. Thanks to this modification the desired DCM trajectory is computed faster.
   For instance, the test gives the following results:
   - Without the PR:
      ```
      ******************************************************************************
      This program contains Ipopt, a library for large-scale nonlinear optimization.
       Ipopt is released as open source code under the Eclipse Public License (EPL).
               For more information visit http://projects.coin-or.org/Ipopt
      ******************************************************************************
      
            solver  :   t_proc      (avg)   t_wall      (avg)    n_eval
             nlp_f  | 595.00us (  8.50us) 597.40us (  8.53us)        70
             nlp_g  |  56.22ms (803.11us)  22.99ms (328.42us)        70
          nlp_grad  |   1.91ms (  1.91ms) 727.76us (727.76us)         1
        nlp_grad_f  | 489.00us ( 19.56us) 493.73us ( 19.75us)        25
        nlp_hess_l  |  71.06ms (  3.38ms)  28.67ms (  1.37ms)        21
         nlp_jac_g  |  81.14ms (  3.01ms)  31.11ms (  1.15ms)        27
             total  | 501.12ms (501.12ms) 374.23ms (374.23ms)         1
      ```
   - With the PR:
      ```
      ******************************************************************************
      This program contains Ipopt, a library for large-scale nonlinear optimization.
       Ipopt is released as open source code under the Eclipse Public License (EPL).
               For more information visit http://projects.coin-or.org/Ipopt
      ******************************************************************************
      
            solver  :   t_proc      (avg)   t_wall      (avg)    n_eval
             nlp_f  | 815.00us ( 15.38us) 822.17us ( 15.51us)        53
             nlp_g  |   1.21ms ( 22.91us)   1.18ms ( 22.20us)        53
          nlp_grad  | 107.00us (107.00us) 106.85us (106.85us)         1
        nlp_grad_f  | 737.00us ( 32.04us) 738.33us ( 32.10us)        23
        nlp_hess_l  |   1.48ms ( 73.80us)   1.50ms ( 74.94us)        20
         nlp_jac_g  |   1.40ms ( 58.13us)   1.41ms ( 58.79us)        24
             total  | 276.92ms (276.92ms) 277.00ms (277.00ms)         1
      ```
- https://github.com/dic-iit/bipedal-locomotion-framework/commit/393f668e6d47883ad50311de5260bd6d189efbb5 introduces the possibility to switch the linear solver used by the IPOPT.
- https://github.com/dic-iit/bipedal-locomotion-framework/commit/f9a4cc397e63a82d5ad0dda99c81cf0af937ec5d improves the documentation