### PR TITLE
Fix cmake optional compilation of FloatingBaseEstimatorDevice

### DIFF
--- a/devices/FloatingBaseEstimatorDevice/CMakeLists.txt
+++ b/devices/FloatingBaseEstimatorDevice/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-if(FRAMEWORK_COMPILE_YarpImplementation)
+if(FRAMEWORK_COMPILE_YarpImplementation AND FRAMEWORK_COMPILE_FloatingBaseEstimators)
 
 add_bipedal_yarp_device(
   NAME FloatingBaseEstimatorDevice


### PR DESCRIPTION
Fixes https://github.com/dic-iit/bipedal-locomotion-framework/issues/152