### PR TITLE
Allow FloatingBaseEstimator to handle multiple contacts, Implement Legged Odometry and favor iDynTree KinDynComputations instead of Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,5 +34,6 @@ All notable changes to this project are documented in this file.
 - Implement `ContactDetectors` library. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/142)
 - Added `mas-imu-test` application to check the output of MAS IMUs (https://github.com/dic-iit/bipedal-locomotion-framework/pull/62)
 - Implement motor currents reading in `YarpSensorBridge`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/187)
+- Implement `LeggedOdometry` class as a part of `FloatingBaseEstimators` library and handle arbitrary contacts in `FloatingBaseEstimator`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/151)
 
 [Unreleased]: https://github.com/dic-iit/bipedal-locomotion-framework/

--- a/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
+++ b/devices/FloatingBaseEstimatorDevice/include/BipedalLocomotion/FloatingBaseEstimatorDevice.h
@@ -75,6 +75,7 @@ private:
     } m_comms;
 
     iDynTree::Model m_model;
+    std::shared_ptr<iDynTree::KinDynComputations> m_kinDyn;
     std::unique_ptr<BipedalLocomotion::RobotInterface::YarpSensorBridge> m_robotSensorBridge;
     std::unique_ptr<BipedalLocomotion::Estimators::FloatingBaseEstimator> m_estimator;
     std::unique_ptr<iDynTree::ContactStateMachine> m_lFootCSM, m_rFootCSM;

--- a/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
+++ b/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
@@ -205,7 +205,8 @@ bool FloatingBaseEstimatorDevice::setupBaseEstimator(yarp::os::Searchable& confi
     originalHandler->set(config);
     IParametersHandler::shared_ptr parameterHandler = originalHandler;
 
-    if (!m_estimator->initialize(parameterHandler, m_model))
+    m_kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    if (!m_estimator->initialize(parameterHandler, m_kinDyn, m_model))
     {
         yError() << "[FloatingBaseEstimatorDevice][setupRobotModel] Could not configure estimator";
         return false;

--- a/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
+++ b/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
@@ -206,7 +206,8 @@ bool FloatingBaseEstimatorDevice::setupBaseEstimator(yarp::os::Searchable& confi
     IParametersHandler::shared_ptr parameterHandler = originalHandler;
 
     m_kinDyn = std::make_shared<iDynTree::KinDynComputations>();
-    if (!m_estimator->initialize(parameterHandler, m_kinDyn, m_model))
+    m_kinDyn->loadRobotModel(m_model);
+    if (!m_estimator->initialize(parameterHandler, m_kinDyn))
     {
         yError() << "[FloatingBaseEstimatorDevice][setupRobotModel] Could not configure estimator";
         return false;

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -26,9 +26,9 @@ if(FRAMEWORK_COMPILE_FloatingBaseEstimators)
   set(H_PREFIX include/BipedalLocomotion/FloatingBaseEstimators)
   add_bipedal_locomotion_library(
     NAME                   FloatingBaseEstimators
-    SOURCES                src/FloatingBaseEstimator.cpp src/InvariantEKFBaseEstimator.cpp
+    SOURCES                src/FloatingBaseEstimator.cpp src/InvariantEKFBaseEstimator.cpp src/LeggedOdometry.cpp
     SUBDIRECTORIES         tests/FloatingBaseEstimators
-    PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h ${H_PREFIX}/InvariantEKFBaseEstimator.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen
+    PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h ${H_PREFIX}/InvariantEKFBaseEstimator.h ${H_PREFIX}/LeggedOdometry.h
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts
     PRIVATE_LINK_LIBRARIES MANIF::manif)
 endif()

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
@@ -196,10 +196,12 @@ public:
     * @param[in] name contact frame name
     * @param[in] contactStatus flag to check active contact
     * @param[in] switchTime  time of switching contact
+    * @param[in] timeNow  current measurement update time
     */
     bool setContactStatus(const std::string& name, 
                           const bool& contactStatus, 
-                          const double& switchTime);
+                          const double& switchTime,
+                          double timeNow = 0.);
 
     /**
     * Set kinematic measurements

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
@@ -195,11 +195,11 @@ public:
     * 
     * @param[in] name contact frame name
     * @param[in] contactStatus flag to check active contact
-    * @param[in] timeNow  time of measurement update
+    * @param[in] switchTime  time of switching contact
     */
     bool setContactStatus(const std::string& name, 
                           const bool& contactStatus, 
-                          const double& timeNow);
+                          const double& switchTime);
 
     /**
     * Set kinematic measurements

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
@@ -115,11 +115,14 @@ public:
          */
         const int& nrJoints() const { return m_nrJoints; }
         const std::string& baseLink() const { return m_baseLink; }
+        const iDynTree::FrameIndex& baseLinkIdx() const { return m_baseLinkIdx; }
+        const iDynTree::FrameIndex& baseIMUIdx() const { return m_baseImuIdx; }
         const std::string& baseLinkIMU() const { return m_baseImuFrame; }
         const std::string& leftFootContactFrame() const { return m_lFootContactFrame; }
         const std::string& rightFootContactFrame() const { return m_rFootContactFrame; }
         const iDynTree::Transform& base_H_IMU() const { return m_base_H_imu; }
         const bool& isModelSet() const { return m_modelSet; }
+        iDynTree::KinDynComputations& kinDyn()  { return m_kindyn; }
 
     private:
         std::string m_baseLink{""}; /**< name of the floating base link*/
@@ -153,6 +156,7 @@ public:
     * @return True in case of success, false otherwise.
     */
     bool initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler, const iDynTree::Model& model);
+    
 
     /**
     * Set the polled IMU measurement
@@ -170,6 +174,17 @@ public:
     * @return True in case of success, false otherwise.
     */
     bool setContacts(const bool& lfInContact, const bool& rfInContact);
+
+    /**
+    * Set contact status
+    * 
+    * @param[in] name contact frame name
+    * @param[in] contactStatus flag to check active contact
+    * @param[in] timeNow  time of measurement update
+    */
+    bool setContactStatus(const std::string& name, 
+                          const bool& contactStatus, 
+                          const double& timeNow);
 
     /**
     * Set kinematic measurements
@@ -194,7 +209,7 @@ public:
      *
      * @note reset and advance estimator to get updated estimator output
      */
-    virtual bool resetEstimator(const FloatingBaseEstimators::InternalState& newState) final;
+    virtual bool resetEstimator(const FloatingBaseEstimators::InternalState& newState);
 
     /**
      * Reset the base pose estimate and consequently the internal state of the estimator
@@ -205,7 +220,7 @@ public:
      * * @note reset and advance estimator to get updated estimator output
      */
     virtual bool resetEstimator(const Eigen::Quaterniond& newBaseOrientation,
-                                const Eigen::Vector3d& newBasePosition) final;
+                                const Eigen::Vector3d& newBasePosition);
 
     /**
     * Get estimator outputs
@@ -266,7 +281,7 @@ protected:
     * @param[in] dt sampling period in seconds
     * @return True in case of success, false otherwise.
     */
-    virtual bool updateKinematics(const FloatingBaseEstimators::Measurements& meas,
+    virtual bool updateKinematics(FloatingBaseEstimators::Measurements& meas,
                                   const double& dt) { return true; };
 
     /**
@@ -359,7 +374,8 @@ protected:
     State m_estimatorState{State::NotInitialized}; /**< State of the estimator */
 
     double m_dt{0.01}; /**< Fixed time step of the estimator, in seconds */
-
+    bool m_useIMUForAngVelEstimate{true}; /**< by default set to true for strap down IMU based EKF implementations, if IMU measurements not used, corresponding impl can set to false */
+    bool m_useIMUVelForBaseVelComputation{true};
 private:
     /**
     * Setup model related parameters

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
@@ -43,14 +43,7 @@ public:
     */
     class ModelComputations
     {
-    public:
-        /**
-        * Set the reduced model
-        * @param[in] model reduced iDynTree model
-        * @return True in case of success, false otherwise.
-        */
-        bool setModel(const iDynTree::Model& model);
-        
+    public:                
         /**
         * Set the shared kindyn object
         * @param[in] kinDyn shared pointer of the common KinDynComputations resource        
@@ -131,7 +124,6 @@ public:
         const std::string& leftFootContactFrame() const { return m_lFootContactFrame; }
         const std::string& rightFootContactFrame() const { return m_rFootContactFrame; }
         const iDynTree::Transform& base_H_IMU() const { return m_base_H_imu; }
-        const bool& isModelSet() const { return m_modelSet; }
         const bool& isKinDynValid() const { return m_validKinDyn; }
         std::shared_ptr<iDynTree::KinDynComputations> kinDyn() const { return m_kindyn; }
         
@@ -148,7 +140,6 @@ public:
         std::shared_ptr<iDynTree::KinDynComputations> m_kindyn{nullptr}; /**< KinDynComputations object to do the model specific computations */
         iDynTree::Transform m_base_H_imu; /**< Rigid body transform of IMU frame with respect to the base link frame */
         int m_nrJoints{0}; /**< number of joints in the loaded reduced model */
-        bool m_modelSet{false};
         bool m_validKinDyn{false};
     };
 
@@ -163,14 +154,12 @@ public:
     *      - right_foot_contact_frame [PARAMETER|REQUIRED|right foot contact frame from the URDF model| Exists in "ModelInfo" GROUP]
     * @param[in] handler configure the generic parameters for the estimator
     * @param[in] kindyn shared pointer of iDynTree kindyncomputations object (model will be loaded internally)
-    * @param[in] model reduced iDynTree model required by the estimator
     * @note any custom initialization of parameters or the algorithm implementation is not done here,
     *       it must be done in customInitialization() by the child class implementing the algorithm
     * @return True in case of success, false otherwise.
     */
     bool initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler, 
-                    std::shared_ptr<iDynTree::KinDynComputations> kindyn,
-                    const iDynTree::Model& model);
+                    std::shared_ptr<iDynTree::KinDynComputations> kindyn);
     
 
     /**

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h
@@ -380,8 +380,8 @@ protected:
     State m_estimatorState{State::NotInitialized}; /**< State of the estimator */
 
     double m_dt{0.01}; /**< Fixed time step of the estimator, in seconds */
-    bool m_useIMUForAngVelEstimate{true}; /**< by default set to true for strap down IMU based EKF implementations, if IMU measurements not used, corresponding impl can set to false */
-    bool m_useIMUVelForBaseVelComputation{true};
+    bool m_useIMUForAngVelEstimate{true}; /**< Use IMU measurements as internal state imu angular velocity by default set to true for strap down IMU based EKF implementations, if IMU measurements not used, corresponding impl can set to false */
+    bool m_useIMUVelForBaseVelComputation{true}; /**< Compute base velocity using inertnal state IMU velocity. by default set to true for strap down IMU based EKF implementations, if IMU measurements not used, corresponding impl can set to false */
 private:
     /**
     * Setup model related parameters

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorIO.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorIO.h
@@ -12,6 +12,9 @@
 #include <iDynTree/Core/Transform.h>
 #include <iDynTree/Core/Twist.h>
 
+#include <BipedalLocomotion/Contacts/Contact.h>
+#include <map>
+
 namespace BipedalLocomotion
 {
 namespace Estimators
@@ -34,6 +37,9 @@ struct InternalState
     Eigen::Vector3d rContactFramePosition; /**< Position of the right foot contact frame in the inertial frame*/
     Eigen::Vector3d accelerometerBias; /**< Bias of the accelerometer expressed in the IMU frame */
     Eigen::Vector3d gyroscopeBias; /**< Bias of the gyroscope expressed in the IMU frame */
+
+    Eigen::Vector3d imuAngularVelocity; /**< angular velocity of the IMU with respect to the inertial frame expressed in inertial frame, typically unused for strap-down IMU based EKF implementations*/
+    std::map<int, BipedalLocomotion::Contacts::EstimatedContact> supportFrameData; /**< contact measurements */
 };
 
 /**
@@ -59,6 +65,13 @@ struct Measurements
     Eigen::VectorXd encoders, encodersSpeed; /**< Joint position and joint velocity measurements */
     bool lfInContact{false}; /**< left foot contact state */
     bool rfInContact{false}; /**< right foot contact state */
+    
+    /** stamped contact status, 
+     * the usage of this map must be in a way 
+     * that every time an element is used, 
+     * it must be erased from the map 
+     */
+    std::map<int, std::pair<double, bool> > stampedContactsStatus;
 };
 
 } // namespace FloatingBaseEstimators

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorIO.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimatorIO.h
@@ -71,7 +71,7 @@ struct Measurements
      * that every time an element is used, 
      * it must be erased from the map 
      */
-    std::map<int, std::pair<double, bool> > stampedContactsStatus;
+    std::map<int, BipedalLocomotion::Contacts::EstimatedContact > stampedContactsStatus;
 };
 
 } // namespace FloatingBaseEstimators

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/InvariantEKFBaseEstimator.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/InvariantEKFBaseEstimator.h
@@ -120,7 +120,7 @@ protected:
     * @param[in] dt sampling period in seconds
     * @return True in case of success, false otherwise.
     */
-    virtual bool updateKinematics(const FloatingBaseEstimators::Measurements& meas,
+    virtual bool updateKinematics(FloatingBaseEstimators::Measurements& meas,
                                   const double& dt) override;
 
 private:

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
@@ -49,6 +49,8 @@ public:
                         const Eigen::Quaterniond& worldOrientationInRefFrame,
                         const Eigen::Vector3d& worldPositionInRefFrame);
 
+    int getFixedFrameIdx();
+
 protected:
     /**
     * These custom parameter specifications should be specified by the derived class.

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
@@ -1,0 +1,81 @@
+/**
+ * @file LeggedOdometry.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_LEGGED_ODOMETRY_H
+#define BIPEDAL_LOCOMOTION_LEGGED_ODOMETRY_H
+
+#include <BipedalLocomotion/FloatingBaseEstimators/FloatingBaseEstimator.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+class LeggedOdometry : public FloatingBaseEstimator
+{
+public:
+    /**
+     * Constructor
+     */
+    LeggedOdometry();
+
+    /**
+     * Destructor (necessary for PIMPL idiom)
+     */
+    ~LeggedOdometry();
+
+    /**
+     * To prevent function hiding due to overloading of virtual methods
+     */
+    using FloatingBaseEstimator::resetEstimator;
+
+    /**
+     * Reset the internal state of the estimator
+     * @param[in] newIMUOrientation  IMU orientation of the estimator
+     * @param[in] newIMUPosition  IMU position of the estimator
+     * @return True in case of success, false otherwise.
+     *
+     * @note reset and advance estimator to get updated estimator output
+     */
+    virtual bool resetEstimator(const Eigen::Quaterniond& newIMUOrientation, 
+                                const Eigen::Vector3d& newIMUPosition) override;
+
+    bool resetEstimator();
+
+    bool resetEstimator(const std::string refFramForWorld,
+                        const Eigen::Quaterniond& worldOrientationInRefFrame,
+                        const Eigen::Vector3d& worldPositionInRefFrame);
+
+protected:
+    /**
+    * These custom parameter specifications should be specified by the derived class.
+    * @param[in] handler configure the custom parameters for the estimator
+    * @return bool
+    */
+    virtual bool customInitialization(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler) override;
+
+    /**
+    * Update the base state estimate using kinematics and contact measurements
+    * @param[in] meas measurements to update states
+    * @param[in] dt sampling period in seconds
+    * @return True in case of success, false otherwise.
+    */
+    virtual bool updateKinematics(FloatingBaseEstimators::Measurements& meas,
+                                  const double& dt) override;
+
+
+private:
+    /**
+    * Private implementation of the class
+    */
+    class Impl;
+    std::unique_ptr<Impl> m_pimpl; /**< Pointer to implementation */
+};
+
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_INVEKF_BASE_ESTIMATOR_H

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
@@ -27,7 +27,7 @@ namespace Estimators
  * ||initial_ref_frame_for_world|string| No| Frame on the URDF model of the robot to be used as a reference to initialize the inertial frame for the estimation. If not present, the initial fixed frame is assumed as the reference|
  * ||initial_world_orientation_in_ref_frame|vector of 4 doubles| No | Orientation of the inertial frame wrt the the reference frame as quaternion wxyz. If not present, assumed to be unit quaternion.|
  * ||initial_world_position_in_ref_frame| vector of 3 doubles | No | Position of the inertial frame wrt the reference frame as xyz. If not present,assumed to be zero position|
- * ||switching_pattern|string|No| Options: latest, lastActive. Switching pattern to decide the fixed frame from the set of all frames in contact. latest chooses the recently switched contact frame, lastActive chooses the earliest switched contact frame. Default is lastActive|
+ * ||switching_pattern|string|No| Options: latest, lastActive, useExternal. Switching pattern to decide the fixed frame from the set of all frames in contact. latest chooses the recently switched contact frame, lastActive chooses the earliest switched contact frame. Default is latest|
  * ||vel_computation_method| string | No| Options: single, multiAvg, multiLS, multLSJvel. Method used for computing the floating base velocity using the fixed frame constraints. single uses only the fixed frame, multiAvg computes a simple average from all the contact frames, multLS uses a least square solution and multLSJVel regualrizes the least square solution by augmenting joint velocities in the computation. Default is multiLS.|
  * ||wLin|double|No| weight used for linear velocity in the least square computation of base velocity. If not present, set to 1.0|
  * ||wAng|double|No| weight used for angular velocity in the least square computation of base velocity. If not present, set to 0.5|
@@ -83,6 +83,11 @@ public:
     bool resetEstimator(const std::string refFramForWorld,
                         const Eigen::Quaterniond& worldOrientationInRefFrame,
                         const Eigen::Vector3d& worldPositionInRefFrame);
+
+    /**
+     * Change fixed frame externally
+     */
+    bool changeFixedFrame(const std::ptrdiff_t& frameIndex);
 
     /**
      * Get the index of the frame currently in contact used for the legged odometry computations

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h
@@ -14,6 +14,26 @@ namespace BipedalLocomotion
 {
 namespace Estimators
 {
+/**
+ * Floating base estimation algorithm using only kinematic measurements
+ * by assuming atleast one frame on the robot is in contact with the environment
+ *
+ * Configuration parameters,
+ *
+ * |Group| Parameter | Type| Required | Description|
+ * |:---:|:---:|:---:|:---:|:---:|
+ * |LeggedOdom| - | group | Yes| Configuration group for initializing the legged odometry block |
+ * ||initial_fixed_frame|string|Yes| Frame on the URDF model of the robot assumed to be fixed (in contact) during the initialization phase|
+ * ||initial_ref_frame_for_world|string| No| Frame on the URDF model of the robot to be used as a reference to initialize the inertial frame for the estimation. If not present, the initial fixed frame is assumed as the reference|
+ * ||initial_world_orientation_in_ref_frame|vector of 4 doubles| No | Orientation of the inertial frame wrt the the reference frame as quaternion wxyz. If not present, assumed to be unit quaternion.|
+ * ||initial_world_position_in_ref_frame| vector of 3 doubles | No | Position of the inertial frame wrt the reference frame as xyz. If not present,assumed to be zero position|
+ * ||switching_pattern|string|No| Options: latest, lastActive. Switching pattern to decide the fixed frame from the set of all frames in contact. latest chooses the recently switched contact frame, lastActive chooses the earliest switched contact frame. Default is lastActive|
+ * ||vel_computation_method| string | No| Options: single, multiAvg, multiLS, multLSJvel. Method used for computing the floating base velocity using the fixed frame constraints. single uses only the fixed frame, multiAvg computes a simple average from all the contact frames, multLS uses a least square solution and multLSJVel regualrizes the least square solution by augmenting joint velocities in the computation. Default is multiLS.|
+ * ||wLin|double|No| weight used for linear velocity in the least square computation of base velocity. If not present, set to 1.0|
+ * ||wAng|double|No| weight used for angular velocity in the least square computation of base velocity. If not present, set to 0.5|
+ * ||wJVel|double|No| weight used for linear velocity in the least square (with joint velocities) computation of base velocity. If not present, set to 10.0|
+ * ||reg|double|No| regularization used for matrix inversion operation in least square. If not present, set to 1e-6|
+ */
 class LeggedOdometry : public FloatingBaseEstimator
 {
 public:
@@ -43,12 +63,33 @@ public:
     virtual bool resetEstimator(const Eigen::Quaterniond& newIMUOrientation, 
                                 const Eigen::Vector3d& newIMUPosition) override;
 
+    /**
+     * Reset the internal state of the estimator using the initialized parameters
+     * @return True in case of success, false otherwise.
+     *
+     * @note reset and advance estimator to get updated estimator output
+     */
     bool resetEstimator();
 
+    /**
+     * Reset the internal state of the estimator by setting a new reference for the inertial frame
+     * @param[in] refFramForWorld  frame from the model as a reference to set the new inertial frame
+     * @param[in] worldOrientationInRefFrame  orientation of the inertial frame wrt to the reference frame
+     * @param[in] worldPositionInRefFrame  position of the inertial frame wrt to the reference frame
+     * @return True in case of success, false otherwise.
+     *
+     * @note reset and advance estimator to get updated estimator output
+     */
     bool resetEstimator(const std::string refFramForWorld,
                         const Eigen::Quaterniond& worldOrientationInRefFrame,
                         const Eigen::Vector3d& worldPositionInRefFrame);
 
+    /**
+     * Get the index of the frame currently in contact used for the legged odometry computations
+     * @return Index of the frame in contact, invalid frame index if no contact.
+     *
+     * @note reset and advance estimator to get updated estimator output
+     */
     int getFixedFrameIdx();
 
 protected:

--- a/src/Estimators/src/FloatingBaseEstimator.cpp
+++ b/src/Estimators/src/FloatingBaseEstimator.cpp
@@ -330,7 +330,7 @@ bool FloatingBaseEstimator::setContacts(const bool& lfInContact,
 
 bool FloatingBaseEstimator::setContactStatus(const std::string& name, 
                                              const bool& contactStatus, 
-                                             const double& timeNow)
+                                             const double& switchTime)
 {
     auto idx = m_modelComp.kinDyn()->model().getFrameIndex(name);
     if (!m_modelComp.kinDyn()->model().isValidFrameIndex(idx))
@@ -344,7 +344,7 @@ bool FloatingBaseEstimator::setContactStatus(const std::string& name,
     
     // operator[] creates a key-value pair if key does not already exist, 
     // otherwise just an update is carried out
-    contacts[idx].first = timeNow;
+    contacts[idx].first = switchTime;
     contacts[idx].second = contactStatus;
     
     return true;

--- a/src/Estimators/src/FloatingBaseEstimator.cpp
+++ b/src/Estimators/src/FloatingBaseEstimator.cpp
@@ -110,6 +110,18 @@ bool FloatingBaseEstimator::advance()
 
     ok = ok && updateBaseStateFromIMUState(m_state, m_measPrev,
                                            m_estimatorOut.basePose, m_estimatorOut.baseTwist);
+
+    if (!m_modelComp.kinDyn()->setRobotState(iDynTree::toEigen(m_estimatorOut.basePose.asHomogeneousTransform()),
+                                             iDynTree::make_span(m_meas.encoders.data(), m_meas.encoders.size()),
+                                             iDynTree::toEigen(m_estimatorOut.baseTwist),
+                                             iDynTree::make_span(m_meas.encodersSpeed.data(), m_meas.encodersSpeed.size()),
+                                             iDynTree::make_span(m_options.accelerationDueToGravity.data(), m_options.accelerationDueToGravity.size())))
+    {
+        std::cerr << "[FloatingBaseEstimator::advance]" << " Failed to get kindyncomputations robot state"
+                  << std::endl;
+        return false;
+    }
+
     m_statePrev = m_state;
     m_measPrev = m_meas;
 
@@ -706,17 +718,6 @@ bool FloatingBaseEstimator::updateBaseStateFromIMUState(const FloatingBaseEstima
         baseTwist = tempTwist;
     }
     
-    if (!m_modelComp.kinDyn()->setRobotState(iDynTree::toEigen(basePose.asHomogeneousTransform()), 
-                                             iDynTree::make_span(meas.encoders.data(), meas.encoders.size()),
-                                             iDynTree::toEigen(baseTwist), 
-                                             iDynTree::make_span(meas.encodersSpeed.data(), meas.encodersSpeed.size()),
-                                             iDynTree::make_span(m_options.accelerationDueToGravity.data(), m_options.accelerationDueToGravity.size())))
-    {
-        std::cerr << "[FloatingBaseEstimator::updateBaseStateFromIMUState]" << " Failed to get kindyncomputations robot state"
-                  << std::endl;
-        return false;
-    }
-
     return true;
 }
 

--- a/src/Estimators/src/FloatingBaseEstimator.cpp
+++ b/src/Estimators/src/FloatingBaseEstimator.cpp
@@ -330,7 +330,8 @@ bool FloatingBaseEstimator::setContacts(const bool& lfInContact,
 
 bool FloatingBaseEstimator::setContactStatus(const std::string& name, 
                                              const bool& contactStatus, 
-                                             const double& switchTime)
+                                             const double& switchTime,
+                                             double timeNow)
 {
     auto idx = m_modelComp.kinDyn()->model().getFrameIndex(name);
     if (!m_modelComp.kinDyn()->model().isValidFrameIndex(idx))
@@ -344,8 +345,9 @@ bool FloatingBaseEstimator::setContactStatus(const std::string& name,
     
     // operator[] creates a key-value pair if key does not already exist, 
     // otherwise just an update is carried out
-    contacts[idx].first = switchTime;
-    contacts[idx].second = contactStatus;
+    contacts[idx].switchTime = switchTime;
+    contacts[idx].isActive = contactStatus;
+    contacts[idx].lastUpdateTime = timeNow;
     
     return true;
 }

--- a/src/Estimators/src/InvariantEKFBaseEstimator.cpp
+++ b/src/Estimators/src/InvariantEKFBaseEstimator.cpp
@@ -364,7 +364,7 @@ bool InvariantEKFBaseEstimator::predictState(const FloatingBaseEstimators::Measu
     return true;
 }
 
-bool InvariantEKFBaseEstimator::updateKinematics(const FloatingBaseEstimators::Measurements& meas,
+bool InvariantEKFBaseEstimator::updateKinematics(FloatingBaseEstimators::Measurements& meas,
                                                  const double& dt)
 {
     Eigen::Matrix3d A_R_IMU = m_state.imuOrientation.toRotationMatrix();

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -1,0 +1,449 @@
+/**
+ * @file LeggedOdometry.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/FloatingBaseEstimators/LeggedOdometry.h>
+#include <BipedalLocomotion/Conversions/ManifConversions.h>
+#include <iDynTree/Core/EigenHelpers.h>
+
+#include <manif/manif.h>
+
+using namespace BipedalLocomotion::Estimators;
+using namespace BipedalLocomotion::Conversions;
+using namespace BipedalLocomotion::Contacts;
+
+class LeggedOdometry::Impl
+{
+public:
+
+    bool changeFixedFrame(const iDynTree::FrameIndex& newIdx,
+                          iDynTree::KinDynComputations& kinDyn);
+    bool updateInternalState(FloatingBaseEstimators::Measurements& meas,
+                             FloatingBaseEstimator::ModelComputations& modelComp,
+                             FloatingBaseEstimators::InternalState& state,
+                             FloatingBaseEstimators::Output& out);
+    void updateInternalContactStates(FloatingBaseEstimators::Measurements& meas,
+                                     FloatingBaseEstimator::ModelComputations& modelComp,
+                                     std::map<int, EstimatedContact>& contacts);
+    iDynTree::FrameIndex getLatestContact(const std::map<int, EstimatedContact>& contacts);
+    bool computeBaseIMUVelocityUsingFixedFrameConstraint(FloatingBaseEstimators::Measurements& meas,
+                                                         FloatingBaseEstimator::ModelComputations& modelComp,
+                                                         FloatingBaseEstimators::Output& out);
+    void resetInternal(FloatingBaseEstimator::ModelComputations& modelComp);
+
+    // parameters
+    std::string m_initialFixedFrame; /**<  Fixed frame at initialization assumed to be in rigid contact with the environment*/
+    std::string m_initialRefFrameForWorld; /**< Reference frame for the world at initialization */
+    iDynTree::FrameIndex m_initialFixedFrameIdx{iDynTree::FRAME_INVALID_INDEX};  /**< Index of fixed frame at initialization */
+    iDynTree::FrameIndex m_initialRefFrameForWorldIdx{iDynTree::FRAME_INVALID_INDEX};  /**< Index of world reference frame at initialization */
+    manif::SE3d m_refFrame_H_world; /**< pose of world wrt reference frame at initialization */
+
+    bool m_odometryInitialized{false}; /**< flag to check if odometry was initialized */
+
+    iDynTree::FrameIndex m_prevFixedFrameIdx{iDynTree::FRAME_INVALID_INDEX};
+    iDynTree::FrameIndex m_currentFixedFrameIdx{iDynTree::FRAME_INVALID_INDEX};
+
+    manif::SE3d m_world_H_fixedFrame; /**< Pose of fixed frame wrt world */
+    
+    Eigen::MatrixXd m_contactJacobian; /**< mixed velocity jacobian of fixed frame with respect to floating base */
+    Eigen::MatrixXd m_contactJacobianBase; /**< base sub-block of mixed velocity jacobian of fixed frame with respect to floating base */
+    Eigen::MatrixXd m_contactJacobianShape; /**< shape sub-block of mixed velocity jacobian of fixed frame with respect to floating base */
+    Eigen::VectorXd m_vBase; /**< mixed velocity representation of base link */
+    const int m_spatialDim{6};
+    const int m_baseOffset{0}; /**< offset in contact Jacobian for the base sub-block*/
+    const int m_shapeOffset{6}; /**< offset in contact Jacobian for the shape sub-block*/
+};
+
+LeggedOdometry::LeggedOdometry() : m_pimpl(std::make_unique<Impl>())
+{
+    m_state.imuOrientation.setIdentity();
+    m_state.imuPosition.setZero();
+    m_state.imuLinearVelocity.setZero();
+    m_state.rContactFrameOrientation.setIdentity();
+    m_state.rContactFramePosition.setZero();
+    m_state.lContactFrameOrientation.setIdentity();
+    m_state.lContactFramePosition.setZero();
+    m_state.accelerometerBias.setZero();
+    m_state.gyroscopeBias.setZero();
+    m_state.imuAngularVelocity.setZero();
+    
+    m_useIMUForAngVelEstimate = false;
+    m_useIMUVelForBaseVelComputation = false;
+    
+    m_statePrev = m_state;
+    m_estimatorOut.state = m_state;
+    
+    m_estimatorOut.baseTwist.zero();
+    m_estimatorOut.basePose.Identity();
+
+    m_meas.acc.setZero();   // unused
+    m_meas.gyro.setZero();  // unused
+    m_meas.lfInContact = false;
+    m_meas.rfInContact = false;
+    
+    m_pimpl->m_vBase.resize(m_pimpl->m_spatialDim);
+    m_pimpl->m_vBase.setZero();
+
+    m_measPrev = m_meas;    
+}
+
+LeggedOdometry::~LeggedOdometry() = default;
+
+bool LeggedOdometry::customInitialization(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+{
+    const std::string_view printPrefix = "[LeggedOdometry::customInitialization] ";
+    auto handle = handler.lock();
+    if (handle == nullptr)
+    {
+        std::cerr << printPrefix << "The parameter handler has expired. Please check its scope."
+        << std::endl;
+        return false;
+    }
+    
+    auto loHandler = handle->getGroup("LeggedOdom");
+    auto lohandle = loHandler.lock();
+    
+    if (!lohandle->getParameter("initial_fixed_frame", m_pimpl->m_initialFixedFrame))
+    {
+        std::cerr <<  printPrefix <<
+        "The parameter handler could not find \" initial_fixed_frame \" in the configuration file."
+        << std::endl;
+        return false;
+    }
+    else
+    {
+        m_pimpl->m_initialFixedFrameIdx = m_modelComp.kinDyn().model().getFrameIndex(m_pimpl->m_initialFixedFrame);
+        if (m_pimpl->m_initialFixedFrameIdx == iDynTree::FRAME_INVALID_INDEX)
+        {
+            std::cerr << printPrefix << "Specified fixed frame not available in the loaded URDF Model."
+            << std::endl;
+            return false;
+        }
+    }
+
+    std::vector<double> initialWorldOrientationInRefFrame{1., 0., 0., 0.};
+    std::vector<double> initialWorldPositionInRefFrame{0., 0., 0.};
+    if (!lohandle->getParameter("initial_ref_frame_for_world", m_pimpl->m_initialRefFrameForWorld))
+    {
+        std::cerr << printPrefix <<
+        "The parameter handler could not find \"initial_ref_frame_for_world \" in the configuration file. Setting \"initial_fixed_frame\" as reference frame for world"
+        << std::endl;
+        m_pimpl->m_initialRefFrameForWorld = m_pimpl->m_initialFixedFrame;
+    }
+    else
+    {
+        m_pimpl->m_initialRefFrameForWorldIdx = m_modelComp.kinDyn().model().getFrameIndex(m_pimpl->m_initialRefFrameForWorld);
+        if (m_pimpl->m_initialRefFrameForWorldIdx == iDynTree::FRAME_INVALID_INDEX)
+        {
+            std::cerr << printPrefix << "Specified reference frame for world not available in the loaded URDF Model."
+            << std::endl;
+            return false;
+        }
+
+        // setup initial states
+        if (!lohandle->getParameter("initial_world_orientation_in_ref_frame", GenericContainer::make_vector(initialWorldOrientationInRefFrame, GenericContainer::VectorResizeMode::Fixed)))
+        {
+            std::cerr <<  printPrefix << "The parameter handler could not find \"initial_world_orientation_in_ref_frame\" in the configuration file. Setting to identity" << std::endl;
+        }
+
+        if (!lohandle->getParameter("initial_world_position_in_ref_frame", GenericContainer::make_vector(initialWorldPositionInRefFrame, GenericContainer::VectorResizeMode::Fixed)))
+        {
+            std::cerr << printPrefix << "The parameter handler could not find \"initial_world_position_in_ref_frame\" in the configuration file. Setting to zero." << std::endl;
+        }
+    }
+
+    Eigen::Quaterniond refFrame_quat_world = Eigen::Quaterniond(initialWorldOrientationInRefFrame[0], initialWorldOrientationInRefFrame[1],
+                                                                initialWorldOrientationInRefFrame[2], initialWorldOrientationInRefFrame[3]); // here loaded as w x y z
+    refFrame_quat_world.normalize();
+    Eigen::Vector3d refFrame_p_world;
+    refFrame_p_world << initialWorldPositionInRefFrame[0], initialWorldPositionInRefFrame[1], initialWorldPositionInRefFrame[2];
+    m_pimpl->m_refFrame_H_world = manif::SE3d(refFrame_p_world, refFrame_quat_world);
+        
+    auto nrJoints = m_modelComp.kinDyn().getNrOfDegreesOfFreedom();
+    m_pimpl->m_contactJacobian.resize(m_pimpl->m_spatialDim, m_pimpl->m_spatialDim + nrJoints);
+    m_pimpl->m_contactJacobianBase.resize(m_pimpl->m_spatialDim, m_pimpl->m_spatialDim);
+    m_pimpl->m_contactJacobianShape.resize(m_pimpl->m_spatialDim, nrJoints);
+    m_pimpl->m_contactJacobian.setZero();
+    m_pimpl->m_contactJacobianBase.setZero();
+    m_pimpl->m_contactJacobianShape.setZero();
+    return true;
+}
+
+void LeggedOdometry::Impl::updateInternalContactStates(FloatingBaseEstimators::Measurements& meas,
+                                                       FloatingBaseEstimator::ModelComputations& modelComp,
+                                                       std::map<int, EstimatedContact>& contactStates)
+{    
+    for (auto& obs : meas.stampedContactsStatus)
+    {
+        auto& measContact = obs.second;
+        auto& idx = obs.first;
+        
+        if (contactStates.find(idx) != contactStates.end())
+        {
+            contactStates.at(idx).setContactStateStamped(measContact);
+            contactStates.at(idx).lastUpdateTime = measContact.first;
+        }
+        else
+        {
+            BipedalLocomotion::Contacts::EstimatedContact newContact;
+            newContact.setContactStateStamped(measContact);
+            newContact.lastUpdateTime = measContact.first;
+            newContact.index = idx;
+            newContact.name = modelComp.kinDyn().getFrameName(idx);
+            contactStates[idx] = newContact;
+        }
+    }
+    meas.stampedContactsStatus.clear();
+}
+
+iDynTree::FrameIndex LeggedOdometry::Impl::getLatestContact(const std::map<int, BipedalLocomotion::Contacts::EstimatedContact>& contacts)
+{
+    std::string_view printPrefix = "[LeggedOdometry::Impl::getLatestContact] ";
+    if (contacts.size() < 1)
+    {
+        std::cerr << printPrefix << "No contact data available." << std::endl;
+        return iDynTree::FRAME_INVALID_INDEX;
+    }
+
+    bool atleastOneActiveContact{false};
+    int latestContactIdx{-1};
+    double latestTime{-1.0}; // assuming time cannot be negative
+    for (auto& [idx, contact] : contacts)
+    {
+        if (contact.isActive)
+        {            
+            atleastOneActiveContact = true;
+            if (contact.switchTime > latestTime)
+            {
+                latestContactIdx = idx;
+                latestTime = contact.switchTime;                
+            }
+        }
+    }
+        
+    if (!atleastOneActiveContact)
+    {
+        std::cerr << printPrefix << "No active contacts." << std::endl;
+        return iDynTree::FRAME_INVALID_INDEX;
+    }
+            
+    return contacts.at(latestContactIdx).index;
+}
+
+
+bool LeggedOdometry::resetEstimator()
+{
+    m_pimpl->resetInternal(m_modelComp);
+    m_pimpl->updateInternalState(m_measPrev, m_modelComp, m_state, m_estimatorOut);
+    return true;
+}
+
+bool LeggedOdometry::resetEstimator(const Eigen::Quaterniond& newIMUOrientation, 
+                                    const Eigen::Vector3d& newIMUPosition)
+{    
+    manif::SE3d world_H_imu = manif::SE3d(newIMUPosition, newIMUOrientation);
+    manif::SE3d refFrame_H_imu  = toManifPose(modelComputations().kinDyn().
+                                              getRelativeTransform(m_pimpl->m_initialRefFrameForWorldIdx,
+                                                                   m_modelComp.baseIMUIdx()));
+    m_pimpl->m_refFrame_H_world = refFrame_H_imu*(world_H_imu.inverse());
+    
+    m_state.imuOrientation = newIMUOrientation;
+    m_state.imuPosition = newIMUPosition;
+    
+    m_statePrev = m_state;
+    
+    m_pimpl->resetInternal(m_modelComp);
+    return true;
+}
+
+bool LeggedOdometry::resetEstimator(const std::string refFrameForWorld, 
+                                    const Eigen::Quaterniond& worldOrientationInRefFrame, 
+                                    const Eigen::Vector3d& worldPositionInRefFrame)
+{
+    std::string_view printPrefix = "[LeggedOdometry::resetEstimator] ";
+    auto refFrameIdx = m_modelComp.kinDyn().model().getFrameIndex(refFrameForWorld);
+    if (refFrameIdx == iDynTree::FRAME_INVALID_INDEX)
+    {
+        std::cerr << printPrefix << "Frame unavailable in the loaded URDF model." << std::endl;
+        return false;
+        
+    }
+    m_pimpl->m_refFrame_H_world = manif::SE3d(worldPositionInRefFrame, worldOrientationInRefFrame);
+    m_pimpl->m_initialRefFrameForWorldIdx = refFrameIdx;    
+    resetEstimator();
+    
+    return true;
+}
+
+void LeggedOdometry::Impl::resetInternal(FloatingBaseEstimator::ModelComputations& modelComp)
+{
+    m_currentFixedFrameIdx = m_initialFixedFrameIdx;
+
+    manif::SE3d refFrame_H_fixedFrame  = toManifPose(modelComp.kinDyn().
+                                                     getRelativeTransform(m_initialRefFrameForWorldIdx,
+                                                                          m_initialFixedFrameIdx));
+
+    m_world_H_fixedFrame = m_refFrame_H_world.inverse()*refFrame_H_fixedFrame;
+
+    m_prevFixedFrameIdx = m_currentFixedFrameIdx;
+    m_odometryInitialized = true;
+}
+
+
+bool LeggedOdometry::Impl::updateInternalState(FloatingBaseEstimators::Measurements& meas,
+                                               FloatingBaseEstimator::ModelComputations& modelComp,
+                                               FloatingBaseEstimators::InternalState& state,
+                                               FloatingBaseEstimators::Output& out)
+{
+    const std::string_view printPrefix = "[LeggedOdometry::Impl::updateInternalState] ";
+    manif::SE3d fixedFrame_H_imu = toManifPose(modelComp.kinDyn().
+                                               getRelativeTransform(m_currentFixedFrameIdx,
+                                                                    modelComp.baseIMUIdx()));
+    manif::SE3d world_H_imu = m_world_H_fixedFrame*fixedFrame_H_imu;
+    state.imuOrientation = world_H_imu.quat();
+    state.imuPosition = world_H_imu.translation();
+
+    for (auto& [idx, contact] : state.supportFrameData)
+    {
+        manif::SE3d world_H_contact;
+        if (idx == m_currentFixedFrameIdx)
+        {
+            contact.pose = m_world_H_fixedFrame;
+        }
+        else
+        {
+            manif::SE3d fixedFrame_H_contact = toManifPose(modelComp.kinDyn().
+                                                       getRelativeTransform(m_currentFixedFrameIdx, idx));
+            contact.pose = m_world_H_fixedFrame*fixedFrame_H_contact;
+        }
+        
+        // TODO{@prashanthr05} deprecate and remove the following in future versions
+        if (contact.name == modelComp.leftFootContactFrame())
+        {
+            state.lContactFrameOrientation = contact.pose.quat();
+            state.lContactFramePosition = contact.pose.translation();
+        }
+        
+        if (contact.name == modelComp.rightFootContactFrame())
+        {
+            state.rContactFrameOrientation = contact.pose.quat();
+            state.rContactFramePosition = contact.pose.translation();
+        }
+    }
+    
+    // compute base velocity
+    if (!computeBaseIMUVelocityUsingFixedFrameConstraint(meas, modelComp, out))
+    {
+        std::cerr << printPrefix << "Could not compute base colocated IMU velocity using fixed frame constraints." << std::endl;
+        return false;  
+    }
+    return true;
+}
+
+bool LeggedOdometry::Impl::computeBaseIMUVelocityUsingFixedFrameConstraint(FloatingBaseEstimators::Measurements& meas,
+                                                                           FloatingBaseEstimator::ModelComputations& modelComp,
+                                                                           FloatingBaseEstimators::Output& out)
+{
+    const std::string_view printPrefix = "[LeggedOdometry::Impl::computeBaseIMUVelocityUsingFixedFrameConstraint] ";
+    if (!modelComp.kinDyn().getFrameFreeFloatingJacobian(m_currentFixedFrameIdx, m_contactJacobian))
+    {
+        std::cerr << printPrefix << "Could not compute contact Jacobian."
+        << std::endl;
+        return false;
+    }
+        
+    m_contactJacobianBase = m_contactJacobian.block<6, 6>(m_baseOffset, m_baseOffset);
+    m_contactJacobianShape = m_contactJacobian.block(m_baseOffset, m_shapeOffset, m_spatialDim, modelComp.kinDyn().getNrOfDegreesOfFreedom());
+
+    m_vBase = -(m_contactJacobianBase.inverse()) * m_contactJacobianShape * meas.encodersSpeed;
+    
+    iDynTree::Vector3 vLin(iDynTree::make_span(m_vBase.head<3>().data(), m_vBase.head<3>().size()));
+    iDynTree::Vector3 vAng(iDynTree::make_span(m_vBase.tail<3>().data(), m_vBase.tail<3>().size()));
+    out.baseTwist.setLinearVec3(vLin);
+    out.baseTwist.setAngularVec3(vAng);
+    return true;
+}
+
+bool LeggedOdometry::updateKinematics(FloatingBaseEstimators::Measurements& meas,
+                                      const double& /*dt*/)
+{
+    const std::string_view printPrefix = "[LeggedOdometry::updateKinematics] ";
+    if ( (meas.encoders.size() != m_modelComp.nrJoints()) ||
+         (meas.encodersSpeed.size() != m_modelComp.nrJoints()))
+    {
+        std::cerr << printPrefix << "Kinematic measurements size mismatch. Please call setKinematics() before calling advance()."
+        << std::endl;
+        return false;
+    }
+    
+    // initialization step
+    if (!m_pimpl->m_odometryInitialized)
+    {
+        if (!m_modelComp.kinDyn().setJointPos(iDynTree::make_span(meas.encoders.data(), meas.encoders.size())))
+        {
+            std::cerr << printPrefix << "Unable to set joint positions."
+            << std::endl;
+            return false;
+        }
+        
+        m_pimpl->resetInternal(m_modelComp);
+        return true;
+    }
+
+    // run step
+    m_pimpl->updateInternalContactStates(meas, m_modelComp, m_state.supportFrameData);
+    // change fixed frame depending on switch times
+    auto newIdx = m_pimpl->getLatestContact(m_state.supportFrameData);
+    if (newIdx == iDynTree::FRAME_INVALID_INDEX)
+    {
+        std::cerr << printPrefix << "The assumption of atleast one active contact is broken. This may lead ot unexpected results." << std::endl;
+        return false;        
+    }
+    
+    if (newIdx != m_pimpl->m_currentFixedFrameIdx)
+    {
+        if (!m_pimpl->changeFixedFrame(newIdx, m_modelComp.kinDyn()))
+        {
+            std::cerr << printPrefix << "Unable to change new fixed frame." << std::endl;
+            return false;
+        }        
+    }
+    
+    // TODO{@prashanthr05} remove contacts if outdated
+    // should we do this  in a top-level at FloatingBaseEstimators.cpp ?
+    // since it might be useful also for other estimators
+    
+    // update internal states
+    if (!m_pimpl->updateInternalState(m_measPrev, m_modelComp, m_state, m_estimatorOut))
+    {
+        std::cerr << printPrefix << "Could not update internal state of the estimator." << std::endl;
+        return false;
+    }
+    return true;
+}
+
+
+bool LeggedOdometry::Impl::changeFixedFrame(const iDynTree::FrameIndex& newIdx,
+                                            iDynTree::KinDynComputations& kinDyn)
+{
+    const std::string_view printPrefix = "[LeggedOdometry::changeFixedFrame] ";
+    if (newIdx == iDynTree::FRAME_INVALID_INDEX)
+    {
+        std::cerr << printPrefix << "Specified frame index not available in the loaded URDF Model."
+            << std::endl;
+            return false;
+    }
+
+    manif::SE3d oldFixed_H_newFixed  = toManifPose(kinDyn.getRelativeTransform(m_currentFixedFrameIdx, newIdx));
+    m_world_H_fixedFrame = (m_world_H_fixedFrame*oldFixed_H_newFixed);
+    m_prevFixedFrameIdx = m_currentFixedFrameIdx;
+    m_currentFixedFrameIdx = newIdx;
+    
+    std::cout << printPrefix << "Fixed frame changed to " << kinDyn.model().getFrameName(m_currentFixedFrameIdx) << "." << std::endl;    
+    return true;
+}
+
+

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -385,7 +385,7 @@ iDynTree::FrameIndex LeggedOdometry::Impl::getLastActiveContact(const std::map<i
 
     double latestTime{std::numeric_limits<double>::max()}; // assuming time cannot be negative
     int latestContactIdx{-1};
-    for (auto& [idx, contact] : contacts)
+    for (const auto& [idx, contact] : contacts)
     {
         if (contact.isActive)
         {

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -225,7 +225,7 @@ bool LeggedOdometry::customInitialization(std::weak_ptr<BipedalLocomotion::Param
     }
 
     std::string switching;
-    if (!lohandle->getParameter("switching_pattern", switching))
+    if (lohandle->getParameter("switching_pattern", switching))
     {
         std::vector<std::string> options{"latest", "lastActive", "useExternal"};
         if (switching == options[0])
@@ -247,7 +247,7 @@ bool LeggedOdometry::customInitialization(std::weak_ptr<BipedalLocomotion::Param
     }
 
     std::string velComp;
-    if (!lohandle->getParameter("vel_computation_method", velComp))
+    if (lohandle->getParameter("vel_computation_method", velComp))
     {
         std::vector<std::string> options{"single", "multiAvg", "multLSJvel", "multiLS"};
         if (velComp == options[0])

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -309,10 +309,10 @@ void LeggedOdometry::Impl::updateInternalContactStates(FloatingBaseEstimators::M
                                                        FloatingBaseEstimator::ModelComputations& modelComp,
                                                        std::map<int, EstimatedContact>& contactStates)
 {
-    for (auto& obs : meas.stampedContactsStatus)
+    for (const auto& obs : meas.stampedContactsStatus)
     {
-        auto& measContact = obs.second;
-        auto& idx = obs.first;
+        const auto& measContact = obs.second;
+        const auto& idx = obs.first;
 
         if (contactStates.find(idx) != contactStates.end())
         {
@@ -344,7 +344,7 @@ iDynTree::FrameIndex LeggedOdometry::Impl::getLatestSwitchedContact(const std::m
     bool atleastOneActiveContact{false};
     int latestContactIdx{-1};
     double latestTime{-1.0}; // assuming time cannot be negative
-    for (auto& [idx, contact] : contacts)
+    for (const auto& [idx, contact] : contacts)
     {
         if (contact.isActive)
         {
@@ -585,7 +585,7 @@ bool LeggedOdometry::Impl::computeBaseVelocityUsingAllFixedFrameConstraint(const
     std::size_t nrJoints{modelComp.kinDyn()->getNrOfDegreesOfFreedom()};
 
     // run two loops (alteratively once can do conservative resize of the matrices)
-    for (auto& [idx, contact] : state.supportFrameData)
+    for (const auto& [idx, contact] : state.supportFrameData)
     {
         if (contact.isActive)
         {
@@ -616,7 +616,7 @@ bool LeggedOdometry::Impl::computeBaseVelocityUsingAllFixedFrameConstraint(const
 
     // run another loop to populate matrices
     std::size_t cIdx{0};
-    for (auto& [idx, contact] : state.supportFrameData)
+    for (const auto& [idx, contact] : state.supportFrameData)
     {
         if (contact.isActive)
         {
@@ -668,7 +668,7 @@ bool LeggedOdometry::Impl::computeBaseVelocityUsingAllFixedFrameAverage(const Fl
     std::size_t nrContacts{0};
     // run two loops (alteratively once can do conservative resize of the matrices)
     Eigen::VectorXd sumV = Eigen::MatrixXd::Zero(6, 1);
-    for (auto& [idx, contact] : state.supportFrameData)
+    for (const auto& [idx, contact] : state.supportFrameData)
     {
         if (contact.isActive)
         {
@@ -716,7 +716,7 @@ bool LeggedOdometry::Impl::computeBaseVelocityUsingAllFixedFrames(const Floating
 
     std::size_t nrContacts{0};
     // run two loops (alteratively once can do conservative resize of the matrices)
-    for (auto& [idx, contact] : state.supportFrameData)
+    for (const auto& [idx, contact] : state.supportFrameData)
     {
         if (contact.isActive)
         {
@@ -743,7 +743,7 @@ bool LeggedOdometry::Impl::computeBaseVelocityUsingAllFixedFrames(const Floating
 
     // run another loop to populate matrices
     std::size_t cIdx{0};
-    for (auto& [idx, contact] : state.supportFrameData)
+    for (const auto& [idx, contact] : state.supportFrameData)
     {
         if (contact.isActive)
         {

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -839,10 +839,13 @@ bool LeggedOdometry::updateKinematics(FloatingBaseEstimators::Measurements& meas
             return false;
         }
 
-        if (!changeFixedFrame(newIdx))
+        if (newIdx != m_pimpl->m_currentFixedFrameIdx)
         {
-            std::cerr << printPrefix << "Unable to change the fixed frame. This may lead ot unexpected results." << std::endl;
-            return false;
+            if (!m_pimpl->changeFixedFrame(newIdx, m_modelComp.kinDyn()))
+            {
+                std::cerr << printPrefix << "Unable to change the fixed frame. This may lead ot unexpected results." << std::endl;
+                return false;
+            }
         }
     }
 
@@ -862,6 +865,12 @@ bool LeggedOdometry::updateKinematics(FloatingBaseEstimators::Measurements& meas
 bool LeggedOdometry::changeFixedFrame(const std::ptrdiff_t& newIdx)
 {
     const std::string_view printPrefix = "[LeggedOdometry::changeFixedFrame] ";
+    if (m_pimpl->switching != LOSwitching::useExternalUpdate)
+    {
+        std::cerr << printPrefix << "Unable to change fixed frame externally, since the estimator was not loaded with the option." << std::endl;
+        return false;
+    }
+
     if (newIdx != m_pimpl->m_currentFixedFrameIdx)
     {
         if (!m_pimpl->changeFixedFrame(newIdx, m_modelComp.kinDyn()))

--- a/src/Estimators/tests/FloatingBaseEstimators/FloatingBaseEstimatorTest.cpp
+++ b/src/Estimators/tests/FloatingBaseEstimators/FloatingBaseEstimatorTest.cpp
@@ -63,10 +63,10 @@ TEST_CASE("Bare Bones Base Estimator")
     auto model = mdl_ldr.model().copy();
 
     auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    kinDyn->loadRobotModel(model);
     // Instantiate the estimator
     FloatingBaseEstimator estimator;
-    REQUIRE(estimator.initialize(parameterHandler, kinDyn, model));
-    REQUIRE(estimator.modelComputations().isModelSet());
+    REQUIRE(estimator.initialize(parameterHandler, kinDyn));
     REQUIRE(estimator.modelComputations().nrJoints() == joints_list.size());
     REQUIRE(estimator.modelComputations().baseLink() == "root_link");
     REQUIRE(estimator.modelComputations().baseLinkIMU() == "root_link_imu_acc");

--- a/src/Estimators/tests/FloatingBaseEstimators/FloatingBaseEstimatorTest.cpp
+++ b/src/Estimators/tests/FloatingBaseEstimators/FloatingBaseEstimatorTest.cpp
@@ -62,9 +62,10 @@ TEST_CASE("Bare Bones Base Estimator")
 
     auto model = mdl_ldr.model().copy();
 
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
     // Instantiate the estimator
     FloatingBaseEstimator estimator;
-    REQUIRE(estimator.initialize(parameterHandler, model));
+    REQUIRE(estimator.initialize(parameterHandler, kinDyn, model));
     REQUIRE(estimator.modelComputations().isModelSet());
     REQUIRE(estimator.modelComputations().nrJoints() == joints_list.size());
     REQUIRE(estimator.modelComputations().baseLink() == "root_link");

--- a/src/Estimators/tests/FloatingBaseEstimators/InvariantEKFBaseEstimatorTest.cpp
+++ b/src/Estimators/tests/FloatingBaseEstimators/InvariantEKFBaseEstimatorTest.cpp
@@ -118,9 +118,10 @@ TEST_CASE("Invariant EKF Base Estimator")
 
     auto model = mdl_ldr.model().copy();
 
+    auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
     // Instantiate the estimator
-    InvariantEKFBaseEstimator estimator;
-    REQUIRE(estimator.initialize(parameterHandler, model));
+    InvariantEKFBaseEstimator estimator;    
+    REQUIRE(estimator.initialize(parameterHandler, kinDyn, model));
     REQUIRE(estimator.modelComputations().isModelSet());
     REQUIRE(estimator.modelComputations().nrJoints() == joints_list.size());
     REQUIRE(estimator.modelComputations().baseLink() == "root_link");

--- a/src/Estimators/tests/FloatingBaseEstimators/InvariantEKFBaseEstimatorTest.cpp
+++ b/src/Estimators/tests/FloatingBaseEstimators/InvariantEKFBaseEstimatorTest.cpp
@@ -119,10 +119,10 @@ TEST_CASE("Invariant EKF Base Estimator")
     auto model = mdl_ldr.model().copy();
 
     auto kinDyn = std::make_shared<iDynTree::KinDynComputations>();
+    kinDyn->loadRobotModel(model);
     // Instantiate the estimator
     InvariantEKFBaseEstimator estimator;    
-    REQUIRE(estimator.initialize(parameterHandler, kinDyn, model));
-    REQUIRE(estimator.modelComputations().isModelSet());
+    REQUIRE(estimator.initialize(parameterHandler, kinDyn));
     REQUIRE(estimator.modelComputations().nrJoints() == joints_list.size());
     REQUIRE(estimator.modelComputations().baseLink() == "root_link");
     REQUIRE(estimator.modelComputations().baseLinkIMU() == "root_link_imu_acc");


### PR DESCRIPTION
This PR tries to improve the existing feature of floating base estimator by allowing the handling of multiple contacts. 
It also implements the Legged odometry algorithm.

This PR also makes an API change to the `initialize()` method of the `FloatingBaseEstimator` class, since KinDynComputations is changed from being an object of the class to a shared_pointer of an external object.

This PR depends on 
- #141 (Merged)
- #142 (Merged)

- [ ] Add a test