### PR TITLE
Implement constructYarpRobotDevice

### DIFF
--- a/src/RobotInterface/YarpImplementation/CMakeLists.txt
+++ b/src/RobotInterface/YarpImplementation/CMakeLists.txt
@@ -6,8 +6,8 @@ if(FRAMEWORK_COMPILE_YarpImplementation)
 
   add_bipedal_locomotion_library(
     NAME                   RobotInterfaceYarpImplementation
-    SOURCES                src/YarpRobotControl.cpp src/YarpSensorBridge.cpp
-    PUBLIC_HEADERS         include/BipedalLocomotion/RobotInterface/YarpRobotControl.h include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+    SOURCES                src/YarpRobotControl.cpp src/YarpSensorBridge.cpp src/YarpHelper.cpp
+    PUBLIC_HEADERS         include/BipedalLocomotion/RobotInterface/YarpRobotControl.h include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h include/BipedalLocomotion/RobotInterface/YarpHelper.h
     PRIVATE_HEADERS        include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::RobotInterface BipedalLocomotion::System YARP::YARP_dev YARP::YARP_os YARP::YARP_sig
     INSTALLATION_FOLDER    RobotInterface)

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -1,0 +1,42 @@
+/**
+ * @file YarpHelper.h
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_HELPER_H
+#define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_HELPER_H
+
+// std
+#include <memory>
+
+// YARP
+#include <yarp/dev/PolyDriver.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+
+namespace BipedalLocomotion
+{
+namespace RobotInterface
+{
+
+/**
+ * Helper function that can be used to build a RemoteControlBoardRemapper device.
+ * @param handler pointer to a parameter handler interface.
+ * @note the following parameters are required by the function
+ * |      Parameter Name     |       Type       |                         Description                        | Mandatory |
+ * |:-----------------------:|:----------------:|:----------------------------------------------------------:|:---------:|
+ * |      `joints_list`      | `vector<string>` |                List of the controlled joints               |    Yes    |
+ * | `remote_control_boards` | `vector<string>` | List of the remote control boards associated to the joints |    Yes    |
+ * |       `robot_name`      |     `string`     |                      Name of the robot                     |    Yes    |
+ * |       `local_name`      |     `string`     |                Name of the local application               |    Yes    |
+ * @return A shared_ptr to the PolyDriver. If one of the parameters is missing a nullptr is returned.
+ */
+std::shared_ptr<yarp::dev::PolyDriver> constructYarpRobotDevice(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+} // namespace RobotInterface
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_HELPER_H

--- a/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpHelper.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file YarpHelper.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/RobotInterface/YarpHelper.h>
+
+std::shared_ptr<yarp::dev::PolyDriver> BipedalLocomotion::RobotInterface::constructYarpRobotDevice(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+{
+    auto robotDevice = std::make_shared<yarp::dev::PolyDriver>();
+    auto ptr = handler.lock();
+
+    if (ptr == nullptr)
+    {
+        std::cerr << "[constructYarpRobotDevice] IParametershandler is empty." << std::endl;
+        return robotDevice;
+    }
+
+    bool ok = true;
+
+    std::vector<std::string> jointsList;
+    ok = ok && ptr->getParameter("joints_list", jointsList);
+
+    std::vector<std::string> controlBoards;
+    ok = ok && ptr->getParameter("remote_control_boards", controlBoards);
+
+    std::string robotName;
+    ok = ok && ptr->getParameter("robot_name", robotName);
+
+    std::string localName;
+    ok = ok && ptr->getParameter("local_name", localName);
+
+    if (!ok)
+    {
+        std::cerr << "[constructYarpRobotDevice] Unable to get all the parameters from "
+                     "configuration file."
+                  << std::endl;
+        return robotDevice;
+    }
+
+    // open the remotecontrolboardremepper YARP device
+    yarp::os::Property options;
+    options.put("device", "remotecontrolboardremapper");
+
+    options.addGroup("axesNames");
+    yarp::os::Bottle& bottle = options.findGroup("axesNames").addList();
+    for (const auto& joint : jointsList)
+        bottle.addString(joint);
+
+    yarp::os::Bottle remoteControlBoards;
+
+    yarp::os::Bottle& remoteControlBoardsList = remoteControlBoards.addList();
+    for (const auto& controlBoard : controlBoards)
+        remoteControlBoardsList.addString("/" + robotName + "/" + controlBoard);
+
+    options.put("remoteControlBoards", remoteControlBoards.get(0));
+    options.put("localPortPrefix", "/" + localName + "/remoteControlBoard");
+    yarp::os::Property& remoteControlBoardsOpts = options.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
+    remoteControlBoardsOpts.put("writeStrict", "on");
+
+    if (!robotDevice->open(options) && !robotDevice->isValid())
+    {
+        std::cerr << "[configureRobot] Could not open remotecontrolboardremapper object."
+                  << std::endl;
+        return robotDevice;
+    }
+
+    return robotDevice;
+}


### PR DESCRIPTION
`constructYarpRobotDevice` function has been implement. Thanks to this function it will be easy to create a remote control board polydriver. 

The function is then used in the `joint-position-tracking` application.

cc @isorrentino 
