### PR TITLE
Fix default resizer.

### DIFF
--- a/src/GenericContainer/include/BipedalLocomotion/GenericContainer/Vector.h
+++ b/src/GenericContainer/include/BipedalLocomotion/GenericContainer/Vector.h
@@ -658,7 +658,7 @@ typename Vector<typename container_data<Class>::type>::resize_function_type Defa
 
         Class* inputPtr = &input;
         resize_function resizeLambda =
-            [inputPtr](index_type newSize) -> iDynTree::Span<typename Class::value_type>
+            [inputPtr](index_type newSize) -> iDynTree::Span<value_type>
         {
             inputPtr->resize(newSize);
             return iDynTree::make_span(*inputPtr);


### PR DESCRIPTION
It was assuming value_type to be defined, even if not necessary.