### PR TITLE
ModelComputationsHelper: Option to load KinDynComputationsDescriptor without specifying joints list

### DIFF
--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
@@ -48,10 +48,10 @@ struct KinDynComputationsDescriptor
  * Helper function that can be used to build a KinDynComputations object loaded with specified model.
  * @param handler pointer to a parameter handler interface.
  * @note the following parameters are required by the function
- * |      Parameter Name     |       Type       |                         Description                       | Mandatory |
- * |:-----------------------:|:----------------:|:---------------------------------------------------------:|:---------:|
- * |      `joints_list`      | `vector<string>` |       List of the joints to be used in the reduced model  |    Yes    |
- * |    `model_file_name`    |     `string`     |    file name containing the full path to the urdf model   |    Yes    |
+ * |      Parameter Name     |       Type       |                         Description                       | Mandatory |              Remark                |
+ * |:-----------------------:|:----------------:|:---------------------------------------------------------:|:---------:|:----------------------------------:|
+ * |      `joints_list`      | `vector<string>` |       List of the joints to be used in the reduced model  |    No     | Full model is loaded if unavailable|
+ * |    `model_file_name`    |     `string`     |    file name containing the full path to the urdf model   |    Yes    |                 -                  |
  * @return A KinDynComputationsDescriptor. If one of the parameters is missing an invalid KinDynComputationsDescriptor is returned.
  */
 KinDynComputationsDescriptor constructKinDynComputationsDescriptor(

--- a/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
+++ b/src/Estimators/include/BipedalLocomotion/FloatingBaseEstimators/ModelComputationsHelper.h
@@ -52,6 +52,8 @@ struct KinDynComputationsDescriptor
  * |:-----------------------:|:----------------:|:---------------------------------------------------------:|:---------:|:----------------------------------:|
  * |      `joints_list`      | `vector<string>` |       List of the joints to be used in the reduced model  |    No     | Full model is loaded if unavailable|
  * |    `model_file_name`    |     `string`     |    file name containing the full path to the urdf model   |    Yes    |                 -                  |
+ * @warning the joint list order that is obtained by loading the model without specifying `joints_list` is not stable in any way.
+ *          It might not match any specific order across different environments, so one must be very careful while loading the model in this way.
  * @return A KinDynComputationsDescriptor. If one of the parameters is missing an invalid KinDynComputationsDescriptor is returned.
  */
 KinDynComputationsDescriptor constructKinDynComputationsDescriptor(

--- a/src/Estimators/src/ModelComputationsHelper.cpp
+++ b/src/Estimators/src/ModelComputationsHelper.cpp
@@ -37,7 +37,11 @@ KinDynComputationsDescriptor BipedalLocomotion::Estimators::constructKinDynCompu
 
     bool ok{true};
     std::vector<std::string> jointsList;
-    ok = ok && ptr->getParameter("joints_list", jointsList);
+    bool loadFullModel{false};
+    if (!ptr->getParameter("joints_list", jointsList))
+    {
+        loadFullModel = true;
+    }
 
     std::string fileName;
     ok = ok && ptr->getParameter("model_file_name", fileName);
@@ -50,7 +54,14 @@ KinDynComputationsDescriptor BipedalLocomotion::Estimators::constructKinDynCompu
     }
 
     iDynTree::ModelLoader mdlLdr;
-    ok = ok && mdlLdr.loadReducedModelFromFile(fileName, jointsList);
+    if (loadFullModel)
+    {
+        ok = ok && mdlLdr.loadModelFromFile(fileName);
+    }
+    else
+    {
+        ok = ok && mdlLdr.loadReducedModelFromFile(fileName, jointsList);
+    }
 
     if (!ok)
     {


### PR DESCRIPTION
This option is useful while loading human URDF models.