### PR TITLE
Add the possibility to pass a reference DCM trajectory to the DCMPlanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to this project are documented in this file.
 - Implement IRobotControl python bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/200)
 - Implement ISensorBridge python bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/203)
 - Implement `LeggedOdometry` class as a part of `FloatingBaseEstimators` library and handle arbitrary contacts in `FloatingBaseEstimator`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/151)
+- Implement the possibility to set a desired reference trajectory in the TimeVaryingDCMPlanner. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/208)
+
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)
 - Move all the ContactDetectors related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/209)
+- The DCMPlanner and TimeVaryingDCMPlanner initialize functions take as input an std::weak_ptr. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/208)
 
 ### Fixed
 - Fix missing implementation of `YarpSensorBridge::getFailedSensorReads()`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/202)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -15,6 +15,7 @@ pybind11_add_module(pybind11_blf MODULE
     SwingFootPlaner.cpp
     TimeVaryingDCMPlanner.cpp
     RobotInterface.cpp
+    Constants.cpp
     )
 
 target_link_libraries(pybind11_blf PUBLIC
@@ -23,6 +24,7 @@ target_link_libraries(pybind11_blf PUBLIC
     BipedalLocomotion::System
     BipedalLocomotion::RobotInterfaceYarpImplementation
     BipedalLocomotion::Contacts
+    BipedalLocomotion::Math
     )
 
 target_include_directories(pybind11_blf PRIVATE

--- a/bindings/python/Constants.cpp
+++ b/bindings/python/Constants.cpp
@@ -1,0 +1,18 @@
+/**
+ * @file Constants.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include "BipedalLocomotion/Math/Constants.h"
+
+#include "bipedal_locomotion_framework.h"
+
+void BipedalLocomotion::bindings::CreateConstants(pybind11::module& module)
+{
+    using namespace BipedalLocomotion::Math;
+
+    module.attr("StandardAccelerationOfGravitation")
+        = pybind11::float_(StandardAccelerationOfGravitation);
+}

--- a/bindings/python/Contacts.cpp
+++ b/bindings/python/Contacts.cpp
@@ -133,7 +133,7 @@ void BipedalLocomotion::bindings::CreateContactPhaseList(pybind11::module& modul
 {
     namespace py = ::pybind11;
     using namespace BipedalLocomotion::Contacts;
-    py::class_<ContactPhaseList, std::shared_ptr<ContactPhaseList>>(module, "ContactPhaseList")
+    py::class_<ContactPhaseList>(module, "ContactPhaseList")
         .def(py::init())
         .def("set_lists",
              py::overload_cast<const ContactListMap&>(&ContactPhaseList::setLists),

--- a/bindings/python/TimeVaryingDCMPlanner.cpp
+++ b/bindings/python/TimeVaryingDCMPlanner.cpp
@@ -21,9 +21,20 @@ void BipedalLocomotion::bindings::CreateTimeVaryingDCMPlanner(pybind11::module& 
 
     py::class_<TimeVaryingDCMPlanner, DCMPlanner>(module, "TimeVaryingDCMPlanner")
         .def(py::init())
-        .def("initialize", &TimeVaryingDCMPlanner::initialize, py::arg("handler"))
+        .def(
+            "initialize",
+            [](TimeVaryingDCMPlanner& impl,
+               std::shared_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+                -> bool { return impl.initialize(handler); },
+            py::arg("handler"))
         .def("compute_trajectory", &TimeVaryingDCMPlanner::computeTrajectory)
         .def("get", &TimeVaryingDCMPlanner::get)
         .def("is_valid", &TimeVaryingDCMPlanner::isValid)
-        .def("advance", &TimeVaryingDCMPlanner::advance);
+        .def("advance", &TimeVaryingDCMPlanner::advance)
+        .def("set_contact_phase_list",
+             &TimeVaryingDCMPlanner::setContactPhaseList,
+             py::arg("contact_phase_list"))
+        .def("set_dcm_reference",
+             &TimeVaryingDCMPlanner::setDCMReference,
+             py::arg("dcm_reference_matrix"));
 }

--- a/bindings/python/bipedal_locomotion_framework.cpp
+++ b/bindings/python/bipedal_locomotion_framework.cpp
@@ -48,6 +48,8 @@ PYBIND11_MODULE(bindings, m)
     bindings::CreateISensorBridge(m);
     bindings::CreateYarpSensorBridge(m);
 
+    // Constants.cpp
+    bindings::CreateConstants(m);
 }
 
 std::string bindings::ToString(const manif::SE3d& se3)

--- a/bindings/python/bipedal_locomotion_framework.h
+++ b/bindings/python/bipedal_locomotion_framework.h
@@ -58,4 +58,7 @@ void CreateYarpRobotControl(pybind11::module& module);
 void CreateISensorBridge(pybind11::module& module);
 void CreateYarpSensorBridge(pybind11::module& module);
 
+// Constants.cpp
+void CreateConstants(pybind11::module& module);
+
 } // namespace BipedalLocomotion::bindings

--- a/bindings/python/tests/test_time_verying_dcm_planner.py
+++ b/bindings/python/tests/test_time_verying_dcm_planner.py
@@ -91,7 +91,7 @@ def test_time_varying_dcm_planner():
     initial_state.dcm_position = np.array([0, 0, 0.53])
     initial_state.dcm_velocity = np.zeros(3)
     initial_state.vrp_position = initial_state.dcm_position
-    initial_state.omega = np.sqrt(9.81 / initial_state.dcm_position[2])
+    initial_state.omega = np.sqrt(blf.StandardAccelerationOfGravitation / initial_state.dcm_position[2])
 
     # Initialize the planner
     planner = blf.TimeVaryingDCMPlanner()

--- a/src/Math/CMakeLists.txt
+++ b/src/Math/CMakeLists.txt
@@ -6,7 +6,7 @@ set(H_PREFIX include/BipedalLocomotion/Math)
 
 add_bipedal_locomotion_library(
   NAME                  Math
-  PUBLIC_HEADERS        ${H_PREFIX}/CARE.h
+  PUBLIC_HEADERS        ${H_PREFIX}/CARE.h ${H_PREFIX}/Constants.h
   SOURCES               src/CARE.cpp
   PUBLIC_LINK_LIBRARIES Eigen3::Eigen BipedalLocomotion::ParametersHandler
   SUBDIRECTORIES        tests)

--- a/src/Math/include/BipedalLocomotion/Math/Constants.h
+++ b/src/Math/include/BipedalLocomotion/Math/Constants.h
@@ -1,0 +1,24 @@
+/**
+ * @file Costants.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_MATH_CONSTANTS_H
+#define BIPEDAL_LOCOMOTION_MATH_CONSTANTS_H
+
+namespace BipedalLocomotion
+{
+namespace Math
+{
+/**
+ * The standard acceleration due to gravity (or standard acceleration of free fall), sometimes
+ * abbreviated as standard gravity, is the nominal gravitational
+ * acceleration of an object in a vacuum near the surface of the Earth.
+ */
+constexpr double StandardAccelerationOfGravitation = 9.80665;
+} // namespace Math
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_MATH_CONSTANTS_H

--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -11,7 +11,7 @@ if (FRAMEWORK_COMPILE_Planners)
     PUBLIC_HEADERS         ${H_PREFIX}/ConvexHullHelper.h ${H_PREFIX}/DCMPlanner.h ${H_PREFIX}/TimeVaryingDCMPlanner.h ${H_PREFIX}/QuinticSpline.h ${H_PREFIX}/SO3Planner.h ${H_PREFIX}/SO3Planner.tpp ${H_PREFIX}/SwingFootPlanner.h
     SOURCES                src/ConvexHullHelper.cpp  src/DCMPlanner.cpp src/TimeVaryingDCMPlanner.cpp src/QuinticSpline.cpp src/SwingFootPlanner.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::System BipedalLocomotion::Contacts
-    PRIVATE_LINK_LIBRARIES Qhull::qhullcpp Qhull::qhullstatic_r casadi
+    PRIVATE_LINK_LIBRARIES Qhull::qhullcpp Qhull::qhullstatic_r casadi BipedalLocomotion::Math
     INSTALLATION_FOLDER    Planners)
 
   add_subdirectory(tests)

--- a/src/Planners/include/BipedalLocomotion/Planners/DCMPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/DCMPlanner.h
@@ -42,8 +42,7 @@ struct DCMPlannerState
 class DCMPlanner : public BipedalLocomotion::System::Advanceable<DCMPlannerState>
 {
 protected:
-    std::shared_ptr<const Contacts::ContactPhaseList> m_contactPhaseList; /**< Pointer containing the contact
-                                                                   phases. */
+    Contacts::ContactPhaseList m_contactPhaseList; /**< Contact phases. */
 
     DCMPlannerState m_initialState; /**< Initial state of the planner */
 
@@ -53,7 +52,7 @@ public:
      * @param handler pointer to the parameter handler.
      * @return true in case of success/false otherwise.
      */
-    virtual bool initialize(std::shared_ptr<ParametersHandler::IParametersHandler> handler);
+    virtual bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
 
     /**
      * Set the initial state of the planner
@@ -69,7 +68,7 @@ public:
      * @param contactPhaseList pointer containing the list of the contact phases
      * @return true in case of success, false otherwise.
      */
-    bool setContactPhaseList(std::shared_ptr<const Contacts::ContactPhaseList> contactPhaseList);
+    virtual bool setContactPhaseList(const Contacts::ContactPhaseList& contactPhaseList);
 
     /**
      * Compute the DCM trajectory.
@@ -77,6 +76,12 @@ public:
      * @return true in case of success, false otherwise.
      */
     virtual bool computeTrajectory() = 0;
+
+    /**
+     * Set the DCM reference.
+     * @return true in case of success, false otherwise.
+     */
+    virtual bool setDCMReference(Eigen::Ref<const Eigen::MatrixXd> dcmReference);
 
     /**
      * Destructor.

--- a/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
@@ -57,6 +57,7 @@ public:
      * |    `vrp_rate_of_change_weight`    |  `double`  |                                               Weight associated to the rate of change of the VRP                                               |    Yes    |
      * |    `dcm_rate_of_change_weight`    |  `double`  |                                               Weight associated to the rate of change of the DCM                                               |    Yes    |
      * |    `use_external_dcm_reference`   |   `bool`   |  Set this option to true if you want provide an external DCM reference with TimeVaryingDCMPlanner::setDCMReference(). (Default value False)    |    No     |
+     * |            `gravity`              |  `double`  |  Value of the gravity acceleration. It should be a positive number (Default value BipedalLocomotion::Math::StandardAccelerationOfGravitation)  |    No     |
      * @return true in case of success/false otherwise.
      */
      bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler) override;

--- a/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
@@ -39,7 +39,7 @@ public:
     /**
      * Destructor.
      */
-    ~TimeVaryingDCMPlanner();
+    ~TimeVaryingDCMPlanner() override;
 
     /**
      * Initialize the planner.
@@ -56,9 +56,10 @@ public:
      * | `omega_dot_rate_of_change_weight` |  `double`  |                                          Weight associated to the rate of change of \f$\dot{omega}\f$                                          |    Yes    |
      * |    `vrp_rate_of_change_weight`    |  `double`  |                                               Weight associated to the rate of change of the VRP                                               |    Yes    |
      * |    `dcm_rate_of_change_weight`    |  `double`  |                                               Weight associated to the rate of change of the DCM                                               |    Yes    |
+     * |    `use_external_dcm_reference`   |   `bool`   |  Set this option to true if you want provide an external DCM reference with TimeVaryingDCMPlanner::setDCMReference(). (Default value False)    |    No     |
      * @return true in case of success/false otherwise.
      */
-     bool initialize(std::shared_ptr<ParametersHandler::IParametersHandler> handler) override;
+     bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler) override;
 
     /**
      * Compute the DCM trajectory.
@@ -66,11 +67,37 @@ public:
      */
      bool computeTrajectory() final;
 
-     /**
+    /**
+     * Set the contact phase list
+     * @note the contactPhaseList pointer should point to an already initialized ContactPhaseList.
+     * Please be sure that the memory pointed is reachable for the entire life time of the
+     * DCMPlanner class.
+     * @param contactPhaseList pointer containing the list of the contact phases
+     * @return true in case of success, false otherwise.
+     */
+    bool setContactPhaseList(const Contacts::ContactPhaseList& contactPhaseList) final;
+
+    /**
+     * Set the DCM reference. This value will be used as regularization term from the planner.
+     * @param dcmReference matrix containing the DCM trajectory. \a dcmReference must be a 3 x n
+     * matrix where the rows are the x y and z coordinates of the DCM and the columns contain the
+     * trajectory of the DCM.
+     * @note The number of columns should be coherent with the contactPhaseList. In details the
+     * number of samples \f$s\f$ is equal to
+     * \f[
+     *  s = \ceil*{\frac{t_f - t_i}{dT}}
+     * \f]
+     * where \f$dT\f$ is the sampling time of the planner, \f$t_f\f$ and \f$t_i\f$ are the end time
+     * of the last contact and the initial time of the first contact.
+     * @return true in case of success, false otherwise.
+     */
+    bool setDCMReference(Eigen::Ref<const Eigen::MatrixXd> dcmReference) final;
+
+    /**
      * @brief Get the object.
      * @return a const reference of the requested object.
      */
-     const DCMPlannerState& get() const final;
+    const DCMPlannerState& get() const final;
 
     /**
      * @brief Determines the validity of the object retrieved with get()

--- a/src/Planners/src/DCMPlanner.cpp
+++ b/src/Planners/src/DCMPlanner.cpp
@@ -10,21 +10,13 @@
 using namespace BipedalLocomotion::Planners;
 using namespace BipedalLocomotion::Contacts;
 
-bool DCMPlanner::initialize(std::shared_ptr<ParametersHandler::IParametersHandler> handler)
+bool DCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler)
 {
     return true;
 }
 
-bool DCMPlanner::setContactPhaseList(std::shared_ptr<const ContactPhaseList> contactPhaseList)
+bool DCMPlanner::setContactPhaseList(const ContactPhaseList& contactPhaseList)
 {
-    if(contactPhaseList == nullptr)
-    {
-        std::cerr << "[DCMPlanner::setContactPhaseList] The contactPhaseList pointer is expired. "
-                     "Please pass a valid pointer."
-                  << std::endl;
-        return false;
-    }
-
     m_contactPhaseList = contactPhaseList;
     return true;
 }
@@ -33,3 +25,8 @@ void DCMPlanner::setInitialState(const DCMPlannerState& initialState)
 {
     m_initialState = initialState;
 }
+
+bool DCMPlanner::setDCMReference(Eigen::Ref<const Eigen::MatrixXd> dcmReference)
+{
+    return true;
+};

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -504,10 +504,6 @@ struct TimeVaryingDCMPlanner::Impl
                                                                 + this->dcmVectorSize)));
         this->opti.set_value(this->optiParameters.omegaInitialValue, initialState.omega);
 
-        const auto& vrp = this->optiVariables.vrp;
-        const auto& omega = this->optiVariables.omega;
-        const auto& omegaDot = this->optiVariables.omegaDot;
-
         this->computeVRPConstraint(contactPhaseList);
 
         if (!this->optiSettings.useExternalDCMReference)

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -115,8 +115,19 @@ struct TimeVaryingDCMPlanner::Impl
         double omegaDotRateOfChangeWeight; /**< Weight related to rate of change of omega dot */
         double vrpRateOfChangeWeight; /**< Weight related to the rate of change of the VRP */
         double dcmRateOfChangeWeight; /**< Weight related to the rate of change of the DCM */
+
+        bool useExternalDCMReference{false}; /**< If true an external DCM reference is expected by
+                                                the planner */
     };
     OptimizationSettings optiSettings; /**< Settings */
+
+    struct InitialValue
+    {
+        casadi::DM dcm; /**< initial guess for the DCM trajectory */
+        casadi::DM omega; /**< initial guess omega trajectory */
+    };
+
+    InitialValue initialValue; /**< Initial value for the optimizer */
 
     /**
      * Get the eCMP from VRP and omega
@@ -340,33 +351,10 @@ struct TimeVaryingDCMPlanner::Impl
         return numberOfCoordinates == 2;
     }
 
-    bool setupOptimizationProblem(std::shared_ptr<const ContactPhaseList> contactPhaseList,
-                                  const DCMPlannerState& initialState)
+
+    void computeVRPConstraint(const ContactPhaseList& contactPhaseList)
     {
         using Sl = casadi::Slice;
-
-        // set the initial conditions
-        this->opti.set_value(this->optiParameters.dcmInitialPosition,
-                             casadi::DM(std::vector<double>(initialState.dcmPosition.data(),
-                                                            initialState.dcmPosition.data()
-                                                                + this->dcmVectorSize)));
-        this->opti.set_value(this->optiParameters.dcmInitialVelocity,
-                             casadi::DM(std::vector<double>(initialState.dcmVelocity.data(),
-                                                            initialState.dcmVelocity.data()
-                                                                + this->dcmVectorSize)));
-        this->opti.set_value(this->optiParameters.omegaInitialValue, initialState.omega);
-
-
-        double time = contactPhaseList->cbegin()->beginTime;
-
-        std::vector<Eigen::VectorXd> dcmKnots;
-        std::vector<double> timeKnots;
-
-        // first point
-        timeKnots.push_back(time);
-        dcmKnots.push_back(initialState.dcmPosition);
-
-        double averageDCMHeight = initialState.dcmPosition[2];
 
         casadi::DM ecmpConstraintA;
         casadi::DM ecmpConstraintB;
@@ -375,10 +363,7 @@ struct TimeVaryingDCMPlanner::Impl
         const auto& omega = this->optiVariables.omega;
         const auto& omegaDot = this->optiVariables.omegaDot;
 
-
-        auto contactPhaseListIt = contactPhaseList->cbegin();
-
-
+        auto contactPhaseListIt = contactPhaseList.cbegin();
         bool feetAreInSamePlane = computeConstraintElementsECMP(*contactPhaseListIt,
                                                                 ecmpConstraintA,
                                                                 ecmpConstraintB);
@@ -392,41 +377,6 @@ struct TimeVaryingDCMPlanner::Impl
                 feetAreInSamePlane = computeConstraintElementsECMP(*contactPhaseListIt,
                                                                    ecmpConstraintA,
                                                                    ecmpConstraintB);
-
-                if (contactPhaseListIt->activeContacts.size() == 2
-                    && contactPhaseListIt != contactPhaseList->begin()
-                    && contactPhaseListIt != contactPhaseList->lastPhase())
-                {
-                    timeKnots.emplace_back(
-                        (contactPhaseListIt->endTime + contactPhaseListIt->beginTime) / 2);
-
-                    auto contactIt = contactPhaseListIt->activeContacts.cbegin();
-                    const Eigen::Vector3d p1 = contactIt->second->pose.translation();
-                    std::advance(contactIt, 1);
-                    const Eigen::Vector3d p2 = contactIt->second->pose.translation();
-
-                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2.0;
-                    desiredDCMPosition(2) += averageDCMHeight;
-
-                    dcmKnots.emplace_back(desiredDCMPosition);
-                }
-
-                // TODO please try to make it more versatile
-                // read it as if the robot is in the last double support phase
-                else if (contactPhaseListIt->activeContacts.size() == 2
-                         && contactPhaseListIt == contactPhaseList->lastPhase())
-                {
-                    timeKnots.push_back(contactPhaseListIt->endTime);
-                    auto contactIt = contactPhaseListIt->activeContacts.cbegin();
-                    const Eigen::Vector3d p1 = contactIt->second->pose.translation();
-                    std::advance(contactIt, 1);
-                    const Eigen::Vector3d p2 = contactIt->second->pose.translation();
-
-                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2.0;
-                    desiredDCMPosition(2) += averageDCMHeight;
-
-                    dcmKnots.emplace_back(desiredDCMPosition);
-                }
             }
 
             if (!feetAreInSamePlane)
@@ -446,46 +396,138 @@ struct TimeVaryingDCMPlanner::Impl
                     == contactPhaseListIt->activeContacts.begin()->second->pose.translation()[2]);
             }
         }
+    }
 
+    bool computeDCMRegularization(const ContactPhaseList& contactPhaseList,
+                                  const DCMPlannerState& initialState)
+    {
+        std::vector<Eigen::VectorXd> dcmKnots;
+        std::vector<double> timeKnots;
+
+        // first point
+        timeKnots.push_back(contactPhaseList.cbegin()->beginTime);
+        dcmKnots.push_back(initialState.dcmPosition);
+
+        double averageDCMHeight = initialState.dcmPosition[2];
+        auto contactPhaseListIt = contactPhaseList.cbegin();
+
+        for (std::size_t k = 0; k < this->optiVariables.vrp.columns(); k++)
+        {
+            // if the
+            if (k * this->optiSettings.plannerSamplingTime > contactPhaseListIt->endTime)
+            {
+                std::advance(contactPhaseListIt, 1);
+
+                if (contactPhaseListIt->activeContacts.size() == 2
+                    && contactPhaseListIt != contactPhaseList.begin()
+                    && contactPhaseListIt != contactPhaseList.lastPhase())
+                {
+                    timeKnots.emplace_back(
+                        (contactPhaseListIt->endTime + contactPhaseListIt->beginTime) / 2);
+
+                    auto contactIt = contactPhaseListIt->activeContacts.cbegin();
+                    const Eigen::Vector3d p1 = contactIt->second->pose.translation();
+                    std::advance(contactIt, 1);
+                    const Eigen::Vector3d p2 = contactIt->second->pose.translation();
+
+                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2.0;
+                    desiredDCMPosition(2) += averageDCMHeight;
+
+                    dcmKnots.emplace_back(desiredDCMPosition);
+                }
+
+                // TODO please try to make it more versatile
+                // read it as if the robot is in the last double support phase
+                else if (contactPhaseListIt->activeContacts.size() == 2
+                         && contactPhaseListIt == contactPhaseList.lastPhase())
+                {
+                    timeKnots.push_back(contactPhaseListIt->endTime);
+                    auto contactIt = contactPhaseListIt->activeContacts.cbegin();
+                    const Eigen::Vector3d p1 = contactIt->second->pose.translation();
+                    std::advance(contactIt, 1);
+                    const Eigen::Vector3d p2 = contactIt->second->pose.translation();
+
+                    Eigen::Vector3d desiredDCMPosition = (p1 + p2) / 2.0;
+                    desiredDCMPosition(2) += averageDCMHeight;
+
+                    dcmKnots.emplace_back(desiredDCMPosition);
+                }
+            }
+        }
         dcmRef.setInitialConditions(initialState.dcmVelocity, Eigen::Vector3d::Zero());
         dcmRef.setFinalConditions(Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero());
         dcmRef.setKnots(dcmKnots, timeKnots);
 
+        // populate the reference
+        this->initialValue.dcm = casadi::DM::zeros(3, this->optiVariables.dcm.columns());
+        Eigen::Vector3d velocity, acceleration;
+        Eigen::Map<Eigen::MatrixXd> initialValueDCMEigenMap(initialValue.dcm.ptr(),
+                                                            initialValue.dcm.rows(),
+                                                            initialValue.dcm.columns());
+
+        for (int i = 0; i < this->optiVariables.dcm.columns(); i++)
+        {
+            const double currentTime = i * this->optiSettings.plannerSamplingTime;
+            if (!dcmRef.evaluatePoint(currentTime,
+                                     initialValueDCMEigenMap.col(i),
+                                     velocity,
+                                     acceleration))
+            {
+                std::cerr << "[TimeVaryingDCMPlanner::Impl::computeDCMRegularization] Unable to "
+                             "evaluate the dcm reference trajectory."
+                          << std::endl;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool setupOptimizationProblem(const ContactPhaseList& contactPhaseList,
+                                  const DCMPlannerState& initialState)
+    {
+        using Sl = casadi::Slice;
+
+        // set the initial conditions
+        this->opti.set_value(this->optiParameters.dcmInitialPosition,
+                             casadi::DM(std::vector<double>(initialState.dcmPosition.data(),
+                                                            initialState.dcmPosition.data()
+                                                                + this->dcmVectorSize)));
+        this->opti.set_value(this->optiParameters.dcmInitialVelocity,
+                             casadi::DM(std::vector<double>(initialState.dcmVelocity.data(),
+                                                            initialState.dcmVelocity.data()
+                                                                + this->dcmVectorSize)));
+        this->opti.set_value(this->optiParameters.omegaInitialValue, initialState.omega);
+
+        const auto& vrp = this->optiVariables.vrp;
+        const auto& omega = this->optiVariables.omega;
+        const auto& omegaDot = this->optiVariables.omegaDot;
+
+        this->computeVRPConstraint(contactPhaseList);
+
+        if (!this->optiSettings.useExternalDCMReference)
+            if (!this->computeDCMRegularization(contactPhaseList, initialState))
+            {
+                std::cerr << "[TimeVaryingDCMPlanner::Impl::setupOptimizationProblem] Unable to "
+                             "compute the DCM regularization term."
+                          << std::endl;
+                return false;
+            }
+
         // set last values
         this->opti.set_value(this->optiParameters.dcmFinalPosition,
-                             casadi::DM(std::vector<double>(dcmKnots.back().data(),
-                                                            dcmKnots.back().data()
-                                                                + this->dcmVectorSize)));
+                             this->initialValue.dcm(Sl(), -1));
 
         this->opti.set_value(this->optiParameters.dcmFinalVelocity,
                              casadi::DM::zeros(this->dcmVectorSize));
 
         // TODO the final omega is equal to the initial omega
         this->opti.set_value(this->optiParameters.omegaFinalValue, initialState.omega);
+        this->initialValue.omega = sqrt(9.81 / this->initialValue.dcm(2, Sl()));
+        this->opti.set_value(this->optiParameters.dcmRefererenceTraj, this->initialValue.dcm);
 
-        casadi::DM initialValueDCM = casadi::DM::zeros(3, this->optiVariables.dcm.columns());
-        casadi::DM initialValueOmega(1, this->optiVariables.dcm.columns());
-
-        Eigen::Vector3d velocity, acceleration;
-        Eigen::Map<Eigen::MatrixXd> initialValueDCMEigenMap(initialValueDCM.ptr(),
-                                                            initialValueDCM.rows(),
-                                                            initialValueDCM.columns());
-
-        for (int i = 0; i < this->optiVariables.dcm.columns(); i++)
-        {
-            const double currentTime = i * this->optiSettings.plannerSamplingTime;
-            dcmRef.evaluatePoint(currentTime,
-                                 initialValueDCMEigenMap.col(i),
-                                 velocity,
-                                 acceleration);
-        }
-
-        initialValueOmega = sqrt(9.81 / initialValueDCM(2,Sl()));
-        this->opti.set_value(this->optiParameters.dcmRefererenceTraj, initialValueDCM);
-
-        this->opti.set_initial(this->optiVariables.dcm, initialValueDCM);
-        this->opti.set_initial(this->optiVariables.vrp, initialValueDCM(Sl(), Sl(0, -1)));
-        this->opti.set_initial(this->optiVariables.omega, initialValueOmega);
+        this->opti.set_initial(this->optiVariables.dcm, this->initialValue.dcm);
+        this->opti.set_initial(this->optiVariables.vrp, this->initialValue.dcm(Sl(), Sl(0, -1)));
+        this->opti.set_initial(this->optiVariables.omega, this->initialValue.omega);
         this->opti.set_initial(this->optiVariables.omegaDot,
                                casadi::DM::zeros(1, omegaDot.columns()));
 
@@ -514,6 +556,7 @@ struct TimeVaryingDCMPlanner::Impl
 };
 
 TimeVaryingDCMPlanner::TimeVaryingDCMPlanner()
+    : DCMPlanner()
 {
     m_pimpl = std::make_unique<Impl>();
     assert(m_pimpl);
@@ -521,11 +564,13 @@ TimeVaryingDCMPlanner::TimeVaryingDCMPlanner()
 
 TimeVaryingDCMPlanner::~TimeVaryingDCMPlanner() = default;
 
-bool TimeVaryingDCMPlanner::initialize(std::shared_ptr<ParametersHandler::IParametersHandler> handler)
+bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler)
 {
     assert(m_pimpl);
 
-    if (handler == nullptr)
+    auto ptr = handler.lock();
+
+    if (ptr == nullptr)
     {
         std::cerr << "[TimeVaryingDCMPlanner::initialize] The handler has to point to an already "
                      "initialized IParametershandler."
@@ -533,7 +578,7 @@ bool TimeVaryingDCMPlanner::initialize(std::shared_ptr<ParametersHandler::IParam
         return false;
     }
 
-    if (!handler->getParameter("planner_sampling_time", m_pimpl->optiSettings.plannerSamplingTime))
+    if (!ptr->getParameter("planner_sampling_time", m_pimpl->optiSettings.plannerSamplingTime))
     {
         std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load the sampling time of "
                      "the planner."
@@ -542,7 +587,7 @@ bool TimeVaryingDCMPlanner::initialize(std::shared_ptr<ParametersHandler::IParam
     }
 
     int numberOfFootCorners;
-    if (!handler->getParameter("number_of_foot_corners", numberOfFootCorners))
+    if (!ptr->getParameter("number_of_foot_corners", numberOfFootCorners))
     {
         std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load the number of foot "
                      "corners."
@@ -552,10 +597,10 @@ bool TimeVaryingDCMPlanner::initialize(std::shared_ptr<ParametersHandler::IParam
 
     m_pimpl->optiSettings.footCorners.resize(numberOfFootCorners);
 
-    for(std::size_t i = 0; i < numberOfFootCorners; i++)
+    for (std::size_t i = 0; i < numberOfFootCorners; i++)
     {
-        if (!handler->getParameter("foot_corner_" + std::to_string(i),
-                                   m_pimpl->optiSettings.footCorners[i]))
+        if (!ptr->getParameter("foot_corner_" + std::to_string(i),
+                               m_pimpl->optiSettings.footCorners[i]))
         {
             std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load get the foot corner "
                          "number: "
@@ -572,27 +617,31 @@ bool TimeVaryingDCMPlanner::initialize(std::shared_ptr<ParametersHandler::IParam
 
     // get the linear solver used by ipopt. This parameter is optional. The default value is mumps
     std::string linearSolver;
-    if (handler->getParameter("linear_solver", linearSolver))
+    if (ptr->getParameter("linear_solver", linearSolver))
         m_pimpl->optiSettings.ipoptLinearSolver = linearSolver;
 
-    bool okCostFunctions = true;
-    okCostFunctions &= handler->getParameter("omega_dot_weight", m_pimpl->optiSettings.omegaDotWeight);
-    okCostFunctions &= handler->getParameter("dcm_tracking_weight", m_pimpl->optiSettings.dcmTrackingWeight);
-    okCostFunctions &= handler->getParameter("omega_dot_rate_of_change_weight",
-                                             m_pimpl->optiSettings.omegaDotRateOfChangeWeight);
-    okCostFunctions &= handler->getParameter("vrp_rate_of_change_weight",
-                                             m_pimpl->optiSettings.vrpRateOfChangeWeight);
+    bool ok = true;
+    ok = ok && ptr->getParameter("omega_dot_weight", m_pimpl->optiSettings.omegaDotWeight);
+    ok = ok && ptr->getParameter("dcm_tracking_weight", m_pimpl->optiSettings.dcmTrackingWeight);
+    ok = ok && ptr->getParameter("omega_dot_rate_of_change_weight",
+                                         m_pimpl->optiSettings.omegaDotRateOfChangeWeight);
+    ok = ok && ptr->getParameter("vrp_rate_of_change_weight",
+                                         m_pimpl->optiSettings.vrpRateOfChangeWeight);
 
-    okCostFunctions &= handler->getParameter("dcm_rate_of_change_weight",
-                                             m_pimpl->optiSettings.dcmRateOfChangeWeight);
+    ok = ok && ptr->getParameter("dcm_rate_of_change_weight",
+                                         m_pimpl->optiSettings.dcmRateOfChangeWeight);
 
-    if (!okCostFunctions)
+    if (!ok)
     {
         std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load weights of the cost "
                      "function"
                   << std::endl;
         return false;
     }
+
+    // if this option is chosen an external dcm reference must be provided
+    m_pimpl->optiSettings.useExternalDCMReference = false;
+    ptr->getParameter("use_external_dcm_reference", m_pimpl->optiSettings.useExternalDCMReference);
 
     // the casadi functions are initialized only once
     m_pimpl->setupCasADiFunctions();
@@ -605,29 +654,25 @@ bool TimeVaryingDCMPlanner::computeTrajectory()
 {
     assert(m_pimpl);
 
-    if(!m_pimpl->isPlannerInitialized)
+    constexpr auto errorPrefix = "[TimeVaryingDCMPlanner::initialize] ";
+
+    if (!m_pimpl->isPlannerInitialized)
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] Please initialize the planner before "
-                     "computing the trajectory."
+        std::cerr << errorPrefix << "Please initialize the planner before computing the trajectory."
                   << std::endl;
         return false;
     }
 
-    // clear the solver and the solution computed
-    m_pimpl->clear();
-
-    const double& initialTrajectoryTime = m_contactPhaseList->cbegin()->beginTime;
-    const double& endTrajectoryTime = m_contactPhaseList->lastPhase()->endTime;
-
-    m_pimpl->numberOfTrajectorySamples = std::ceil((endTrajectoryTime - initialTrajectoryTime)
-                                                   / m_pimpl->optiSettings.plannerSamplingTime);
-
-    m_pimpl->setupOpti(m_pimpl->numberOfTrajectorySamples);
+    if(m_pimpl->isTrajectoryComputed)
+    {
+        std::cerr << errorPrefix << "The trajectory has been already computed."
+                  << std::endl;
+        return false;
+    }
 
     if (!m_pimpl->setupOptimizationProblem(m_contactPhaseList, m_initialState))
     {
-        std::cerr << "[TimeVaryingDCMPlanner::computeTrajectory] Unable to setup the optimization "
-                     "problem."
+        std::cerr << errorPrefix << "Unable to setup the optimization problem."
                   << std::endl;
         return false;
     }
@@ -654,6 +699,66 @@ bool TimeVaryingDCMPlanner::computeTrajectory()
     m_pimpl->prepareSolution();
 
     m_pimpl->isTrajectoryComputed = true;
+
+    return true;
+}
+
+bool TimeVaryingDCMPlanner::setContactPhaseList(const Contacts::ContactPhaseList &contactPhaseList)
+{
+    assert(m_pimpl);
+
+    if(!m_pimpl->isPlannerInitialized)
+    {
+        std::cerr << "[TimeVaryingDCMPlanner::initialize] Please initialize the planner before "
+                     "computing the trajectory."
+                  << std::endl;
+        return false;
+    }
+
+    // clear the solver and the solution computed
+    m_pimpl->clear();
+
+    // store the contact phase list
+    m_contactPhaseList = contactPhaseList;
+
+    const double& initialTrajectoryTime = m_contactPhaseList.cbegin()->beginTime;
+    const double& endTrajectoryTime = m_contactPhaseList.lastPhase()->endTime;
+
+    m_pimpl->numberOfTrajectorySamples = std::ceil((endTrajectoryTime - initialTrajectoryTime)
+                                                   / m_pimpl->optiSettings.plannerSamplingTime);
+
+    m_pimpl->setupOpti(m_pimpl->numberOfTrajectorySamples);
+
+    // We have to recompute the trajectory
+    m_pimpl->isTrajectoryComputed = false;
+    return true;
+}
+
+bool TimeVaryingDCMPlanner::setDCMReference(Eigen::Ref<const Eigen::MatrixXd> dcmReference)
+{
+    assert(m_pimpl);
+    if(!m_pimpl->optiSettings.useExternalDCMReference)
+    {
+        std::cerr << "[TimeVaryingDCMPlanner::setDCMReference] You cannot call this function if "
+                     "you configure the planner with use_external_dcm_reference equal to false."
+                  << std::endl;
+        return false;
+    }
+
+    if (dcmReference.rows() != 3 || dcmReference.cols() != m_pimpl->optiVariables.dcm.columns())
+    {
+        std::cerr << "[TimeVaryingDCMPlanner::setDCMReference] Wrong size of the dcmReference. "
+                     "Expected matrix: (3 x "
+                  << m_pimpl->optiVariables.dcm.columns() << "). Passed matrix: ("
+                  << dcmReference.rows() << " x " << dcmReference.cols() << ")." << std::endl;
+        return false;
+    }
+
+    m_pimpl->initialValue.dcm = casadi::DM::zeros(3, m_pimpl->optiVariables.dcm.columns());
+    Eigen::Map<Eigen::MatrixXd>(m_pimpl->initialValue.dcm.ptr(),
+                                m_pimpl->initialValue.dcm.rows(),
+                                m_pimpl->initialValue.dcm.columns())
+        = dcmReference;
 
     return true;
 }

--- a/src/Planners/tests/CMakeLists.txt
+++ b/src/Planners/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ add_bipedal_test(
 add_bipedal_test(
   NAME TimeVaryingDCMPlanner
   SOURCES TimeVaryingDCMPlannerTest.cpp
-  LINKS BipedalLocomotion::Planners)
+  LINKS BipedalLocomotion::Planners BipedalLocomotion::Math)
 
 add_bipedal_test(
   NAME QuinticSpline

--- a/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
+++ b/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
@@ -18,7 +18,7 @@ using namespace BipedalLocomotion::ParametersHandler;
 
 TEST_CASE("TimeVaryingDCMPlanner")
 {
-    auto phaseList = std::make_shared<ContactPhaseList>();
+    ContactPhaseList phaseList;
 
     ContactListMap contactListMap;
 
@@ -47,7 +47,7 @@ TEST_CASE("TimeVaryingDCMPlanner")
     rightPos(2) = 0.2;
     rightTransform = manif::SE3d(rightPos, manif::SO3d::Identity());
     REQUIRE(contactListMap["right"].addContact(rightTransform, 4.0, 7.0));
-    phaseList->setLists(contactListMap);
+    phaseList.setLists(contactListMap);
 
     // Set the parameters
     std::shared_ptr<IParametersHandler> handler = std::make_shared<StdImplementation>();

--- a/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
+++ b/src/Planners/tests/TimeVaryingDCMPlannerTest.cpp
@@ -8,13 +8,15 @@
 // Catch2
 #include <catch2/catch.hpp>
 
-#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
 #include <BipedalLocomotion/Contacts/ContactPhaseList.h>
+#include <BipedalLocomotion/Math/Constants.h>
+#include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
 #include <BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h>
 
 using namespace BipedalLocomotion::Planners;
 using namespace BipedalLocomotion::Contacts;
 using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::Math;
 
 TEST_CASE("TimeVaryingDCMPlanner")
 {
@@ -84,7 +86,7 @@ TEST_CASE("TimeVaryingDCMPlanner")
     initialState.dcmPosition[2] = 0.53;
     initialState.dcmVelocity.setZero();
     initialState.vrpPosition = initialState.dcmPosition;
-    initialState.omega = std::sqrt(9.81 / initialState.dcmPosition[2]);
+    initialState.omega = std::sqrt(StandardAccelerationOfGravitation / initialState.dcmPosition[2]);
 
     // Initialize the planner
     TimeVaryingDCMPlanner planner;


### PR DESCRIPTION
With this PR it will be possible to pass a desired reference DCM trajectory to the DCMPlanner. The trajectory will be used as a regularization term. 

In details it introduces the optional parameter `use_external_dcm_reference`. If set to true the user should call  `setDCMReference()` to set the desired DCM reference.

The python bindings have been updated and they already implement this new feature. 

I checked the output of the planner with the already existing code and this is the planned trajectory

![dcm](https://user-images.githubusercontent.com/16744101/109048185-12c6d980-76d7-11eb-86ca-39a1e2a5a527.png)


cc @paolo-viceconte @diegoferigo 