### PR TITLE
General refactoring of polydriver construction in RobotInterface

### DIFF
--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpHelper.h
@@ -10,6 +10,7 @@
 
 // std
 #include <memory>
+#include <string>
 
 // YARP
 #include <yarp/dev/PolyDriver.h>
@@ -22,6 +23,33 @@ namespace RobotInterface
 {
 
 /**
+ * PolyDriverDescriptor describes a PolyDriver.
+ * @note Please be careful with the namespaces then to avoid clashes with YARP
+ * [PolyDriverDescriptor](https://www.yarp.it/git-master/classyarp_1_1dev_1_1PolyDriverDescriptor.html).
+ */
+struct PolyDriverDescriptor
+{
+    std::string key{""}; /**< key associated to the polydriver */
+    std::shared_ptr<yarp::dev::PolyDriver> poly{nullptr}; /**< Pointer associated to the polydriver. */
+
+    /**
+     * Constructor.
+     */
+    PolyDriverDescriptor(const std::string& key, std::shared_ptr<yarp::dev::PolyDriver> poly);
+
+    /**
+     * Constructor.
+     */
+    PolyDriverDescriptor();
+
+    /**
+     * Check if the poly driver descriptor is valid.
+     * @return True if the polydriver is valid, false otherwise.
+     */
+    bool isValid() const;
+};
+
+/**
  * Helper function that can be used to build a RemoteControlBoardRemapper device.
  * @param handler pointer to a parameter handler interface.
  * @note the following parameters are required by the function
@@ -30,10 +58,10 @@ namespace RobotInterface
  * |      `joints_list`      | `vector<string>` |                List of the controlled joints               |    Yes    |
  * | `remote_control_boards` | `vector<string>` | List of the remote control boards associated to the joints |    Yes    |
  * |       `robot_name`      |     `string`     |                      Name of the robot                     |    Yes    |
- * |       `local_name`      |     `string`     |                Name of the local application               |    Yes    |
- * @return A shared_ptr to the PolyDriver. If one of the parameters is missing a nullptr is returned.
+ * |      `local_prefix`     |     `string`     |    Prefix of the local port (e.g. the application name)    |    Yes    |
+ * @return A PolyDriverDescriptor. If one of the parameters is missing an invalid PolyDriverDescriptor is returned.
  */
-std::shared_ptr<yarp::dev::PolyDriver> constructYarpRobotDevice(
+PolyDriverDescriptor constructRemoteControlBoardRemapper(
     std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
 
 } // namespace RobotInterface

--- a/utilities/joint-position-tracking/include/BipedalLocomotion/JointPositionTracking/Module.h
+++ b/utilities/joint-position-tracking/include/BipedalLocomotion/JointPositionTracking/Module.h
@@ -20,6 +20,7 @@
 #include <BipedalLocomotion/Planners/QuinticSpline.h>
 #include <BipedalLocomotion/RobotInterface/YarpRobotControl.h>
 #include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
+#include <BipedalLocomotion/RobotInterface/YarpHelper.h>
 
 namespace BipedalLocomotion
 {
@@ -33,7 +34,7 @@ class Module : public yarp::os::RFModule
 
     Eigen::VectorXd m_currentJointPos;
 
-    std::shared_ptr<yarp::dev::PolyDriver> m_robotDevice;
+    BipedalLocomotion::RobotInterface::PolyDriverDescriptor m_controlBoard;
 
     BipedalLocomotion::RobotInterface::YarpRobotControl m_robotControl;
     BipedalLocomotion::RobotInterface::YarpSensorBridge m_sensorBridge;

--- a/utilities/joint-trajectory-player/include/BipedalLocomotion/JointTrajectoryPlayer/Module.h
+++ b/utilities/joint-trajectory-player/include/BipedalLocomotion/JointTrajectoryPlayer/Module.h
@@ -21,6 +21,7 @@
 
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotion/Planners/QuinticSpline.h>
+#include <BipedalLocomotion/RobotInterface/YarpHelper.h>
 #include <BipedalLocomotion/RobotInterface/YarpRobotControl.h>
 #include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
 
@@ -36,7 +37,7 @@ class Module : public yarp::os::RFModule
 
     Eigen::VectorXd m_currentJointPos; /**< Current joint positions. */
 
-    std::shared_ptr<yarp::dev::PolyDriver> m_robotDevice; /**< PolyDriver. */
+    BipedalLocomotion::RobotInterface::PolyDriverDescriptor m_controlBoard; /**< Control board remapper. */
 
     RobotInterface::YarpRobotControl m_robotControl; /**< Robot control object. */
     RobotInterface::YarpSensorBridge m_sensorBridge; /**< Sensor bridge object. */

--- a/utilities/joint-trajectory-player/src/Module.cpp
+++ b/utilities/joint-trajectory-player/src/Module.cpp
@@ -36,9 +36,9 @@ bool Module::createPolydriver(std::shared_ptr<ParametersHandler::IParametersHand
         std::cerr << "[Module::createPolydriver] Robot interface options is empty." << std::endl;
         return false;
     }
-    ptr->setParameter("local_name", this->getName());
-    m_robotDevice = RobotInterface::constructYarpRobotDevice(ptr);
-    if (m_robotDevice == nullptr)
+    ptr->setParameter("local_prefix", this->getName());
+    m_controlBoard = RobotInterface::constructRemoteControlBoardRemapper(ptr);
+    if (!m_controlBoard.isValid())
     {
         std::cerr << "[Module::createPolydriver] the robot polydriver has not been constructed."
                   << std::endl;
@@ -57,7 +57,7 @@ bool Module::initializeRobotControl(std::shared_ptr<ParametersHandler::IParamete
                   << std::endl;
         return false;
     }
-    if (!m_robotControl.setDriver(m_robotDevice))
+    if (!m_robotControl.setDriver(m_controlBoard.poly))
     {
         std::cerr << "[Module::initializeRobotControl] Unable to initialize the "
                      "control board"
@@ -85,7 +85,7 @@ bool Module::instantiateSensorBridge(std::shared_ptr<ParametersHandler::IParamet
     }
 
     yarp::dev::PolyDriverList list;
-    list.push(m_robotDevice.get(), "Remote control board");
+    list.push(m_controlBoard.poly.get(), m_controlBoard.key.c_str());
     if (!m_sensorBridge.setDriversList(list))
     {
         std::cerr << "[Module::initializeSensorBridge] Unable to set the driver list" << std::endl;


### PR DESCRIPTION
This is required because in a next PR I'm going to implement a function to build a [`GenericSensorClient`](https://github.com/robotology/whole-body-estimators/blob/master/devices/genericSensorClient/GenericSensorClient.h) required to retrieve the estimation of the contact wrenches  

- Rename BipedalLocomotion::RobotInterface::constructYarpRobotDevice() into BipedalLocomotion::RobotInterface::constructRemoteControlBoardRemapper()
- Introduce PolyDriverDescriptor in RobotInterface/YarpHelper