### PR TITLE
Propose a first implementation of the Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,3 +114,6 @@ include(AddUninstallTarget)
 
 include(GenerateAndAddUrdfModel)
 add_subdirectory(Python)
+
+
+add_subdirectory(bindings)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+option(FRAMEWORK_USES_PYTHON "Do you want to create the Python bindings" FALSE)
+
+if(FRAMEWORK_USES_PYTHON)
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if (Python3_FOUND)
+        execute_process(COMMAND ${Python3_EXECUTABLE}
+            -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+            OUTPUT_VARIABLE _PYTHON_INSTDIR)
+        string(STRIP ${_PYTHON_INSTDIR} FRAMEWORK_PYTHON_INSTALL_DIR)
+        # # Bindings are installed in `BipedalLocomotion` subdirectory.
+        # list(APPEND FRAMEWORK_BINARY_DIRS "${FRAMEWORK_PYTHON_INSTALL_DIR}/BipedalLocomotion")
+    endif()
+endif()
+
+# Setup installation directory for Python bindings.
+if (FRAMEWORK_USES_PYTHON)
+  set(PYTHON_INSTDIR ${FRAMEWORK_PYTHON_INSTALL_DIR}/BipedalLocomotion)
+endif()
+
+find_package(pybind11 QUIET)
+if (FRAMEWORK_USES_PYTHON)
+  if (${pybind11_FOUND})
+        add_subdirectory(python)
+    else()
+       MESSAGE(FATAL_ERROR "pybind11 not found, impossible to generate Bipedal-locomotion-framework bindings.")
+    endif()
+endif()
+
+# Install main __init__.py file.
+if (FRAMEWORK_USES_PYTHON)
+    if (WIN32)
+        set(NEW_LINE "\n\r")
+    else()
+        set(NEW_LINE "\n")
+    endif()
+    # Clear the file first if it exists.
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/__init__.py "")
+    # If pybind is enabled, add the corresponding import.
+    if (${FRAMEWORK_USES_PYTHON})
+        file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/__init__.py "from . import pybind${NEW_LINE}")
+    endif()
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
+             DESTINATION ${PYTHON_INSTDIR})
+endif()

--- a/bindings/python/BipedalLocomotion.cpp
+++ b/bindings/python/BipedalLocomotion.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file BipedalLocomotion.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+
+#include <vector>
+
+#include "BipedalLocomotion_GenericContainer.h"
+#include "BipedalLocomotion_ParametersHandler.h"
+#include "BipedalLocomotion_Planners.h"
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace
+{
+
+namespace py = ::pybind11;
+PYBIND11_MODULE(pybind, m)
+{
+    BipedalLocomotion::bindings::BipedalLocomotionGenericContainerBindings(m);
+    BipedalLocomotion::bindings::BipedalLocomotionParametersHandlerBindings(m);
+    BipedalLocomotion::bindings::BipedalLocomotionPlannersBindings(m);
+}
+
+} // namespace
+} // namespace BipedalLocomotion

--- a/bindings/python/BipedalLocomotion_GenericContainer.cpp
+++ b/bindings/python/BipedalLocomotion_GenericContainer.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file BipedalLocomotion_GenericContainer.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/operators.h>
+
+#include <BipedalLocomotion/GenericContainer/Vector.h>
+
+#include "BipedalLocomotion_GenericContainer.h"
+using namespace BipedalLocomotion::GenericContainer;
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace
+{
+namespace py = ::pybind11;
+template <typename T> void createVector(pybind11::module& module, const std::string& className)
+{
+    py::class_<Vector<T>>(module, className.c_str())
+        .def(py::init<iDynTree::Span<T>>())
+        .def("clone", static_cast<bool (Vector<T>::*)(const Vector<T>&)>(&Vector<T>::clone))
+        .def("clone", static_cast<bool (Vector<T>::*)(iDynTree::Span<T>)>(&Vector<T>::clone))
+        .def("__len__", &Vector<T>::size)
+        .def("resize", &Vector<T>::resize)
+        .def("resize_vector", &Vector<T>::resizeVector)
+        .def("empty", &Vector<T>::empty);
+}
+
+} // namespace
+
+void BipedalLocomotionGenericContainerBindings(pybind11::module& module)
+{
+    createVector<int>(module, "VectorInt");
+    createVector<double>(module, "VectorDouble");
+    createVector<std::string>(module, "VectorString");
+}
+
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/BipedalLocomotion_GenericContainer.h
+++ b/bindings/python/BipedalLocomotion_GenericContainer.h
@@ -1,0 +1,23 @@
+/**
+ * @file BipedalLocomotion_GenericContainer.h
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_GENERIC_CONTAINER_H
+#define BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_GENERIC_CONTAINER_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+
+void BipedalLocomotionGenericContainerBindings(pybind11::module& module);
+
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_GENERIC_CONTAINER_H

--- a/bindings/python/BipedalLocomotion_ParametersHandler.cpp
+++ b/bindings/python/BipedalLocomotion_ParametersHandler.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file BipedalLocomotion_GenericContainer.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/operators.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+
+#include "BipedalLocomotion_ParametersHandler.h"
+using namespace BipedalLocomotion::ParametersHandler;
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace
+{
+
+namespace py = ::pybind11;
+void createIParameterHandler(pybind11::module& module)
+{
+    py::class_<IParametersHandler>(module, "IParameter_handler");
+
+}
+
+void createStdParameterHandler(pybind11::module& module)
+{
+    py::class_<StdImplementation, IParametersHandler>(module, "parameter_handler")
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, const int&)>(&StdImplementation::setParameter))
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, const double&)>(&StdImplementation::setParameter))
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, const std::string&)>(&StdImplementation::setParameter))
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, const bool&)>(&StdImplementation::setParameter))
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, const std::vector<bool>&)>(&StdImplementation::setParameter))
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, BipedalLocomotion::GenericContainer::Vector<const int>::Ref)>(&StdImplementation::setParameter))
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, BipedalLocomotion::GenericContainer::Vector<const double>::Ref)>(&StdImplementation::setParameter))
+        .def("set_parameter", static_cast<void (StdImplementation::*)(const std::string&, BipedalLocomotion::GenericContainer::Vector<const std::string>::Ref)>(&StdImplementation::setParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, int&) const>(&StdImplementation::getParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, double&) const>(&StdImplementation::getParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, std::string&) const>(&StdImplementation::getParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, bool&) const>(&StdImplementation::getParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, std::vector<bool>&) const>(&StdImplementation::getParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, BipedalLocomotion::GenericContainer::Vector<int>::Ref) const>(&StdImplementation::getParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, BipedalLocomotion::GenericContainer::Vector<double>::Ref) const>(&StdImplementation::getParameter))
+        .def("get_parameter", static_cast<bool (StdImplementation::*)(const std::string&, BipedalLocomotion::GenericContainer::Vector<std::string>::Ref) const>(&StdImplementation::getParameter))
+        .def("is_empty", &StdImplementation::isEmpty)
+        .def("__repr__", &StdImplementation::toString)
+        .def("clear", &StdImplementation::clear);
+}
+
+} // namespace
+
+void BipedalLocomotionParametersHandlerBindings(pybind11::module& module)
+{
+    createIParameterHandler(module);
+    createStdParameterHandler(module);
+}
+
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/BipedalLocomotion_ParametersHandler.h
+++ b/bindings/python/BipedalLocomotion_ParametersHandler.h
@@ -1,0 +1,24 @@
+/**
+ * @file BipedalLocomotion_ParameterHandler.h
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_PARAMETER_HANDLER_H
+#define BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_PARAMETER_HANDLER_H
+
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+
+void BipedalLocomotionParametersHandlerBindings(pybind11::module& module);
+
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_PARAMETER_HANDLER_H

--- a/bindings/python/BipedalLocomotion_Planners.cpp
+++ b/bindings/python/BipedalLocomotion_Planners.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file BipedalLocomotion_Planners.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+
+#include <BipedalLocomotion/Planners/QuinticSpline.h>
+
+#include "BipedalLocomotion_Planners.h"
+
+using namespace BipedalLocomotion::Planners;
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace
+{
+
+namespace py = ::pybind11;
+void createQuinticSpline(pybind11::module& module)
+{
+    py::class_<QuinticSpline>(module, "QuinticSpline")
+        .def(py::init())
+        .def("set_knots", &QuinticSpline::setKnots)
+        .def("set_initial_conditions", &QuinticSpline::setInitialConditions)
+        .def("set_final_conditions", &QuinticSpline::setFinalConditions)
+        .def("evaluate_point",
+             static_cast<bool (QuinticSpline::*)(const double&,
+                                                 Eigen::Ref<Eigen::VectorXd>,
+                                                 Eigen::Ref<Eigen::VectorXd>,
+                                                 Eigen::Ref<Eigen::VectorXd>)>(
+                 &QuinticSpline::evaluatePoint));
+}
+
+} // namespace
+
+void BipedalLocomotionPlannersBindings(pybind11::module& module)
+{
+    createQuinticSpline(module);
+}
+
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/BipedalLocomotion_Planners.h
+++ b/bindings/python/BipedalLocomotion_Planners.h
@@ -1,0 +1,23 @@
+/**
+ * @file BipedalLocomotion_Planners.h
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_PLANNERS_H
+#define BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_PLANNERS_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+
+void BipedalLocomotionPlannersBindings(pybind11::module& module);
+
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_PYTHON_BINDINGS_PLANNERS_H

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
+
+pybind11_add_module(pybind11_BipedalLocomotion SYSTEM
+  BipedalLocomotion.cpp
+  BipedalLocomotion_GenericContainer.h BipedalLocomotion_GenericContainer.cpp
+  BipedalLocomotion_ParametersHandler.h BipedalLocomotion_ParametersHandler.cpp
+  BipedalLocomotion_Planners.h BipedalLocomotion_Planners.cpp)
+
+target_link_libraries(pybind11_BipedalLocomotion PUBLIC
+  BipedalLocomotion::GenericContainer
+  BipedalLocomotion::ParametersHandler
+  BipedalLocomotion::Planners)
+
+# The generated Python dynamic module must have the same name as the pybind11
+# module, i.e. `bindings`.
+set_target_properties(pybind11_BipedalLocomotion PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/BipedalLocomotion
+    OUTPUT_NAME "pybind")
+
+if(FRAMEWORK_COMPILE_tests)
+    add_subdirectory(tests)
+endif()
+
+# Output package is:
+# BipedalLocomotion
+# |
+# |- __init__.py (generated from main bindings CMake file).
+# |
+# |_ pybind.<cpython_extension>
+install(TARGETS pybind11_BipedalLocomotion DESTINATION ${PYTHON_INSTDIR})

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+add_test (NAME pybind11_BipdealLocomotion_test
+  COMMAND ${Python3_EXECUTABLE} -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/bindings/python
+)

--- a/bindings/python/tests/test_bipedal_locomotion_planners.py
+++ b/bindings/python/tests/test_bipedal_locomotion_planners.py
@@ -1,0 +1,94 @@
+"""Tests for BipedalLocotion::Planners Python bindings."""
+import itertools
+import unittest
+
+import BipedalLocomotion.pybind as bl
+import numpy as np
+
+
+class QuinticSplineTest(unittest.TestCase):
+
+    def test_spline(self):
+
+        number_of_points = 100
+        init_time = 0.32
+        final_time = 2.64
+
+        dT = (final_time - init_time) / (number_of_points - 1)
+
+        coefficients = [np.random.rand(4,1) for i in range(6)]
+
+        time = [init_time + dT * i for i in range(number_of_points)]
+
+
+        knots = [coefficients[0] + coefficients[1] * t \
+                        + coefficients[2] * (t ** 2) \
+                        + coefficients[3] * (t ** 3) \
+                        + coefficients[4] * (t ** 4) \
+                        + coefficients[5] * (t ** 5) for t in time]
+
+
+        init_velocity = coefficients[1] + 2 * coefficients[2] * init_time \
+                                   + 3 * coefficients[3] * (init_time ** 2) \
+                                   + 4 * coefficients[4] * (init_time ** 3) \
+                                   + 5 * coefficients[5] * (init_time ** 4)
+
+        init_acceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * init_time \
+                                       + 4 * 3 * coefficients[4] * (init_time ** 2) \
+                                       + 5 * 4 * coefficients[5] * (init_time ** 3)
+
+        final_velocity = coefficients[1] + 2 * coefficients[2] * final_time  \
+                                   + 3 * coefficients[3] * (final_time ** 2) \
+                                   + 4 * coefficients[4] * (final_time ** 3) \
+                                   + 5 * coefficients[5] * (final_time ** 4)
+
+        final_acceleration = 2 * coefficients[2] + 3 * 2 * coefficients[3] * final_time \
+                                       + 4 * 3 * coefficients[4] * (final_time ** 2)    \
+                                       + 5 * 4 * coefficients[5] * (final_time ** 3)
+
+
+        spline = bl.QuinticSpline()
+
+        self.assertTrue(spline.set_knots(knots, time));
+        self.assertTrue(spline.set_initial_conditions(init_velocity, init_acceleration));
+        self.assertTrue(spline.set_final_conditions(final_velocity, final_acceleration));
+
+        points_to_check_number = 1e4
+
+
+        dT_check_points = (final_time - init_time) / (points_to_check_number);
+
+        position = np.ndarray(shape =(4))
+        velocity = np.ndarray(shape =(4))
+        acceleration = np.ndarray(shape =(4))
+
+        for i in range(int(points_to_check_number)):
+
+            t = dT_check_points * i + init_time;
+
+            self.assertTrue(spline.evaluate_point(t, position, velocity, acceleration));
+
+            expected = coefficients[0] + coefficients[1] * t \
+                       + coefficients[2] * (t ** 2) \
+                       + coefficients[3] * (t ** 3) \
+                       + coefficients[4] * (t ** 4) \
+                       + coefficients[5] * (t ** 5)
+            
+            self.assertTrue(np.allclose(expected.transpose()[0], position, atol = 1e-5))
+
+            # check velocity
+            expected = coefficients[1] + 2 * coefficients[2] * t \
+                       + 3 * coefficients[3] * (t ** 2) \
+                       + 4 * coefficients[4] * (t ** 3) \
+                       + 5 * coefficients[5] * (t ** 4)
+            self.assertTrue(np.allclose(expected.transpose()[0], velocity, atol = 1e-5))
+
+            # check acceleration
+            expected = 2 * coefficients[2] \
+                       + 3 * 2 * coefficients[3] * t \
+                       + 4 * 3 * coefficients[4] * (t ** 2) \
+                       + 5 * 4 * coefficients[5] * (t ** 3)
+            self.assertTrue(np.allclose(expected.transpose()[0], acceleration, atol = 1e-5))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR proposes a first implementation of the python bindings using pybind11. 

Among all the components of BipedalLocomotionFramework only the QuinticSpline binding has been tested. 

The main skeleton of this PR is taken from https://github.com/robotology/idyntree/pull/741.

The mapping between `eigen` and `numpy` is automatically done by `pybind11`.

This is an example of python code that can be used to compute the `QuinticSpline`
```python
import BipedalLocomotion.pybind as bl
import numpy as np

init_time = 0.32
final_time = 2.64

time = [init_time, 0.45, 1.0, 1.5, final_time]
knots = [np.random.rand(4,1) for i in range(5)]

init_velocity = np.zeros(5)
init_acceleration = np.zeros(5)

final_velocity = np.zeros(5)
final_acceleration = np.zeros(5)

spline = bl.QuinticSpline()

spline.set_knots(knots, time)
spline.set_initial_conditions(init_velocity, init_acceleration)
spline.set_final_conditions(final_velocity, final_acceleration))

position = np.ndarray(shape =(4))
velocity = np.ndarray(shape =(4))
acceleration = np.ndarray(shape =(4))

t = 0.86
spline.evaluate_point(t, position, velocity, acceleration)
```

cc @diegoferigo @traversaro @S-Dafarra @DanielePucci 