### PR TITLE
Add conda-force-ci GitHub Action job

### DIFF
--- a/.github/workflows/conda-forge-ci-build-and-tests.yml
+++ b/.github/workflows/conda-forge-ci-build-and-tests.yml
@@ -1,8 +1,9 @@
-name: C++ CI Workflow with conda-forge dependencies
+name: Build with Tests CI Workflow with conda-forge dependencies
 
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
   # * is a special character in YAML so you have to quote this string
   # Execute a "nightly" build at 2 AM UTC 
@@ -15,11 +16,16 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [macOS-10.15]
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v2
+    
+    - name: Clone gazebo repo
+      shell: bash -l {0}
+      run: |
+        git clone https://github.com/osrf/gazebo
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
@@ -33,12 +39,37 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology-staging idyntree yarp  eigen qhull casadi cppad manif
-        
+        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 tinyxml boost-cpp libcurl ffmpeg 
+ 
+    - name: Dependencies [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mamba install libtar libccd 
+    
+    - name: Dependencies [Linux]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mamba install libuuid
+
+    - name: Dependencies [macOS]
+      if: contains(matrix.os, 'macos')
+      shell: bash -l {0}
+      run: |
+        mamba install libuuid bzip2 zlib
+
+    - name: Dependencies [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mamba install dlfcn-win32 tiny-process-library
+
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
+        cd gazebo
         mkdir -p build
         cd build
         cmake -GNinja -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
@@ -47,6 +78,7 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
+        cd gazebo
         mkdir -p build
         cd build
         cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
@@ -54,11 +86,14 @@ jobs:
     - name: Build 
       shell: bash -l {0}
       run: |
+        cd gazebo
         cd build
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Test
       shell: bash -l {0}
       run: |
+        cd gazebo
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}
+

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -33,7 +33,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology-staging idyntree yarp matio-cpp eigen qhull casadi cppad manif spdlog catch2
+        mamba install -c robotology-staging idyntree yarp matio-cpp lie-group-controllers eigen qhull casadi cppad manif spdlog catch2
         
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -1,9 +1,8 @@
-name: Build with Tests CI Workflow with conda-forge dependencies
+name: C++ CI Workflow with conda-forge dependencies
 
 on:
   push:
   pull_request:
-  workflow_dispatch:
   schedule:
   # * is a special character in YAML so you have to quote this string
   # Execute a "nightly" build at 2 AM UTC 
@@ -16,16 +15,11 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [macOS-10.15]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v2
-    
-    - name: Clone gazebo repo
-      shell: bash -l {0}
-      run: |
-        git clone https://github.com/osrf/gazebo
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
@@ -39,37 +33,12 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 tinyxml boost-cpp libcurl ffmpeg 
- 
-    - name: Dependencies [Linux&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
-      shell: bash -l {0}
-      run: |
-        mamba install libtar libccd 
-    
-    - name: Dependencies [Linux]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
-      shell: bash -l {0}
-      run: |
-        mamba install libuuid
-
-    - name: Dependencies [macOS]
-      if: contains(matrix.os, 'macos')
-      shell: bash -l {0}
-      run: |
-        mamba install libuuid bzip2 zlib
-
-    - name: Dependencies [Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
-      run: |
-        mamba install dlfcn-win32 tiny-process-library
-
+        mamba install -c robotology-staging idyntree yarp  eigen qhull casadi cppad manif
+        
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        cd gazebo
         mkdir -p build
         cd build
         cmake -GNinja -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
@@ -78,7 +47,6 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        cd gazebo
         mkdir -p build
         cd build
         cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
@@ -86,14 +54,11 @@ jobs:
     - name: Build 
       shell: bash -l {0}
       run: |
-        cd gazebo
         cd build
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Test
       shell: bash -l {0}
       run: |
-        cd gazebo
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}
-

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -33,7 +33,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology-staging idyntree yarp  eigen qhull casadi cppad manif
+        mamba install -c robotology-staging idyntree yarp  eigen qhull casadi cppad manif spdlog
         
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -1,0 +1,64 @@
+name: C++ CI Workflow with conda-forge dependencies
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+
+jobs:
+  build:
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build_type: [Release]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
+
+    - name: Dependencies
+      shell: bash -l {0}
+      run: |
+        # Compilation related dependencies 
+        mamba install cmake compilers make ninja pkg-config
+        # Actual dependencies
+        mamba install -c robotology-staging idyntree yarp  eigen qhull casadi cppad manif
+        
+    - name: Configure [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+      
+    - name: Configure [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+
+    - name: Build 
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+        
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        cd build
+        ctest --output-on-failure -C ${{ matrix.build_type }}

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -33,7 +33,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology-staging idyntree yarp  eigen qhull casadi cppad manif spdlog
+        mamba install -c robotology-staging idyntree yarp matio-cpp eigen qhull casadi cppad manif spdlog catch2
         
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Add GitHub Action job that compile the project using conda-forge-provided dependencies on Linux/macOS/Windows. The main advantage over apt-based workflow is that we always get the latest version of dependencies, easily detecting eventual regressions. Furthermore, no dependency needs to be compiled from source, making the GitHub Action simpler and more mantainable. 

Similar PRs:
* https://github.com/dic-iit/matio-cpp/pull/29
* https://github.com/robotology/idyntree/pull/786

