### PR TITLE
FloatingBaseEstimatorDevice: remove leftover ini file

### DIFF
--- a/devices/FloatingBaseEstimatorDevice/FloatingBaseEstimatorDevice.ini
+++ b/devices/FloatingBaseEstimatorDevice/FloatingBaseEstimatorDevice.ini
@@ -1,4 +1,0 @@
-[plugin FloatingBaseEstimatorDevice]
-type device
-name FloatingBaseEstimatorDevice
-library FloatingBaseEstimatorDevice


### PR DESCRIPTION
Sorry, this is a leftover that I missed in https://github.com/dic-iit/bipedal-locomotion-framework/pull/155.