### PR TITLE
Add FloatingBaseEstimatorDevice YARP wrapper to the algorithms in FloatingBaseEstimator library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@ All notable changes to this project are documented in this file.
 - Added `CommonConversions` and `ManifConversions` libraries to handle type conversions.
 - Implement the `JointPositionTracking` application. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/136)
 - Initial implementation of Python bindings using pybind11 (https://github.com/dic-iit/bipedal-locomotion-framework/pull/134)
+- Implement `FloatingBaseEstimatorDevice` YARP device for wrapping floating base estimation algorithms. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/130)
 
 [Unreleased]: https://github.com/dic-iit/bipedal-locomotion-framework/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ include(AddBipedalLocomotionLibrary)
 #Function to automatize the process of creating a new application
 include(AddBipedalLocomotionApplication)
 
+# macro to automatize the process of creating a YARP device
+include(AddBipedalLocomotionYARPDevice)
+
 #Utility to install ini files
 include(InstallIniFiles)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ include(AddBipedalLocomotionApplication)
 include(InstallIniFiles)
 
 add_subdirectory(src)
+add_subdirectory(devices)
 
 #Creates the interface target BipedalLocomotion::Framework that depends on all the targets.
 #By including the file "BipedalLocomotion/Framework.h" it is possible to include all the headers automatically.

--- a/cmake/AddBipedalLocomotionYARPDevice.cmake
+++ b/cmake/AddBipedalLocomotionYARPDevice.cmake
@@ -1,0 +1,61 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+function(add_bipedal_yarp_device)
+  set(options )
+  set(oneValueArgs NAME)
+  set(multiValueArgs
+    SOURCES
+    PUBLIC_HEADERS
+    PRIVATE_HEADERS
+    PUBLIC_LINK_LIBRARIES
+    PRIVATE_LINK_LIBRARIES    
+    TYPE
+    INI)
+
+  set(prefix "bipedal_yarp")
+
+  cmake_parse_arguments(${prefix}
+          "${options}"
+          "${oneValueArgs}"
+          "${multiValueArgs}"
+          ${ARGN})
+
+  set(name ${${prefix}_NAME})
+  set(type ${${prefix}_TYPE})
+  set(ini ${${prefix}_INI})
+  set(sources ${${prefix}_SOURCES})
+  set(public_headers ${${prefix}_PUBLIC_HEADERS})
+  set(public_link_libraries ${${prefix}_PUBLIC_LINK_LIBRARIES})
+
+  yarp_prepare_plugin(${name} CATEGORY device
+                              TYPE ${type}
+                              INCLUDE ${public_headers})
+
+  yarp_add_plugin(${name} ${sources} ${public_headers})
+
+  target_link_libraries(${name} PUBLIC ${public_link_libraries})
+  target_compile_features(${name} PUBLIC cxx_std_17)
+
+  # Specify include directories for both compilation and installation process.
+  # The $<INSTALL_PREFIX> generator expression is useful to ensure to create
+  # relocatable configuration files, see https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-relocatable-packages
+  target_include_directories(${name} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "<INSTALLINTERFACE:<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
+  # Specify installation targets, typology and destination folders.
+  yarp_install(TARGETS ${name}
+               COMPONENT runtime
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}/
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}/)
+  yarp_install(FILES ${ini}
+               COMPONENT runtime
+               DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}/)
+
+  add_subdirectory(app)
+
+
+  message(STATUS "Created device ${name}.")
+
+endfunction()

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+add_subdirectory(FloatingBaseEstimatorDevice)
+

--- a/devices/FloatingBaseEstimatorDevice/CMakeLists.txt
+++ b/devices/FloatingBaseEstimatorDevice/CMakeLists.txt
@@ -3,45 +3,13 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 if(FRAMEWORK_COMPILE_YarpImplementation)
-  cmake_minimum_required(VERSION 3.5)
-  set(PLUGIN_NAME FloatingBaseEstimatorDevice)
 
-  set(${PLUGIN_NAME}_SRC src/FloatingBaseEstimatorDevice.cpp)
-  set(${PLUGIN_NAME}_HDR include/BipedalLocomotion/FloatingBaseEstimatorDevice.h)
-
-  yarp_prepare_plugin(${PLUGIN_NAME} CATEGORY device
-                                     TYPE BipedalLocomotion::FloatingBaseEstimatorDevice
-                                     INCLUDE ${${PLUGIN_NAME}_HDR}
-                                     DEFAULT ON)
-
-  yarp_add_plugin(${PLUGIN_NAME} ${${PLUGIN_NAME}_SRC} ${${PLUGIN_NAME}_HDR})
-
-  target_link_libraries(${PLUGIN_NAME} PUBLIC ${YARP_LIBRARIES}
-                                              ${iDynTree_LIBRARIES}
-                                              BipedalLocomotion::YarpUtilities
-                                              BipedalLocomotion::RobotInterfaceYarpImplementation
-                                              BipedalLocomotion::ParametersHandlerYarpImplementation
-                                              BipedalLocomotion::FloatingBaseEstimators)
-  target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_17)
-
-  # Specify include directories for both compilation and installation process.
-  # The $<INSTALL_PREFIX> generator expression is useful to ensure to create
-  # relocatable configuration files, see https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-relocatable-packages
-  target_include_directories(${PLUGIN_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "<INSTALLINTERFACE:<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-
-  # Specify installation targets, typology and destination folders.
-  yarp_install(TARGETS ${PLUGIN_NAME}
-               COMPONENT runtime
-               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}/
-               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}/)
-  yarp_install(FILES FloatingBaseEstimatorDevice.ini
-               COMPONENT runtime
-               DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}/)
-
-  add_subdirectory(app)
-
-  message(STATUS "Created device ${PLUGIN_NAME}.")
-
+add_bipedal_yarp_device(
+  NAME FloatingBaseEstimatorDevice
+  TYPE BipedalLocomotion::FloatingBaseEstimatorDevice
+  SOURCES src/FloatingBaseEstimatorDevice.cpp
+  PUBLIC_HEADERS include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
+  PUBLIC_LINK_LIBRARIES ${YARP_LIBRARIES} ${iDynTree_LIBRARIES} BipedalLocomotion::YarpUtilities BipedalLocomotion::RobotInterfaceYarpImplementation BipedalLocomotion::ParametersHandlerYarpImplementation BipedalLocomotion::FloatingBaseEstimators
+  INI FloatingBaseEstimatorDevice.ini)
 endif()
 

--- a/devices/FloatingBaseEstimatorDevice/CMakeLists.txt
+++ b/devices/FloatingBaseEstimatorDevice/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+if(FRAMEWORK_COMPILE_YarpImplementation)
+  cmake_minimum_required(VERSION 3.5)
+  set(PLUGIN_NAME FloatingBaseEstimatorDevice)
+
+  set(${PLUGIN_NAME}_SRC src/FloatingBaseEstimatorDevice.cpp)
+  set(${PLUGIN_NAME}_HDR include/BipedalLocomotion/FloatingBaseEstimatorDevice.h)
+
+  yarp_prepare_plugin(${PLUGIN_NAME} CATEGORY device
+                                     TYPE BipedalLocomotion::FloatingBaseEstimatorDevice
+                                     INCLUDE ${${PLUGIN_NAME}_HDR}
+                                     DEFAULT ON)
+
+  yarp_add_plugin(${PLUGIN_NAME} ${${PLUGIN_NAME}_SRC} ${${PLUGIN_NAME}_HDR})
+
+  target_link_libraries(${PLUGIN_NAME} PUBLIC ${YARP_LIBRARIES}
+                                              ${iDynTree_LIBRARIES}
+                                              BipedalLocomotion::YarpUtilities
+                                              BipedalLocomotion::RobotInterfaceYarpImplementation
+                                              BipedalLocomotion::ParametersHandlerYarpImplementation
+                                              BipedalLocomotion::FloatingBaseEstimators)
+  target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_17)
+
+  # Specify include directories for both compilation and installation process.
+  # The $<INSTALL_PREFIX> generator expression is useful to ensure to create
+  # relocatable configuration files, see https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-relocatable-packages
+  target_include_directories(${PLUGIN_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "<INSTALLINTERFACE:<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
+  # Specify installation targets, typology and destination folders.
+  yarp_install(TARGETS ${PLUGIN_NAME}
+               COMPONENT runtime
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}/
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}/)
+  yarp_install(FILES FloatingBaseEstimatorDevice.ini
+               COMPONENT runtime
+               DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}/)
+
+  add_subdirectory(app)
+
+  message(STATUS "Created device ${PLUGIN_NAME}.")
+
+endif()
+

--- a/devices/FloatingBaseEstimatorDevice/FloatingBaseEstimatorDevice.ini
+++ b/devices/FloatingBaseEstimatorDevice/FloatingBaseEstimatorDevice.ini
@@ -1,0 +1,4 @@
+[plugin FloatingBaseEstimatorDevice]
+type device
+name FloatingBaseEstimatorDevice
+library FloatingBaseEstimatorDevice

--- a/devices/FloatingBaseEstimatorDevice/app/CMakeLists.txt
+++ b/devices/FloatingBaseEstimatorDevice/app/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+# Get list of models
+subdirlist(subdirs ${CMAKE_CURRENT_SOURCE_DIR}/robots/)
+# Install each model
+foreach (dir ${subdirs})
+  yarp_install(DIRECTORY robots/${dir} DESTINATION ${YARP_ROBOTS_INSTALL_DIR})
+endforeach ()
+

--- a/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/estimators/invekf-base-estimator.xml
+++ b/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/estimators/invekf-base-estimator.xml
@@ -1,0 +1,128 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="base-estimator" type="FloatingBaseEstimatorDevice">
+    <param name="robot">icubSim</param>
+    <param name="sampling_period_in_s">0.01</param>
+    <param name="port_prefix">/base-estimator</param>
+    <param name="model_file">model.urdf</param>
+    <param name="joint_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+    <param name="base_link_imu">root_link_imu_acc</param>
+    <param name="left_foot_wrench">left_foot_cartesian_wrench</param>
+    <param name="right_foot_wrench">right_foot_cartesian_wrench</param>
+    <param name="estimator_type">InvEKF</param>
+
+
+     <group name="RobotSensorBridge">
+        <param name="check_for_nan">false</param>
+        <param name="stream_joint_states">true</param>
+        <param name="stream_inertials">true</param>
+        <param name="stream_cartesian_wrenches">true</param>
+        <param name="stream_forcetorque_sensors">true</param>
+        <param name="stream_cameras">true</param>
+
+        <group name="RemoteControlBoardRemapper">
+            <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+        </group>
+
+        <group name="InertialSensors">
+            <param name="imu_list">("root_link_imu_acc")</param>
+        </group>
+
+        <group name="CartesianWrenches">
+            <param name="cartesian_wrenches_list">("right_foot_cartesian_wrench", "left_foot_cartesian_wrench")</param>
+        </group>
+    </group>
+
+    <group name="ContactSchmittTrigger">
+        <group name="left_foot">
+            <param name="schmitt_stable_contact_make_time">0.05</param>
+            <param name="schmitt_stable_contact_break_time">0.02</param>
+            <param name="schmitt_contact_make_force_threshold">170.0</param>
+            <param name="schmitt_contact_break_force_threshold">75.0</param>
+        </group>
+        <group name="right_foot">
+            <param name="schmitt_stable_contact_make_time">0.05</param>
+            <param name="schmitt_stable_contact_break_time">0.02</param>
+            <param name="schmitt_contact_make_force_threshold">170.0</param>
+            <param name="schmitt_contact_break_force_threshold">75.0</param>
+        </group>
+    </group>
+
+    <group name="ModelInfo">
+        <param name="base_link">root_link</param>
+        <param name="left_foot_contact_frame">l_sole</param>
+        <param name="right_foot_contact_frame">r_sole</param>
+        <param name="base_link_imu">root_link_imu_acc</param>
+    </group>
+
+    <group name="Options">
+        <param name="enable_imu_bias_estimation">false</param>
+        <param name="enable_static_imu_bias_initialization">false</param>
+        <param name="nr_samples_for_imu_bias_initialization">0</param>
+        <param name="enable_ekf_update">true</param>
+        <param name="acceleration_due_to_gravity">(0.0, 0.0, -9.80665)</param>
+    </group>
+
+    <group name="SensorsStdDev">
+        <!-- <param name="accelerometer_measurement_noise_std_dev">(0.0382, 0.01548, 0.0042)</param>
+        <param name="gyroscope_measurement_noise_std_dev">(0.0111, 0.0024, 0.0043)</param>  -->
+        <param name="accelerometer_measurement_noise_std_dev">(0.102, 0.148, 0.142)</param>
+        <param name="gyroscope_measurement_noise_std_dev">(0.05, 0.04, 0.06)</param>
+        <param name="contact_foot_linear_velocity_noise_std_dev">(9e-3, 9.5e-3, 7e-3)</param>
+        <param name="contact_foot_angular_velocity_noise_std_dev">(0.007, 0.0075, 0.004)</param>
+        <param name="swing_foot_linear_velocity_noise_std_dev">(0.05, 0.05, 0.05)</param>
+        <param name="swing_foot_angular_velocity_noise_std_dev">(0.015, 0.015, 0.015)</param>
+        <param name="forward_kinematic_measurement_noise_std_dev">(1e-3, 1e-3, 1e-3, 1e-6, 1e-6, 1e-6)</param>
+        <param name="encoders_measurement_noise_std_dev">(1e-4, 1e-4, 1e-4,
+                                                          1e-4, 1e-4, 1e-4,
+                                                          1e-4, 1e-4, 1e-4, 1e-4,
+                                                          1e-4, 1e-4, 1e-4, 1e-4,
+                                                          1e-4, 1e-4, 1e-4,
+                                                          1e-4, 1e-4, 1e-4,
+                                                          1e-4, 1e-4, 1e-4,
+                                                          1e-4, 1e-4, 1e-4)</param>
+        <param name="accelerometer_measurement_bias_noise_std_dev">(1e-4, 1e-4, 1e-4)</param>
+        <param name="gyroscope_measurement_bias_noise_std_dev">(1e-4, 1e-4, 1e-4)</param>
+    </group>
+
+    <group name="InitialStates">
+        <param name="imu_orientation_quaternion_wxyz">(0.3218, -0.6304, -0.6292, 0.3212)</param>
+        <param name="imu_position_xyz">(0.0296,-0.1439, 0.4915)</param>
+        <param name="imu_linear_velocity_xyz">(0.0, 0.0, 0.0)</param>
+        <param name="l_contact_frame_orientation_quaternion_wxyz">(1.0000, -0.0059, -0.0001, -0.0015)</param>
+        <param name="l_contact_frame_position_xyz">(0.0791, -0.0817, 0.0109)</param>
+        <param name="r_contact_frame_orientation_quaternion_wxyz">(1.0000, 0.0059, -0.0002, -0.0004)</param>
+        <param name="r_contact_frame_position_xyz">(0.0788, -0.2282, 0.0109)</param>
+        <param name="accelerometer_bias">(0.0, 0.0, 0.0)</param>
+        <param name="gyroscope_bias">(0.0, 0.0, 0.0)</param>
+    </group>
+
+    <group name="PriorsStdDev">
+        <param name="imu_orientation">(0.175, 0.175, 0.0175)</param>
+        <param name="imu_position">(1e-1, 1e-1, 1e-1)</param>
+        <param name="imu_linear_velocity">(0.075, 0.05, 0.05)</param>
+        <param name="l_contact_frame_orientation">(0.175, 0.175, 0.0175)</param>
+        <param name="l_contact_frame_position">(1e-1, 1e-1, 1e-1)</param>
+        <param name="r_contact_frame_orientation">(0.175, 0.175, 0.0175)</param>
+        <param name="r_contact_frame_position">(1e-1, 1e-1, 1e-1)</param>
+        <param name="accelerometer_bias">(1e-3, 1e-3, 1e-3)</param>
+        <param name="gyroscope_bias">(1e-3, 1e-3, 1e-3)</param>
+    </group>
+
+    <!-- ATTACH -->
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="all_joints">all_joints_mc</elem>
+            <elem name="root_link_imu_acc">root_link_imu_acc</elem>
+            <elem name="left_foot_cartesian_wrench">left_foot_cartesian_wrench</elem>
+            <elem name="right_foot_cartesian_wrench">right_foot_cartesian_wrench</elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="2" type="detach" />
+    <!-- FINISH ATTACH-->
+
+</device>

--- a/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/all_joints_mc.xml
+++ b/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/all_joints_mc.xml
@@ -1,0 +1,10 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="all_joints_mc" type="remotecontrolboardremapper">
+    <param name="remoteControlBoards">("/icubSim/head", "/icubSim/torso", "/icubSim/left_arm", "/icubSim/right_arm", "/icubSim/left_leg", "/icubSim/right_leg")</param>
+    <param name="axesNames">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll")</param>
+    <param name="localPortPrefix">/baseestimation</param>
+</device>
+

--- a/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/root_imu.xml
+++ b/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/root_imu.xml
@@ -1,0 +1,9 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="root_link_imu_acc" type="genericSensorClient">
+    <param name="remote">/icubSim/xsens_inertial</param>
+    <param name="local">/baseestimation/xsens_inertial</param>
+</device>
+

--- a/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/wbd_left_foot.xml
+++ b/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/wbd_left_foot.xml
@@ -1,0 +1,9 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot_cartesian_wrench" type="genericSensorClient">
+    <param name="remote">/wholeBodyDynamics/left_foot/cartesianEndEffectorWrench:o</param>
+    <param name="local">/baseestimation/left_foot/cartesianEndEffectorWrench</param>
+</device>
+

--- a/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/wbd_right_foot.xml
+++ b/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/interface/wbd_right_foot.xml
@@ -1,0 +1,9 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot_cartesian_wrench" type="genericSensorClient">
+    <param name="remote">/wholeBodyDynamics/right_foot/cartesianEndEffectorWrench:o</param>
+    <param name="local">/baseestimation/right_foot/cartesianEndEffectorWrench</param>
+</device>
+

--- a/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/launch-base-estimator.xml
+++ b/devices/FloatingBaseEstimatorDevice/app/robots/iCubGazeboV2_5/launch-base-estimator.xml
@@ -1,0 +1,21 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGazeboV2_5" portprefix="icubSim" build="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <!-- interface -->
+        <xi:include href="interface/all_joints_mc.xml" />
+        <xi:include href="interface/root_imu.xml" />
+        <xi:include href="interface/wbd_left_foot.xml" />
+        <xi:include href="interface/wbd_right_foot.xml" />
+
+
+        <xi:include href="estimators/invekf-base-estimator.xml" />
+    </devices>
+
+</robot>
+

--- a/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
+++ b/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
@@ -1,0 +1,98 @@
+/**
+ * @file FloatingBaseEstimatorDevice.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_FRAMEWORK_BASE_ESTIMATOR_DEVICE_H
+#define BIPEDAL_LOCOMOTION_FRAMEWORK_BASE_ESTIMATOR_DEVICE_H
+
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
+#include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h>
+
+#include <iDynTree/Estimation/ContactStateMachine.h>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/Wrapper.h>
+#include <yarp/os/ResourceFinder.h>
+#include <yarp/dev/IFrameTransform.h>
+
+#include <mutex>
+#include <memory>
+
+namespace BipedalLocomotion
+{
+    class FloatingBaseEstimatorDevice;
+}
+
+class BipedalLocomotion::FloatingBaseEstimatorDevice : public yarp::dev::DeviceDriver,
+                                                       public yarp::dev::IMultipleWrapper,
+                                                       public yarp::os::PeriodicThread
+{
+public:
+    explicit FloatingBaseEstimatorDevice(double period, yarp::os::ShouldUseSystemClock useSystemClock = yarp::os::ShouldUseSystemClock::No);
+    FloatingBaseEstimatorDevice();
+    ~FloatingBaseEstimatorDevice();
+
+    virtual bool open(yarp::os::Searchable& config) final;
+    virtual bool close() final;
+    virtual bool attachAll(const yarp::dev::PolyDriverList & poly) final;
+    virtual bool detachAll() final;
+    virtual void run() final;
+
+private:
+    bool setupRobotModel(yarp::os::Searchable& config);
+    bool setupRobotSensorBridge(yarp::os::Searchable& config);
+    bool setupFeetContactStateMachines(yarp::os::Searchable& config);
+    bool parseFootSchmittParams(yarp::os::Searchable& config, iDynTree::SchmittParams& params);
+    bool setupBaseEstimator(yarp::os::Searchable& config);
+    bool loadTransformBroadcaster();
+    bool updateMeasurements();
+    bool updateInertialBuffers();
+    bool updateContactStates();
+    bool updateKinematics();
+
+    void publish();
+    void publishBaseLinkState(const BipedalLocomotion::Estimators::FloatingBaseEstimators::Output& out);
+    void publishInternalStateAndStdDev(const BipedalLocomotion::Estimators::FloatingBaseEstimators::Output& out);
+    void publishFootContactStatesAndNormalForces();
+    bool openCommunications();
+    void closeCommunications();
+    bool openBufferedSigPort(yarp::os::BufferedPort<yarp::sig::Vector>& port,
+                             const std::string& portPrefix,
+                             const std::string& address);
+    void closeBufferedSigPort(yarp::os::BufferedPort<yarp::sig::Vector>& port);
+
+    struct
+    {
+        yarp::os::BufferedPort<yarp::sig::Vector> floatingBaseStatePort;
+        yarp::os::BufferedPort<yarp::sig::Vector> internalStateAndStdDevPort;
+        yarp::os::BufferedPort<yarp::sig::Vector> contactStatePort;
+    } m_comms;
+
+    iDynTree::Model m_model;
+    std::unique_ptr<BipedalLocomotion::RobotInterface::YarpSensorBridge> m_robotSensorBridge;
+    std::unique_ptr<BipedalLocomotion::Estimators::FloatingBaseEstimator> m_estimator;
+    std::unique_ptr<iDynTree::ContactStateMachine> m_lFootCSM, m_rFootCSM;
+    bool m_currentlFootState{false}, m_currentrFootState{false};
+    double m_currentlContactNormal{0.0}, m_currentrContactNormal{0.0};
+    std::mutex m_deviceMutex;
+    std::string m_portPrefix{"/base-estimator"};
+    std::string m_robot{"icubSim"};
+    std::string m_estimatorType{"InvEKF"};
+    std::string m_baseLinkImuName{"root_link_imu_acc"};
+    std::string m_leftFootWrenchName{"left_foot_cartesian_wrench"};
+    std::string m_rightFootWrenchName{"right_foot_cartesian_wrench"};
+
+    yarp::dev::PolyDriver m_transformBroadcaster;
+    yarp::dev::IFrameTransform* m_transformInterface{nullptr};
+    bool m_publishROSTF{false};
+};
+
+
+
+#endif //BIPEDAL_LOCOMOTION_FRAMEWORK_BASE_ESTIMATOR_DEVICE_H

--- a/devices/FloatingBaseEstimatorDevice/scope/sim/base_pose_scope.xml
+++ b/devices/FloatingBaseEstimatorDevice/scope/sim/base_pose_scope.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="3" columns="2" carrier="mcast">
+ 
+    <!--X Position Estimate-->
+    <plot gridx="0"
+          gridy="0"
+          title="Postion X Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="0"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="0"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Y Position Estimate-->
+    <plot gridx="0"
+          gridy="1"
+          title="Postion Y Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="1"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="1"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Z Position Estimate-->
+    <plot gridx="0"
+          gridy="2"
+          title="Postion Z Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-500"
+          maxval="500"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="2"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="2"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+    
+    <!--Roll Estimate-->
+    <plot gridx="1"
+          gridy="0"
+          title="Roll Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="3"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="3"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Pitch Estimate-->
+    <plot gridx="1"
+          gridy="1"
+          title="Pitch Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="4"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="4"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Yaw Estimates-->
+    <plot gridx="1"
+          gridy="2"
+          title="Yaw Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-500"
+          maxval="500"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="5"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="5"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>   
+</portscope>

--- a/devices/FloatingBaseEstimatorDevice/scope/sim/base_velocity_scope.xml
+++ b/devices/FloatingBaseEstimatorDevice/scope/sim/base_velocity_scope.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="3" columns="2" carrier="mcast">
+ 
+    <!--Mixed trivailized Linear Velocity X-->
+    <plot gridx="0"
+          gridy="0"
+          title="Mixed trivialized Linear Velocity X Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="6"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="6"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Mixed trivailized Linear Velocity X-->
+    <plot gridx="0"
+          gridy="1"
+          title="Mixed trivialized Linear Velocity X Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="7"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="7"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Mixed trivailized Linear Velocity X-->
+    <plot gridx="0"
+          gridy="2"
+          title="Mixed trivialized Linear Velocity X Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-500"
+          maxval="500"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="8"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="8"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+    
+    <!--Mixed trivailized Angular Velocity X-->
+    <plot gridx="1"
+          gridy="0"
+          title="Mixed trivialized Angular Velocity X Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="9"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="9"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Mixed trivailized Angular Velocity Y-->
+    <plot gridx="1"
+          gridy="1"
+          title="Mixed trivialized Angular Velocity Y Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="10"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="10"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>
+
+    <!--Mixed trivailized Angular Velocity Z-->
+    <plot gridx="1"
+          gridy="2"
+          title="Mixed trivialized Angular Velocity Z Estimate Gazebo(blue)/BLF(red)"
+          size="60"
+          minval="-500"
+          maxval="500"
+          bgcolor="white">
+        <graph remote="/icubSim/floating_base/state:o"
+               index="11"
+               color="#0173BC"
+               title="Gazebo"
+               type="lines" />
+	<graph remote="/base-estimator/floating_base/state:o"
+               index="11"
+               color="#D95218"
+               title="BLF"
+               type="lines" />
+    </plot>   
+</portscope>

--- a/devices/FloatingBaseEstimatorDevice/scope/sim/contact_normal_scope.xml
+++ b/devices/FloatingBaseEstimatorDevice/scope/sim/contact_normal_scope.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="2" columns="1" carrier="mcast">
+ 
+    <!--Left foot contact-->
+    <plot gridx="0"
+          gridy="0"
+          title="Left foot contact state(blue) Fz (red)"
+          size="50"
+          minval="-400"
+          maxval="400"
+          bgcolor="white">
+        <graph remote="/base-estimator/contacts/stateAndNormalForce:o"
+               index="0"
+               color="#0173BC"
+               title="Contact state"
+               type="lines" />
+	<graph remote="/base-estimator/contacts/stateAndNormalForce:o"
+               index="2"
+               color="#D95218"
+               title="Contact force"
+               type="lines" />
+    </plot>
+
+    <!--Right foot contact-->
+    <plot gridx="0"
+          gridy="1"
+          title="Right foot contact state(blue) Fz (red)"
+          size="50"
+          minval="-400"
+          maxval="400"
+          bgcolor="white">
+        <graph remote="/base-estimator/contacts/stateAndNormalForce:o"
+               index="0"
+               color="#0173BC"
+               title="Contact state"
+               type="lines" />
+	<graph remote="/base-estimator/contacts/stateAndNormalForce:o"
+               index="2"
+               color="#D95218"
+               title="Contact force"
+               type="lines" />
+    </plot>
+</portscope>
+

--- a/devices/FloatingBaseEstimatorDevice/scope/sim/waist_imu.xml
+++ b/devices/FloatingBaseEstimatorDevice/scope/sim/waist_imu.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="3" columns="1" carrier="mcast">
+        <plot gridx="0"
+              gridy="0"
+              hspan="1"
+              vspan="1"
+              title="Roll Gazebo inertial(red)"
+              size="200"
+              minval="-2"
+              maxval="18"
+              bgcolor="white">
+              
+            <graph remote="/icubSim/xens_inertial"
+                   index="0"
+                   color="Red"
+                   title="Xsens roll"
+                   type="lines"
+                   size="3" />  
+         </plot>
+        <plot gridx="0"
+              gridy="1"
+              hspan="1"
+              vspan="1"
+              title="Pitch Gazebo inertial(red)"
+              size="200"
+              minval="-2"
+              maxval="18"
+              bgcolor="white">
+              
+            <graph remote="/icubSim/xens_inertial"
+                   index="1"
+                   color="Red"
+                   title="Xsens pitch"
+                   type="lines"
+                   size="3" />
+         </plot>
+      
+         <plot gridx="0"
+              gridy="2"
+              hspan="1"
+              vspan="1"
+              title="Yaw Gazebo inertial(red)"
+              size="200"
+              minval="-2"
+              maxval="18"
+              bgcolor="white">
+              
+            <graph remote="/icubSim/xens_inertial"
+                   index="2"
+                   color="Red"
+                   title="Xsens yaw"
+                   type="lines"
+                   size="3" />
+         </plot>
+                       
+</portscope>
+

--- a/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
+++ b/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
@@ -111,7 +111,7 @@ bool FloatingBaseEstimatorDevice::setupRobotModel(yarp::os::Searchable& config)
         return false;
     }
 
-    m_model = modelLoader.model().copy();
+    m_model = modelLoader.model();
     return true;
 }
 
@@ -262,21 +262,21 @@ void FloatingBaseEstimatorDevice::run()
     // advance sensor bridge
     if (!m_robotSensorBridge->advance())
     {
-        std::cout << "Advance Sensor bridge failed." << std::endl;
+        yWarning() << "Advance Sensor bridge failed.";
         return;
     }
 
     // update estimator measurements
     if (!updateMeasurements())
     {
-        std::cout << "Measurement updates failed." << std::endl;
+        yWarning() << "Measurement updates failed.";
         return;
     }
 
     // advance estimator
     if (!m_estimator->advance())
     {
-        std::cout << "Advance estimator failed." << std::endl;
+        yWarning()  << "Advance estimator failed.";
         return;
     }
 
@@ -386,7 +386,7 @@ void FloatingBaseEstimatorDevice::publishBaseLinkState(const FloatingBaseEstimat
     size_t angVelOffset{9};
 
     auto basePos = estimatorOut.basePose.getPosition();
-    auto baseRPY = iDynTree::toEigen(estimatorOut.basePose.getRotation().asRPY());
+    Eigen::Vector3d baseRPY = iDynTree::toEigen(estimatorOut.basePose.getRotation().asRPY());
     auto baseLinearVel = estimatorOut.baseTwist.getLinearVec3();
     auto baseAngularVel = estimatorOut.baseTwist.getAngularVec3();
 
@@ -418,9 +418,9 @@ void FloatingBaseEstimatorDevice::publishInternalStateAndStdDev(const FloatingBa
 
     const auto& s = estimatorOut.state;
     const auto& d = estimatorOut.stateStdDev;
-    auto imuRPY = s.imuOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
-    auto rfRPY = s.rContactFrameOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
-    auto lfRPY = s.lContactFrameOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+    Eigen::Vector3d imuRPY = s.imuOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+    Eigen::Vector3d rfRPY = s.rContactFrameOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+    Eigen::Vector3d lfRPY = s.lContactFrameOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
 
     Eigen::VectorXd internalstateAndStdDev;
     internalstateAndStdDev.resize(vecSize + vecSize);

--- a/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
+++ b/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
@@ -1,0 +1,519 @@
+/**
+ * @file FloatingBaseEstimatorDevice.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/FloatingBaseEstimatorDevice.h>
+#include <BipedalLocomotion/YarpUtilities/Helper.h>
+
+#include <BipedalLocomotion/FloatingBaseEstimators/InvariantEKFBaseEstimator.h>
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/yarp/YARPConversions.h>
+#include <yarp/os/LogStream.h>
+
+using namespace BipedalLocomotion;
+using namespace BipedalLocomotion::Estimators;
+using namespace BipedalLocomotion::RobotInterface;
+using namespace BipedalLocomotion::ParametersHandler;
+
+FloatingBaseEstimatorDevice::FloatingBaseEstimatorDevice(double period,
+                                                         yarp::os::ShouldUseSystemClock useSystemClock)
+        : yarp::os::PeriodicThread(period, useSystemClock)
+{
+}
+
+FloatingBaseEstimatorDevice::FloatingBaseEstimatorDevice()
+        : yarp::os::PeriodicThread(0.01, yarp::os::ShouldUseSystemClock::No)
+{
+}
+
+FloatingBaseEstimatorDevice::~FloatingBaseEstimatorDevice()
+{
+}
+
+bool FloatingBaseEstimatorDevice::open(yarp::os::Searchable& config)
+{
+    YarpUtilities::getElementFromSearchable(config, "robot", m_robot);
+    YarpUtilities::getElementFromSearchable(config, "port_prefix", m_portPrefix);
+    YarpUtilities::getElementFromSearchable(config, "base_link_imu", m_baseLinkImuName);
+    YarpUtilities::getElementFromSearchable(config, "left_foot_wrench", m_leftFootWrenchName);
+    YarpUtilities::getElementFromSearchable(config, "right_foot_wrench", m_rightFootWrenchName);
+    double devicePeriod{0.01};
+
+    if (YarpUtilities::getElementFromSearchable(config, "sampling_period_in_s", devicePeriod))
+    {
+        setPeriod(devicePeriod);
+    }
+
+    if (!setupRobotModel(config))
+    {
+        return false;
+    }
+
+    if (!setupRobotSensorBridge(config))
+    {
+        return false;
+    }
+
+    if (!setupFeetContactStateMachines(config))
+    {
+        return false;
+    }
+
+    if (!setupBaseEstimator(config))
+    {
+        return false;
+    }
+
+    if (!YarpUtilities::getElementFromSearchable(config, "publish_rostf", m_publishROSTF))
+     {
+         m_publishROSTF = false;
+     }
+
+     if (m_publishROSTF)
+     {
+         if (!loadTransformBroadcaster())
+         {
+             return false;
+         }
+     }
+
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::setupRobotModel(yarp::os::Searchable& config)
+{
+
+    std::string modelFileName;
+    std::vector<std::string> jointsList;
+    if (!YarpUtilities::getElementFromSearchable(config, "model_file", modelFileName))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupRobotModel] Missing required parameter \"model_file\"";
+        return false;
+    }
+
+    if (!YarpUtilities::getVectorFromSearchable(config, "joint_list", jointsList))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupRobotModel] Missing required parameter \"joint_list\"";
+        return false;
+    }
+
+    yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();
+    std::string modelFilePath{rf.findFileByName(modelFileName)};
+    yInfo() << "[FloatingBaseEstimatorDevice][setupRobotModel] Loading model from " << modelFilePath;
+
+    iDynTree::ModelLoader modelLoader;
+    if (!modelLoader.loadReducedModelFromFile(modelFilePath, jointsList))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupRobotModel] Could not load robot model";
+        return false;
+    }
+
+    m_model = modelLoader.model().copy();
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::setupRobotSensorBridge(yarp::os::Searchable& config)
+{
+    auto bridgeConfig = config.findGroup("RobotSensorBridge");
+    if (bridgeConfig.isNull())
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupRobotSensorBridge] Missing required group \"RobotSensorBridge\"";
+        return false;
+    }
+
+    std::shared_ptr<YarpImplementation> bridgeHandler = std::make_shared<YarpImplementation>();
+    bridgeHandler->set(bridgeConfig);
+
+    m_robotSensorBridge = std::make_unique<YarpSensorBridge>();
+    if (!m_robotSensorBridge->initialize(bridgeHandler))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupRobotSensorBridge] Could not configure RobotSensorBridge";
+        return false;
+    }
+
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::setupFeetContactStateMachines(yarp::os::Searchable& config)
+{
+    auto csmConfig = config.findGroup("ContactSchmittTrigger");
+    if (csmConfig.isNull())
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupFeetContactStateMachines] Missing required group \"ContactSchmittTrigger\"";
+        return false;
+    }
+
+    iDynTree::SchmittParams lParams, rParams;
+    auto lCSMConfig = csmConfig.findGroup("left_foot");
+    if (lCSMConfig.isNull())
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupFeetContactStateMachines] Could not load left foot contact Schmitt trigger configuration group.";
+        return false;
+    }
+    if (!parseFootSchmittParams(lCSMConfig, lParams))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupFeetContactStateMachines] Could not load left foot contact Schmitt trigger parameters";
+        return false;
+    }
+
+    auto rCSMConfig = csmConfig.findGroup("right_foot");
+    if (rCSMConfig.isNull())
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupFeetContactStateMachines] Could not load right foot contact Schmitt trigger configuration group.";
+        return false;
+    }
+    if (!parseFootSchmittParams(rCSMConfig, rParams))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupFeetContactStateMachines] Could not load right foot contact Schmitt trigger parameters";
+        return false;
+    }
+
+    m_lFootCSM = std::make_unique<iDynTree::ContactStateMachine>(lParams);
+    m_rFootCSM = std::make_unique<iDynTree::ContactStateMachine>(rParams);
+
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::parseFootSchmittParams(yarp::os::Searchable& config,
+                                                         iDynTree::SchmittParams& params)
+{
+    if (!YarpUtilities::getElementFromSearchable(config, "schmitt_stable_contact_make_time", params.stableTimeContactMake)) { return false; }
+    if (!YarpUtilities::getElementFromSearchable(config, "schmitt_stable_contact_break_time", params.stableTimeContactBreak)) { return false; }
+    if (!YarpUtilities::getElementFromSearchable(config, "schmitt_contact_make_force_threshold", params.contactMakeForceThreshold)) { return false; }
+    if (!YarpUtilities::getElementFromSearchable(config, "schmitt_contact_break_force_threshold", params.contactBreakForceThreshold)) { return false; }
+
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::setupBaseEstimator(yarp::os::Searchable& config)
+{
+    if (!YarpUtilities::getElementFromSearchable(config, "estimator_type", m_estimatorType))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupRobotModel] Missing required parameter \"estimator_type\"";
+        return false;
+    }
+
+    if (m_estimatorType == "InvEKF")
+    {
+        m_estimator = std::make_unique<InvariantEKFBaseEstimator>();
+    }
+
+    std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
+    originalHandler->set(config);
+    IParametersHandler::shared_ptr parameterHandler = originalHandler;
+
+    if (!m_estimator->initialize(parameterHandler, m_model))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][setupRobotModel] Could not configure estimator";
+        return false;
+    }
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::attachAll(const yarp::dev::PolyDriverList & poly)
+{
+    if (!m_robotSensorBridge->setDriversList(poly))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][attachAll] Failed to attach to devices through RobotSensorBridge.";
+        return false;
+    }
+
+    if (!openCommunications())
+    {
+        yError() << "[FloatingBaseEstimatorDevice][attachAll] Could not open ports for publishing outputs.";
+        return false;
+    }
+
+    start();
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::openCommunications()
+{
+    if (!openBufferedSigPort(m_comms.floatingBaseStatePort, m_portPrefix, "/floating_base/state:o"))
+    {
+        return false;
+    }
+
+    openBufferedSigPort(m_comms.internalStateAndStdDevPort, m_portPrefix, "/internal_state/stateAndStdDev:o");
+    openBufferedSigPort(m_comms.contactStatePort, m_portPrefix, "/contacts/stateAndNormalForce:o");
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::openBufferedSigPort(yarp::os::BufferedPort<yarp::sig::Vector>& port,
+                                                      const std::string& portPrefix,
+                                                      const std::string& address)
+{
+    bool ok{false};
+    ok = port.open(portPrefix + address);
+    if (!ok)
+    {
+        yError() << "[FloatingBaseEstimatorDevice][openBufferedSigPort] error opening port " << portPrefix + address;
+        return false;
+    }
+    return true;
+}
+
+void FloatingBaseEstimatorDevice::run()
+{
+    // advance sensor bridge
+    if (!m_robotSensorBridge->advance())
+    {
+        std::cout << "Advance Sensor bridge failed." << std::endl;
+        return;
+    }
+
+    // update estimator measurements
+    if (!updateMeasurements())
+    {
+        std::cout << "Measurement updates failed." << std::endl;
+        return;
+    }
+
+    // advance estimator
+    if (!m_estimator->advance())
+    {
+        std::cout << "Advance estimator failed." << std::endl;
+        return;
+    }
+
+    publish();
+}
+
+bool FloatingBaseEstimatorDevice::updateMeasurements()
+{
+    bool ok{true};
+
+    ok = ok && updateContactStates();
+    ok = ok && updateInertialBuffers();
+    ok = ok && updateKinematics();
+
+    return ok;
+}
+
+bool FloatingBaseEstimatorDevice::updateInertialBuffers()
+{
+    Eigen::Matrix<double, 12, 1> imuMeasure;
+    if (!m_robotSensorBridge->getIMUMeasurement(m_baseLinkImuName, imuMeasure))
+    {
+        return false;
+    }
+
+    const int accOffset{3};
+    const int gyroOffset{6};
+    if (!m_estimator->setIMUMeasurement(imuMeasure.segment<3>(accOffset), imuMeasure.segment<3>(gyroOffset)))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::updateContactStates()
+{
+    Eigen::Matrix<double, 6, 1> lfWrench, rfWrench;
+    double lfTimeStamp, rfTimeStamp;
+    bool ok{true};
+    ok = ok && m_robotSensorBridge->getCartesianWrench(m_leftFootWrenchName, lfWrench, &lfTimeStamp);
+    if (ok)
+    {
+        m_currentlContactNormal = lfWrench(2);
+        m_lFootCSM->contactMeasurementUpdate(lfTimeStamp, lfWrench(2)); // fz
+    }
+
+    ok = ok && m_robotSensorBridge->getCartesianWrench(m_rightFootWrenchName, rfWrench, &rfTimeStamp);
+    if (ok)
+    {
+        m_currentrContactNormal = rfWrench(2);
+        m_rFootCSM->contactMeasurementUpdate(rfTimeStamp, rfWrench(2)); // fz
+    }
+
+    if (!ok)
+    {
+        return false;
+    }
+
+    m_currentlFootState = m_lFootCSM->contactState();
+    m_currentrFootState = m_rFootCSM->contactState();
+    if (!m_estimator->setContacts(m_currentlFootState, m_currentrFootState))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::updateKinematics()
+{
+    Eigen::VectorXd encoders(m_model.getNrOfDOFs()), encoderSpeeds(m_model.getNrOfDOFs());
+    double timeStamp;
+    if (!m_robotSensorBridge->getJointPositions(encoders))
+    {
+        return false;
+    }
+
+    if (!m_robotSensorBridge->getJointVelocities(encoderSpeeds))
+    {
+        return false;
+    }
+
+    if (!m_estimator->setKinematics(encoders, encoderSpeeds))
+    {
+        return false;
+    }
+    return true;
+}
+
+void FloatingBaseEstimatorDevice::publish()
+{
+    if (m_estimator->isValid())
+    {
+        auto estimatorOut = m_estimator->get();
+        publishBaseLinkState(estimatorOut);
+        publishInternalStateAndStdDev(estimatorOut);
+    }
+    publishFootContactStatesAndNormalForces();
+}
+
+void FloatingBaseEstimatorDevice::publishBaseLinkState(const FloatingBaseEstimators::Output& estimatorOut)
+{
+    size_t stateVecSize{12};
+    size_t rpyOffset{3};
+    size_t linVelOffset{6};
+    size_t angVelOffset{9};
+
+    auto basePos = estimatorOut.basePose.getPosition();
+    auto baseRPY = iDynTree::toEigen(estimatorOut.basePose.getRotation().asRPY());
+    auto baseLinearVel = estimatorOut.baseTwist.getLinearVec3();
+    auto baseAngularVel = estimatorOut.baseTwist.getAngularVec3();
+
+    yarp::sig::Vector& stateVec = m_comms.floatingBaseStatePort.prepare();
+    stateVec.clear();
+    stateVec.resize(stateVecSize);
+
+    for (size_t idx = 0; idx < rpyOffset; idx++) { stateVec(idx) = basePos(idx); }
+    for (size_t idx = rpyOffset; idx < linVelOffset; idx++) { stateVec(idx) = baseRPY(idx - rpyOffset); }
+    for (size_t idx = linVelOffset; idx < angVelOffset; idx++) { stateVec(idx) = baseLinearVel(idx - linVelOffset); }
+    for (size_t idx = angVelOffset; idx < stateVecSize; idx++) { stateVec(idx) = baseAngularVel(idx - angVelOffset); }
+
+    m_comms.floatingBaseStatePort.write();
+
+    yarp::sig::Matrix basePoseYARP;
+    iDynTree::toYarp(estimatorOut.basePose, basePoseYARP);
+    if (m_publishROSTF && m_transformInterface != nullptr)
+    {
+        if (!m_transformInterface->setTransform("/world", "/base_link", basePoseYARP))
+        {
+            yError() << "[FloatingBaseEstimatorDevice] Could not publish measured base pose transform from  primary IMU";
+        }
+    }
+}
+
+void FloatingBaseEstimatorDevice::publishInternalStateAndStdDev(const FloatingBaseEstimators::Output& estimatorOut)
+{
+    size_t vecSize{27};
+
+    const auto& s = estimatorOut.state;
+    const auto& d = estimatorOut.stateStdDev;
+    auto imuRPY = s.imuOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+    auto rfRPY = s.rContactFrameOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+    auto lfRPY = s.lContactFrameOrientation.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+
+    Eigen::VectorXd internalstateAndStdDev;
+    internalstateAndStdDev.resize(vecSize + vecSize);
+    internalstateAndStdDev << s.imuPosition, imuRPY, s.imuLinearVelocity,
+                              s.rContactFramePosition, rfRPY,
+                              s.lContactFramePosition, lfRPY,
+                              s.accelerometerBias, s.gyroscopeBias,
+                              d.imuPosition, d.imuOrientation, d.imuLinearVelocity,
+                              d.rContactFramePosition, d.rContactFrameOrientation,
+                              d.lContactFramePosition, d.lContactFrameOrientation,
+                              d.accelerometerBias, d.gyroscopeBias;
+
+    yarp::sig::Vector& stateAndStdDev = m_comms.internalStateAndStdDevPort.prepare();
+    stateAndStdDev.clear();
+    stateAndStdDev.resize(vecSize + vecSize);
+
+    for (size_t idx = 0; idx < 2*vecSize; idx++)
+    {
+        stateAndStdDev(idx) = internalstateAndStdDev[idx];
+    }
+
+    m_comms.internalStateAndStdDevPort.write();
+}
+
+void FloatingBaseEstimatorDevice::publishFootContactStatesAndNormalForces()
+{
+    yarp::sig::Vector& contactVec = m_comms.contactStatePort.prepare();
+    contactVec.clear();
+
+    contactVec.resize(4);
+    const int scaling_const_for_visualization{300};
+    contactVec(0) = scaling_const_for_visualization*static_cast<int>(m_currentlFootState);
+    contactVec(1) = scaling_const_for_visualization*static_cast<int>(m_currentrFootState);
+    contactVec(2) = m_currentlContactNormal;
+    contactVec(3) = m_currentrContactNormal;
+    m_comms.contactStatePort.write();
+}
+
+bool FloatingBaseEstimatorDevice::detachAll()
+{
+    std::lock_guard<std::mutex> guard(m_deviceMutex);
+    if (isRunning())
+    {
+        stop();
+    }
+
+    return true;
+}
+
+void FloatingBaseEstimatorDevice::closeBufferedSigPort(yarp::os::BufferedPort<yarp::sig::Vector>& port)
+{
+    if (!port.isClosed())
+    {
+        port.close();
+    }
+
+    if (m_publishROSTF)
+    {
+        m_transformInterface = nullptr;
+    }
+}
+
+void FloatingBaseEstimatorDevice::closeCommunications()
+{
+    closeBufferedSigPort(m_comms.floatingBaseStatePort);
+    closeBufferedSigPort(m_comms.internalStateAndStdDevPort);
+    closeBufferedSigPort(m_comms.contactStatePort);
+}
+
+bool FloatingBaseEstimatorDevice::close()
+{
+    std::lock_guard<std::mutex> guard(m_deviceMutex);
+    closeCommunications();
+    return true;
+}
+
+bool FloatingBaseEstimatorDevice::loadTransformBroadcaster()
+{
+    yarp::os::Property tfBroadcasterSettings{{"device", yarp::os::Value("transformClient")},
+                                             {"remote", yarp::os::Value("/transformServer")},
+                                             {"local", yarp::os::Value(m_portPrefix + "/transformClient")}};
+
+    if (!m_transformBroadcaster.open(tfBroadcasterSettings))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][loadTransformBroadcaster] could not open transform broadcaster.";
+        return false;
+    }
+
+    if (!m_transformBroadcaster.view(m_transformInterface))
+    {
+        yError() << "[FloatingBaseEstimatorDevice][loadTransformBroadcaster] could not access transform interface";
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
This PR adds a YARP device wrapper for the FloatingBaseEstimator library, in its current version implementing an InvariantEKF.


**Remark for reviewers:**
Mostly contains small files for configuration and scopes.
Only two files for the source code are significantly big.
