### PR TITLE
[TimeVaryingDCMPlanner] restructure of setDCMReference() and setContactPhaseList()

### DIFF
--- a/bindings/python/TimeVaryingDCMPlanner.cpp
+++ b/bindings/python/TimeVaryingDCMPlanner.cpp
@@ -36,5 +36,6 @@ void BipedalLocomotion::bindings::CreateTimeVaryingDCMPlanner(pybind11::module& 
              py::arg("contact_phase_list"))
         .def("set_dcm_reference",
              &TimeVaryingDCMPlanner::setDCMReference,
-             py::arg("dcm_reference_matrix"));
+             py::arg("dcm_reference_matrix"))
+        .def("set_initial_state", &TimeVaryingDCMPlanner::setInitialState, py::arg("state"));
 }

--- a/src/Planners/include/BipedalLocomotion/Planners/DCMPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/DCMPlanner.h
@@ -58,7 +58,7 @@ public:
      * Set the initial state of the planner
      * @param initialState the initial state of the planner
      */
-    void setInitialState(const DCMPlannerState& initialState);
+    virtual void setInitialState(const DCMPlannerState& initialState);
 
     /**
      * Set the contact phase list

--- a/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/TimeVaryingDCMPlanner.h
@@ -95,6 +95,12 @@ public:
     bool setDCMReference(Eigen::Ref<const Eigen::MatrixXd> dcmReference) final;
 
     /**
+     * Set the initial state of the planner
+     * @param initialState the initial state of the planner
+     */
+    void setInitialState(const DCMPlannerState& initialState) final;
+
+    /**
      * @brief Get the object.
      * @return a const reference of the requested object.
      */

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -643,7 +643,14 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
     // get the linear solver used by ipopt. This parameter is optional. The default value is mumps
     std::string linearSolver;
     if (ptr->getParameter("linear_solver", linearSolver))
+    {
         m_pimpl->optiSettings.ipoptLinearSolver = linearSolver;
+    } else
+    {
+        std::cerr << "[TimeVaryingDCMPlanner::initialize] linear_solver not found. The following "
+                     "parameter will be used "
+                  << m_pimpl->optiSettings.ipoptLinearSolver << "." << std::endl;
+    }
 
     bool ok = true;
     ok = ok && ptr->getParameter("omega_dot_weight", m_pimpl->optiSettings.omegaDotWeight);
@@ -668,7 +675,13 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
 
     // if this option is chosen an external dcm reference must be provided
     m_pimpl->optiSettings.useExternalDCMReference = false;
-    ptr->getParameter("use_external_dcm_reference", m_pimpl->optiSettings.useExternalDCMReference);
+    if (!ptr->getParameter("use_external_dcm_reference",
+                           m_pimpl->optiSettings.useExternalDCMReference))
+    {
+        std::cerr << "[TimeVaryingDCMPlanner::initialize] use_external_dcm_reference not found. "
+                     "The following parameter will be used "
+                  << m_pimpl->optiSettings.useExternalDCMReference << "." << std::endl;
+    }
 
     if (ptr->getParameter("gravity", m_pimpl->optiSettings.gravity))
     {
@@ -681,6 +694,11 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
                       << std::endl;
             return false;
         }
+    } else
+    {
+        std::cerr << "[TimeVaryingDCMPlanner::initialize] gravity not found. The following "
+                     "parameter will be used "
+                  << BipedalLocomotion::Math::StandardAccelerationOfGravitation << "." << std::endl;
     }
 
     // the casadi functions are initialized only once

--- a/src/Planners/src/TimeVaryingDCMPlanner.cpp
+++ b/src/Planners/src/TimeVaryingDCMPlanner.cpp
@@ -482,7 +482,7 @@ struct TimeVaryingDCMPlanner::Impl
                                      velocity,
                                      acceleration))
             {
-                std::cerr << "[TimeVaryingDCMPlanner::Impl::computeDCMRegularization] Unable to "
+                std::cerr << "[ERROR] [TimeVaryingDCMPlanner::Impl::computeDCMRegularization] Unable to "
                              "evaluate the dcm reference trajectory."
                           << std::endl;
                 return false;
@@ -494,7 +494,7 @@ struct TimeVaryingDCMPlanner::Impl
     bool setupOptimizationProblem(const ContactPhaseList& contactPhaseList,
                                   const DCMPlannerState& initialState)
     {
-        constexpr auto errorPrefix = "[TimeVaryingDCMPlanner::Impl::setupOptimizationProblem] ";
+        constexpr auto errorPrefix = "[ERROR] [TimeVaryingDCMPlanner::Impl::setupOptimizationProblem] ";
 
         using Sl = casadi::Slice;
 
@@ -597,7 +597,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
 
     if (ptr == nullptr)
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] The handler has to point to an already "
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] The handler has to point to an already "
                      "initialized IParametershandler."
                   << std::endl;
         return false;
@@ -605,7 +605,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
 
     if (!ptr->getParameter("planner_sampling_time", m_pimpl->optiSettings.plannerSamplingTime))
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load the sampling time of "
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] Unable to load the sampling time of "
                      "the planner."
                   << std::endl;
         return false;
@@ -614,7 +614,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
     int numberOfFootCorners;
     if (!ptr->getParameter("number_of_foot_corners", numberOfFootCorners))
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load the number of foot "
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] Unable to load the number of foot "
                      "corners."
                   << std::endl;
         return false;
@@ -627,7 +627,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
         if (!ptr->getParameter("foot_corner_" + std::to_string(i),
                                m_pimpl->optiSettings.footCorners[i]))
         {
-            std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load get the foot corner "
+            std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] Unable to load get the foot corner "
                          "number: "
                       << i << ". Please provide the foot corners having the following names: ";
             for (std::size_t j = 0; j < numberOfFootCorners; j++)
@@ -647,7 +647,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
         m_pimpl->optiSettings.ipoptLinearSolver = linearSolver;
     } else
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] linear_solver not found. The following "
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] linear_solver not found. The following "
                      "parameter will be used "
                   << m_pimpl->optiSettings.ipoptLinearSolver << "." << std::endl;
     }
@@ -665,7 +665,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
 
     if (!ok)
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] Unable to load weights of the cost "
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] Unable to load weights of the cost "
                      "function"
                   << std::endl;
         return false;
@@ -678,7 +678,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
     if (!ptr->getParameter("use_external_dcm_reference",
                            m_pimpl->optiSettings.useExternalDCMReference))
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] use_external_dcm_reference not found. "
+        std::cerr << "[INFO] [TimeVaryingDCMPlanner::initialize] use_external_dcm_reference not found. "
                      "The following parameter will be used "
                   << m_pimpl->optiSettings.useExternalDCMReference << "." << std::endl;
     }
@@ -687,7 +687,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
     {
         if (m_pimpl->optiSettings.gravity <= 0)
         {
-            std::cerr << "[TimeVaryingDCMPlanner::initialize] The gravity should be a strictly "
+            std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] The gravity should be a strictly "
                          "positive number. If you do not know which value use you can avoid to set "
                          "this parameter. The default value will be used. Default value: "
                       << BipedalLocomotion::Math::StandardAccelerationOfGravitation << "."
@@ -696,7 +696,7 @@ bool TimeVaryingDCMPlanner::initialize(std::weak_ptr<ParametersHandler::IParamet
         }
     } else
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] gravity not found. The following "
+        std::cerr << "[INFO] [TimeVaryingDCMPlanner::initialize] gravity not found. The following "
                      "parameter will be used "
                   << BipedalLocomotion::Math::StandardAccelerationOfGravitation << "." << std::endl;
     }
@@ -712,7 +712,7 @@ bool TimeVaryingDCMPlanner::computeTrajectory()
 {
     assert(m_pimpl);
 
-    constexpr auto errorPrefix = "[TimeVaryingDCMPlanner::initialize] ";
+    constexpr auto errorPrefix = "[ERROR] [TimeVaryingDCMPlanner::initialize] ";
 
     if (!m_pimpl->isPlannerInitialized)
     {
@@ -751,8 +751,8 @@ bool TimeVaryingDCMPlanner::computeTrajectory()
         m_pimpl->optiSolution.solution = std::make_unique<casadi::OptiSol>(m_pimpl->opti.solve());
     } catch (const std::exception& e)
     {
-        std::cerr << "[TimeVaryingDCMPlanner::computeTrajectory] Unable to solve the optimization "
-                     "problem. The following exception has been thrown by the solver: "
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::computeTrajectory] Unable to solve the "
+                     "optimization problem. The following exception has been thrown by the solver: "
                   << std::endl
                   << e.what() << "." << std::endl;
         return false;
@@ -779,8 +779,8 @@ bool TimeVaryingDCMPlanner::setContactPhaseList(const Contacts::ContactPhaseList
 
     if(!m_pimpl->isPlannerInitialized)
     {
-        std::cerr << "[TimeVaryingDCMPlanner::initialize] Please initialize the planner before "
-                     "computing the trajectory."
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::initialize] Please initialize the planner "
+                     "before computing the trajectory."
                   << std::endl;
         return false;
     }
@@ -795,7 +795,7 @@ bool TimeVaryingDCMPlanner::setContactPhaseList(const Contacts::ContactPhaseList
 
 bool TimeVaryingDCMPlanner::setDCMReference(Eigen::Ref<const Eigen::MatrixXd> dcmReference)
 {
-    constexpr auto errorPrefix = "[TimeVaryingDCMPlanner::setDCMReference] ";
+    constexpr auto errorPrefix = "[ERROR] [TimeVaryingDCMPlanner::setDCMReference] ";
 
     assert(m_pimpl);
     if(!m_pimpl->optiSettings.useExternalDCMReference)
@@ -849,8 +849,8 @@ bool TimeVaryingDCMPlanner::advance()
 {
     if (!isValid())
     {
-        std::cerr << "[TimeVaryingDCMPlanner::advance] The data are not valid it is not possible "
-                     "to advance."
+        std::cerr << "[ERROR] [TimeVaryingDCMPlanner::advance] The data are not valid it is not "
+                     "possible to advance."
                   << std::endl;
         return false;
     }


### PR DESCRIPTION
#208 implements   `setDCMReference()` however the user had to call the function after `setContactPhaseList()`.  Thanks to this PR, `setDCMReference()` does not depends on `setContactPhaseList()` and the user can call it whenever their want. 

cc @paolo-viceconte 