### PR TITLE
Implement IRobotControl python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 ### Added
+- Implement IRobotControl python bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/200)
 
 ### Changed
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -14,12 +14,14 @@ pybind11_add_module(pybind11_blf MODULE
     QuinticSpline.cpp
     SwingFootPlaner.cpp
     TimeVaryingDCMPlanner.cpp
+    RobotInterface.cpp
     )
 
 target_link_libraries(pybind11_blf PUBLIC
     BipedalLocomotion::ParametersHandler
     BipedalLocomotion::Planners
     BipedalLocomotion::System
+    BipedalLocomotion::RobotInterfaceYarpImplementation
     )
 
 target_include_directories(pybind11_blf PRIVATE

--- a/bindings/python/RobotInterface.cpp
+++ b/bindings/python/RobotInterface.cpp
@@ -1,0 +1,106 @@
+/**
+ * @file RobotInterface.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <yarp/dev/PolyDriver.h>
+
+#include "BipedalLocomotion/RobotInterface/IRobotControl.h"
+#include "BipedalLocomotion/RobotInterface/YarpHelper.h"
+#include "BipedalLocomotion/RobotInterface/YarpRobotControl.h"
+
+#include "bipedal_locomotion_framework.h"
+
+void BipedalLocomotion::bindings::CreatePolyDriver(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace yarp::dev;
+    py::class_<PolyDriver, std::shared_ptr<PolyDriver>>(module, "PolyDriver");
+}
+
+void BipedalLocomotion::bindings::CreatePolyDriverDescriptor(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace BipedalLocomotion::RobotInterface;
+    using namespace BipedalLocomotion::ParametersHandler;
+
+    py::class_<PolyDriverDescriptor>(module, "PolyDriverDescriptor")
+        .def(py::init())
+        .def_readwrite("key", &PolyDriverDescriptor::key)
+        .def_readwrite("poly", &PolyDriverDescriptor::poly)
+        .def("is_valid", &PolyDriverDescriptor::isValid);
+
+    module.def(
+        "construct_remote_control_board_remapper",
+        [](std::shared_ptr<IParametersHandler> handler) -> PolyDriverDescriptor {
+            return constructRemoteControlBoardRemapper(handler);
+        },
+        py::arg("handler"));
+
+    module.def(
+        "construct_generic_sensor_client",
+        [](std::shared_ptr<IParametersHandler> handler) -> PolyDriverDescriptor {
+            return constructGenericSensorClient(handler);
+        },
+        py::arg("handler"));
+}
+
+void BipedalLocomotion::bindings::CreateIRobotControl(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace BipedalLocomotion::RobotInterface;
+
+    py::class_<IRobotControl> iRobotControl(module, "IRobotControl");
+    py::enum_<IRobotControl::ControlMode>(iRobotControl, "ControlMode")
+        .value("Position", IRobotControl::ControlMode::Position)
+        .value("PositionDirect", IRobotControl::ControlMode::PositionDirect)
+        .value("Velocity", IRobotControl::ControlMode::Velocity)
+        .value("Torque", IRobotControl::ControlMode::Torque)
+        .value("Idle", IRobotControl::ControlMode::Idle)
+        .value("Unknown", IRobotControl::ControlMode::Unknown)
+        .export_values();
+}
+
+void BipedalLocomotion::bindings::CreateYarpRobotControl(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace BipedalLocomotion::ParametersHandler;
+    using namespace BipedalLocomotion::RobotInterface;
+
+    py::class_<YarpRobotControl, IRobotControl>(module, "YarpRobotControl")
+        .def(py::init())
+        .def(
+            "initialize",
+            [](YarpRobotControl& impl, std::shared_ptr<IParametersHandler> handler) -> bool {
+                return impl.initialize(handler);
+            },
+            py::arg("handler"))
+        .def("set_driver", &YarpRobotControl::setDriver, py::arg("driver"))
+        .def("check_motion_done",
+             [](YarpRobotControl& impl) {
+                 bool motionDone{false};
+                 bool isTimeExpired{false};
+                 std::vector<std::pair<std::string, double>> info;
+                 bool isOk = impl.checkMotionDone(motionDone, isTimeExpired, info);
+
+                 return std::make_tuple(isOk, motionDone, isTimeExpired, info);
+             })
+        .def("set_references",
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>,
+                               const std::vector<IRobotControl::ControlMode>&>(
+                 &YarpRobotControl::setReferences),
+             py::arg("joints_value"),
+             py::arg("control_modes"))
+        .def("set_references",
+             py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, const IRobotControl::ControlMode&>(
+                 &YarpRobotControl::setReferences),
+             py::arg("joints_value"),
+             py::arg("control_mode"))
+        .def("get_joint_list", &YarpRobotControl::getJointList);
+}

--- a/bindings/python/bipedal_locomotion_framework.cpp
+++ b/bindings/python/bipedal_locomotion_framework.cpp
@@ -39,6 +39,13 @@ PYBIND11_MODULE(bindings, m)
 
     // TimeVaryingDCMPlanner.cpp
     bindings::CreateTimeVaryingDCMPlanner(m);
+
+    // RobotInterface.cpp
+    bindings::CreatePolyDriver(m);
+    bindings::CreatePolyDriverDescriptor(m);
+    bindings::CreateIRobotControl(m);
+    bindings::CreateYarpRobotControl(m);
+
 }
 
 std::string bindings::ToString(const manif::SE3d& se3)

--- a/bindings/python/bipedal_locomotion_framework.h
+++ b/bindings/python/bipedal_locomotion_framework.h
@@ -48,4 +48,11 @@ void CreateDCMPlanner(pybind11::module& module);
 
 // TimeVaryingDCMPlanner.cpp
 void CreateTimeVaryingDCMPlanner(pybind11::module& module);
+
+// RobotInterface.cpp
+void CreatePolyDriver(pybind11::module& module);
+void CreatePolyDriverDescriptor(pybind11::module& module);
+void CreateIRobotControl(pybind11::module& module);
+void CreateYarpRobotControl(pybind11::module& module);
+
 } // namespace BipedalLocomotion::bindings

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -111,7 +111,7 @@ framework_dependent_option(FRAMEWORK_COMPILE_JointPositionTrackingApplication
 
 framework_dependent_option(FRAMEWORK_COMPILE_PYTHON_BINDINGS
   "Do you want to generate and compile the Python bindings?" ON
-  "FRAMEWORK_USE_Python3;FRAMEWORK_USE_pybind11;FRAMEWORK_COMPILE_Planners;FRAMEWORK_COMPILE_System" OFF)
+  "FRAMEWORK_USE_Python3;FRAMEWORK_USE_pybind11;FRAMEWORK_COMPILE_Planners;FRAMEWORK_COMPILE_System;FRAMEWORK_COMPILE_RobotInterface;FRAMEWORK_COMPILE_YarpImplementation" OFF)
 
 framework_dependent_option(FRAMEWORK_TEST_PYTHON_BINDINGS
   "Do you want to test the Python bindings?" ON


### PR DESCRIPTION
The PR introduces the python bindings for the `IRobotControl` and the `YARP` implementation.

This is a usage example

```python
import bipedal_locomotion_framework.bindings as blf
import time

if __name__ == "__main__":
    handler = blf.StdParametersHandler()
    handler.set_parameter_vector_string("joints_list", ["r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll"])
    handler.set_parameter_vector_string("remote_control_boards", ["right_leg"])
    handler.set_parameter_string("robot_name", "icubSim")
    handler.set_parameter_string("local_prefix", "test_local")
    handler.set_parameter_float("positioning_duration", 3.0)
    handler.set_parameter_float("positioning_tolerance", 0.05)
    handler.set_parameter_float("position_direct_max_admissible_error", 0.1)

    # Create the control board
    control_board = blf.construct_remote_control_board_remapper(handler)
    time.sleep(1)

    # Create the robot control 
    robot_control = blf.YarpRobotControl()
    robot_control.initialize(handler)
    robot_control.set_driver(control_board.poly)

    # Move the robot
    robot_control.set_references([0.8, 0.5, 0.0, 0.0, 0.5, 0.0], \
                                 blf.IRobotControl.ControlMode.Position)
    
    while(1):
        time.sleep(2.0)
        print("I'm alive.")
```