### PR TITLE
Speed up TSID tests

### DIFF
--- a/src/TSID/tests/JointsTrackingTaskTest.cpp
+++ b/src/TSID/tests/JointsTrackingTaskTest.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Joint Regularization task")
     // set the velocity representation
     REQUIRE(kinDyn->setFrameVelocityRepresentation(iDynTree::FrameVelocityRepresentation::MIXED_REPRESENTATION));
 
-    for (std::size_t numberOfJoints = 6; numberOfJoints < 1000; numberOfJoints += 15)
+    for (std::size_t numberOfJoints = 6; numberOfJoints < 200; numberOfJoints += 15)
     {
         DYNAMIC_SECTION("Model with " << numberOfJoints << " joints")
         {

--- a/src/TSID/tests/SE3TaskTest.cpp
+++ b/src/TSID/tests/SE3TaskTest.cpp
@@ -42,7 +42,7 @@ TEST_CASE("SE3 Task")
     // set the velocity representation
     REQUIRE(kinDyn->setFrameVelocityRepresentation(iDynTree::FrameVelocityRepresentation::MIXED_REPRESENTATION));
 
-    for (std::size_t numberOfJoints = 6; numberOfJoints < 1000; numberOfJoints += 15)
+    for (std::size_t numberOfJoints = 6; numberOfJoints < 200; numberOfJoints += 15)
     {
         DYNAMIC_SECTION("Model with " << numberOfJoints << " joints")
         {


### PR DESCRIPTION
When blf is built in debug, running TSID tests lasts 30 minutes. This should speed up the tests 