### PR TITLE
Add ModelComputationsHelper to constuct KinDynComputations object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Implement `LeggedOdometry` class as a part of `FloatingBaseEstimators` library and handle arbitrary contacts in `FloatingBaseEstimator`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/151)
 - Implement the possibility to set a desired reference trajectory in the TimeVaryingDCMPlanner. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/208)
 - Implement SchmittTriggerDetector python bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/213)
+- Implement ModelComputationsHelper for quick construction of KinDynComputations object using parameters handler (https://github.com/dic-iit/bipedal-locomotion-framework/pull/216)
 
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -16,9 +16,9 @@ if(FRAMEWORK_COMPILE_FloatingBaseEstimators)
   set(H_PREFIX include/BipedalLocomotion/FloatingBaseEstimators)
   add_bipedal_locomotion_library(
     NAME                   FloatingBaseEstimators
-    SOURCES                src/FloatingBaseEstimator.cpp src/InvariantEKFBaseEstimator.cpp src/LeggedOdometry.cpp
+    SOURCES                src/ModelComputationsHelper.cpp src/FloatingBaseEstimator.cpp src/InvariantEKFBaseEstimator.cpp src/LeggedOdometry.cpp
     SUBDIRECTORIES         tests/FloatingBaseEstimators
-    PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h ${H_PREFIX}/InvariantEKFBaseEstimator.h ${H_PREFIX}/LeggedOdometry.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts
+    PUBLIC_HEADERS         ${H_PREFIX}/FloatingBaseEstimatorParams.h ${H_PREFIX}/FloatingBaseEstimatorIO.h ${H_PREFIX}/FloatingBaseEstimator.h ${H_PREFIX}/InvariantEKFBaseEstimator.h ${H_PREFIX}/LeggedOdometry.h ${H_PREFIX}/ModelComputationsHelper.h
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions iDynTree::idyntree-high-level iDynTree::idyntree-core iDynTree::idyntree-model BipedalLocomotion::System Eigen3::Eigen BipedalLocomotion::Contacts iDynTree::idyntree-modelio-urdf
     PRIVATE_LINK_LIBRARIES MANIF::manif)
 endif()

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
@@ -1,0 +1,64 @@
+/**
+ * @file ModelComputationsHelper.h
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_FLOATING_BASE_ESTIMATORS_MODEL_COMPUTATIONS_HELPER_H
+#define BIPEDAL_LOCOMOTION_FLOATING_BASE_ESTIMATORS_MODEL_COMPUTATIONS_HELPER_H
+
+// std
+#include <memory>
+
+// iDynTree
+#include <iDynTree/KinDynComputations.h>
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+
+namespace BipedalLocomotion
+{
+namespace Estimators
+{
+
+/**
+ * KinDynComputationsDescriptor wraps a pointer iDynTree KinDynComputations object.
+ */
+struct KinDynComputationsDescriptor
+{
+    std::shared_ptr<iDynTree::KinDynComputations> kindyn{nullptr}; /**< Pointer associated to the KinDynComputations. */
+
+    /**
+     * Constructor.
+     */
+    KinDynComputationsDescriptor(std::shared_ptr<iDynTree::KinDynComputations> kindyn);
+
+    /**
+     * Constructor.
+     */
+    KinDynComputationsDescriptor();
+
+    /**
+     * Check if the poly driver descriptor is valid.
+     * @return True if the polydriver is valid, false otherwise.
+     */
+    bool isValid() const;
+};
+
+/**
+ * Helper function that can be used to build a KinDynComputations object loaded with specified model.
+ * @param handler pointer to a parameter handler interface.
+ * @note the following parameters are required by the function
+ * |      Parameter Name     |       Type       |                         Description                       | Mandatory |
+ * |:-----------------------:|:----------------:|:---------------------------------------------------------:|:---------:|
+ * |      `joints_list`      | `vector<string>` |       List of the joints to be used in the reduced model  |    Yes    |
+ * |    `model_file_name`    |     `string`     |    file name containing the full path to the urdf model   |    Yes    |
+ * @return A KinDynComputationsDescriptor. If one of the parameters is missing an invalid KinDynComputationsDescriptor is returned.
+ */
+KinDynComputationsDescriptor constructKinDynComputationsDescriptor(
+    std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler);
+
+
+} // namespace Estimators
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_FLOATING_BASE_ESTIMATORS_MODEL_COMPUTATIONS_HELPER_H

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
@@ -38,8 +38,8 @@ struct KinDynComputationsDescriptor
     KinDynComputationsDescriptor();
 
     /**
-     * Check if the poly driver descriptor is valid.
-     * @return True if the polydriver is valid, false otherwise.
+     * Check if the KinDynComputationsDescriptor contains a valid pointer.
+     * @return True if valid, false otherwise.
      */
     bool isValid() const;
 };

--- a/src/Estimators/src/ModelComputationsHelper.cpp
+++ b/src/Estimators/src/ModelComputationsHelper.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file ModelComputationsHelper.cpp
+ * @authors Prashanth Ramadoss
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h>
+
+#include <string>
+#include <iDynTree/ModelIO/ModelLoader.h>
+
+using namespace BipedalLocomotion::Estimators;
+
+KinDynComputationsDescriptor::KinDynComputationsDescriptor(std::shared_ptr<iDynTree::KinDynComputations> kindyn)
+    : kindyn(kindyn)
+{
+}
+
+KinDynComputationsDescriptor::KinDynComputationsDescriptor() = default;
+
+bool BipedalLocomotion::Estimators::KinDynComputationsDescriptor::isValid() const
+{
+    return kindyn != nullptr;
+}
+
+KinDynComputationsDescriptor BipedalLocomotion::Estimators::constructKinDynComputationsDescriptor(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler)
+{
+    constexpr std::string_view errorPrefix = "[constructKinDynComputationsDescriptor] ";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        std::cerr << errorPrefix << "IParametershandler is empty. Returning an invalid KinDynComputationsDescriptor" << std::endl;
+        return KinDynComputationsDescriptor();
+    }
+
+    bool ok{true};
+    std::vector<std::string> jointsList;
+    ok = ok && ptr->getParameter("joints_list", jointsList);
+
+    std::string fileName;
+    ok = ok && ptr->getParameter("model_file_name", fileName);
+
+    if (!ok)
+    {
+        std::cerr << errorPrefix << "Unable to get all the parameters from configuration file."
+                  << std::endl;
+        return KinDynComputationsDescriptor();
+    }
+
+    iDynTree::ModelLoader mdlLdr;
+    ok = ok && mdlLdr.loadReducedModelFromFile(fileName, jointsList);
+
+    if (!ok)
+    {
+        std::cerr << errorPrefix << "Could not load the model using the specified parameters."
+                  << std::endl;
+        return KinDynComputationsDescriptor();
+    }
+
+    KinDynComputationsDescriptor kindynDesc(std::make_shared<iDynTree::KinDynComputations>());
+    if (!kindynDesc.kindyn->loadRobotModel(mdlLdr.model()))
+    {
+        std::cerr << errorPrefix << "Could not load a valid KinDynComputations object."
+                  << std::endl;
+        return KinDynComputationsDescriptor();
+    }
+
+    return kindynDesc;
+}
+

--- a/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
+++ b/src/Estimators/tests/FloatingBaseEstimators/CMakeLists.txt
@@ -12,5 +12,5 @@ add_bipedal_test(
 add_bipedal_test(
  NAME InvariantEKFBaseEstimatorTest
  SOURCES InvariantEKFBaseEstimatorTest.cpp
- LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions Eigen3::Eigen iDynTree::idyntree-modelio-urdf MANIF::manif)
+ LINKS BipedalLocomotion::FloatingBaseEstimators BipedalLocomotion::ParametersHandler BipedalLocomotion::ManifConversions Eigen3::Eigen MANIF::manif)
 


### PR DESCRIPTION
This PR,
- adds `KinDynComputationsDescriptor` class which is a simple wrapper for a shared pointer for an iDyntree KinDynComputations object
- helper method to load a model and construct a valid KinDynComputations using a parameter handler

Related issue https://github.com/dic-iit/bipedal-locomotion-framework/issues/214#issuecomment-786666189