### PR TITLE
Add a test device for YARP based ROS Publisher 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,5 +28,6 @@ All notable changes to this project are documented in this file.
 - Implement `FloatingBaseEstimatorDevice` YARP device for wrapping floating base estimation algorithms. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/130)
 - Implement Continuous algebraic Riccati equation function (https://github.com/dic-iit/bipedal-locomotion-framework/pull/157)
 - Implement YARP based `ROSPublisher` in the `YarpUtilities` library. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/156)
+- Implement example YARP device `ROSPublisherTestDevice` for understanding the usage of `ROSPublisher`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/160)
 
 [Unreleased]: https://github.com/dic-iit/bipedal-locomotion-framework/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
 option(BUILD_TESTING "Create tests using CMake" OFF)
 include(CTest)
 
+option(BUILD_DEVICE_EXAMPLES "Create example devices using CMake" OFF)
+
 # Check BipedalLocomotionFramework dependencies, find necessary libraries.
 include(BipedalLocomotionFrameworkFindDependencies)
 

--- a/cmake/AddBipedalLocomotionYARPDevice.cmake
+++ b/cmake/AddBipedalLocomotionYARPDevice.cmake
@@ -2,6 +2,11 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+framework_dependent_option(FRAMEWORK_COMPILE_example_devices
+  "Compile example devices?" ON
+  "BUILD_DEVICE_EXAMPLES" OFF)
+
+
 function(add_bipedal_yarp_device)
   set(options )
   set(oneValueArgs NAME)

--- a/devices/examples/CMakeLists.txt
+++ b/devices/examples/CMakeLists.txt
@@ -2,10 +2,5 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-add_subdirectory(FloatingBaseEstimatorDevice)
-
-if (FRAMEWORK_COMPILE_example_devices)
-  add_subdirectory(examples)
-endif()
-
+add_subdirectory(ROSPublisherTestDevice)
 

--- a/devices/examples/ROSPublisherTestDevice/CMakeLists.txt
+++ b/devices/examples/ROSPublisherTestDevice/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+if(FRAMEWORK_COMPILE_YarpImplementation AND FRAMEWORK_COMPILE_YarpUtilities)
+# Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
+add_bipedal_yarp_device(
+  NAME ROSPublisherTestDevice
+  TYPE BipedalLocomotion::ROSPublisherTestDevice
+  SOURCES src/ROSPublisherTestDevice.cpp
+  PUBLIC_HEADERS include/BipedalLocomotion/ROSPublisherTestDevice.h
+  PUBLIC_LINK_LIBRARIES ${YARP_LIBRARIES} BipedalLocomotion::YarpUtilities  BipedalLocomotion::ParametersHandlerYarpImplementation
+  CONFIGURE_PACKAGE_NAME ros_publisher_test_device)
+endif()
+

--- a/devices/examples/ROSPublisherTestDevice/README.md
+++ b/devices/examples/ROSPublisherTestDevice/README.md
@@ -1,0 +1,28 @@
+### ROS Publisher Test Device
+
+- Run the servers 
+
+  ```bash
+  roscore
+  yarpserver --ros
+  yarpdev --device transformServer --name tfServer --ROS::enable_ros_publisher true --ROS::enable_ros_subscriber true
+  ```
+
+  (This step can also be done using [ros-publisher-test-runner.xml](./ros-publisher-test-runner.xml) through the yarpmanager).
+
+- Run the device using
+
+  ``` bash
+  YARP_ROBOT_NAME=iCubGazeboV2_5 yarprobotinterface --config launch-ros-publisher-test.xml
+  ```
+
+- Check the outputs of the test device by running,
+
+  ``` bash
+  rostopic echo /joint_states    # to check the published joint states - name: [hello] position: [20] 
+  rostopic echo /wrench/right    # to check the published wrench - frame: right force: x:0.0 y:1.0 z:2.0 torque: x:0.0 y:0.0 z:0.0
+  rostopic echo /tf # to check the published pose between /world and /dummy as identity (zero position and unit quaternion)
+  ```
+
+  
+

--- a/devices/examples/ROSPublisherTestDevice/app/CMakeLists.txt
+++ b/devices/examples/ROSPublisherTestDevice/app/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+# Get list of models
+subdirlist(subdirs ${CMAKE_CURRENT_SOURCE_DIR}/robots/)
+# Install each model
+foreach (dir ${subdirs})
+  yarp_install(DIRECTORY robots/${dir} DESTINATION ${YARP_ROBOTS_INSTALL_DIR})
+endforeach ()
+

--- a/devices/examples/ROSPublisherTestDevice/app/robots/iCubGazeboV2_5/launch-ros-publisher-test.xml
+++ b/devices/examples/ROSPublisherTestDevice/app/robots/iCubGazeboV2_5/launch-ros-publisher-test.xml
@@ -1,0 +1,13 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGazeboV2_5" portprefix="icubSim" build="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <xi:include href="publisher/ros-publisher.xml" />
+    </devices>
+</robot>
+

--- a/devices/examples/ROSPublisherTestDevice/app/robots/iCubGazeboV2_5/publisher/ros-publisher.xml
+++ b/devices/examples/ROSPublisherTestDevice/app/robots/iCubGazeboV2_5/publisher/ros-publisher.xml
@@ -1,0 +1,13 @@
+<!-- Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="ros-publisher-test" type="ROSPublisherTestDevice">
+    <param name="joint_states_topic">/joint_states</param>
+    <param name="transform_server_port">/tfServer</param>
+     <group name="WrenchPublishers">
+        <param name="frame_names">("right", "left")</param> 
+        <param name="topics">("/wrench/right", "/wrench/left")</param>
+    </group>
+</device>

--- a/devices/examples/ROSPublisherTestDevice/include/BipedalLocomotion/ROSPublisherTestDevice.h
+++ b/devices/examples/ROSPublisherTestDevice/include/BipedalLocomotion/ROSPublisherTestDevice.h
@@ -1,0 +1,40 @@
+/**
+ * @file ROSPublisherTestDevice.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_FRAMEWORK_ROS_PUBLISHER_TEST_DEVICE_H
+#define BIPEDAL_LOCOMOTION_FRAMEWORK_ROS_PUBLISHER_TEST_DEVICE_H
+
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/YarpUtilities/RosPublisher.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/dev/DeviceDriver.h>
+
+#include <memory>
+
+namespace BipedalLocomotion
+{
+    class ROSPublisherTestDevice;
+}
+
+class BipedalLocomotion::ROSPublisherTestDevice : public yarp::dev::DeviceDriver,
+                                                  public yarp::os::PeriodicThread
+{
+public:
+    explicit ROSPublisherTestDevice(double period, yarp::os::ShouldUseSystemClock useSystemClock = yarp::os::ShouldUseSystemClock::No);
+    ROSPublisherTestDevice();
+    ~ROSPublisherTestDevice();
+
+    virtual bool open(yarp::os::Searchable& config) final;
+    virtual bool close() final;
+    virtual void run() final;
+    
+    std::unique_ptr<BipedalLocomotion::YarpUtilities::RosPublisher> pub;
+};
+
+
+
+#endif //BIPEDAL_LOCOMOTION_FRAMEWORK_ROS_PUBLISHER_TEST_DEVICE_H

--- a/devices/examples/ROSPublisherTestDevice/ros-publisher-test-runner.xml
+++ b/devices/examples/ROSPublisherTestDevice/ros-publisher-test-runner.xml
@@ -1,0 +1,18 @@
+<application>
+  <name>ros-publisher-test-launcher</name>
+  <module>
+    <name>roscore</name>
+  </module>
+
+  <module>
+    <name>yarpserver</name>
+    <parameters>--ros</parameters>
+  </module>
+
+  <module>
+    <name>yarpdev</name>
+    <parameters>--device transformServer --name tfServer --ROS::enable_ros_publisher true --ROS::enable_ros_subscriber true</parameters>
+  </module>
+
+</application>
+

--- a/devices/examples/ROSPublisherTestDevice/src/ROSPublisherTestDevice.cpp
+++ b/devices/examples/ROSPublisherTestDevice/src/ROSPublisherTestDevice.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file ROSPublisherTestDevice.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/ROSPublisherTestDevice.h>
+#include <BipedalLocomotion/YarpUtilities/Helper.h>
+#include <BipedalLocomotion/GenericContainer/Vector.h>
+#include <yarp/os/LogStream.h>
+
+BipedalLocomotion::ROSPublisherTestDevice::ROSPublisherTestDevice(double period,
+                                               yarp::os::ShouldUseSystemClock useSystemClock)
+        : yarp::os::PeriodicThread(period, useSystemClock)
+{
+	pub = std::make_unique<BipedalLocomotion::YarpUtilities::RosPublisher>("/PublisherTest");
+}
+
+BipedalLocomotion::ROSPublisherTestDevice::ROSPublisherTestDevice()
+        : yarp::os::PeriodicThread(0.01, yarp::os::ShouldUseSystemClock::No)
+{
+	pub = std::make_unique<BipedalLocomotion::YarpUtilities::RosPublisher>("/PublisherTest");
+}
+
+BipedalLocomotion::ROSPublisherTestDevice::~ROSPublisherTestDevice()
+{
+}
+
+bool BipedalLocomotion::ROSPublisherTestDevice::open(yarp::os::Searchable& config)
+{
+    std::shared_ptr<BipedalLocomotion::ParametersHandler::YarpImplementation> configHandler = std::make_shared<BipedalLocomotion::ParametersHandler::YarpImplementation>();
+    configHandler->set(config);
+	
+    if (!pub->initialize(configHandler))
+    {
+    	return false;
+    }
+	
+    this->start();
+    return true;
+}
+
+void BipedalLocomotion::ROSPublisherTestDevice::run()
+{
+   std::vector<std::string> jointList{"hello"};
+   std::vector<double> jointPos{20.0};
+   
+   pub->publishJointStates(jointList, jointPos);
+   
+   std::vector<double> wrench{0.0, 1.0, 2.0,0.0, 0.0, 0.0};
+   pub->publishWrench("right", wrench);
+   
+   
+   std::vector<double> pose{1., 0, 0, 0, 0, 1., 0, 0, 0, 0, 1., 0, 0, 0, 0, 1.};
+   pub->publishTransform("/world", "/dummy", pose);
+}
+
+
+bool BipedalLocomotion::ROSPublisherTestDevice::close()
+{
+    this->stop();
+    pub->stop();
+    return true;
+}
+


### PR DESCRIPTION
This PR adds a test device for YARP based ROS Publisher added in https://github.com/dic-iit/bipedal-locomotion-framework/pull/156.

Current implementation cannot fit in to a CI testing framework, since the process requires `roscore` to run (which is not our dependency), further it requires an additional subscribing mechanism to check if the data is published properly or not. 
So we will stick to manually running the test device, at the moment. We could fix it when we have more time dedicated for software-engineering tasks.