### PR TITLE
Start using spdlog in the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
         # Install pybind11
         ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports pybind11:x64-windows
 
+        # Install spdlog
+        ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports spdlog
+
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
       run: |
@@ -88,7 +91,7 @@ jobs:
         brew unlink gcc@9
 
         brew update
-        brew install ace boost eigen swig qt5 orocos-kdl catch2 qhull ipopt cppad pkg-config pybind11 libmatio
+        brew install ace boost eigen swig qt5 orocos-kdl catch2 qhull ipopt cppad pkg-config pybind11 libmatio spdlog
 
     - name: Dependencies [Ubuntu]
       if: startsWith(matrix.os, 'ubuntu')
@@ -97,7 +100,7 @@ jobs:
         sudo apt-get install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
                              libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev \
                              libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python3-dev valgrind coinor-libipopt-dev \
-                             libmatio-dev python3-pytest python3-numpy python3-scipy python3-setuptools
+                             libmatio-dev python3-pytest python3-numpy python3-scipy python3-setuptools libspdlog-dev
 
     - name: Cache Source-based Dependencies
       id: cache-source-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  vcpkg_robotology_TAG: v0.4.0
-  vcpkg_TAG: 76a7e9248fb3c57350b559966dcaa2d52a5e4458
+  vcpkg_robotology_TAG: v0.6.2
+  vcpkg_TAG: 45fc55825db2a5bcaffccff1e6afadc519d164ea
   YCM_TAG: v0.12.1
   YARP_TAG: v3.4.2
   iDynTree_TAG: v3.0.0
@@ -61,23 +61,19 @@ jobs:
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/robotology/vcpkg
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology.zip
-        unzip vcpkg-robotology.zip -d C:/
-        rm vcpkg-robotology.zip
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology-with-gazebo.zip
+        unzip vcpkg-robotology-with-gazebo.zip -d C:/
+        rm vcpkg-robotology-with-gazebo.zip
 
-        # Install Catch2 and cppad
+        # Install Catch2
         cd C:/robotology/vcpkg
         git fetch
         git checkout $env:vcpkg_TAG
         ./bootstrap-vcpkg.bat
-        ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports catch2:x64-windows cppad:x64-windows matio:x64-windows
-        echo "cppad_DIR=C:/robotology/vcpkg/installed/x64-windows" >> $GITHUB_ENV
+        ./vcpkg.exe install catch2:x64-windows
 
         # Install pybind11
-        ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports pybind11:x64-windows
-
-        # Install spdlog
-        ./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports spdlog
+        ./vcpkg.exe install pybind11:x64-windows
 
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - Implement SchmittTriggerDetector python bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/213)
 - Implement ModelComputationsHelper for quick construction of KinDynComputations object using parameters handler (https://github.com/dic-iit/bipedal-locomotion-framework/pull/216)
 - Implement FloatingBaseEstimator and LeggedOdometry python bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/218)
+- Add spdlog as mandatory dependency of the project (https://github.com/dic-iit/bipedal-locomotion-framework/pull/225)
 
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The **bipedal-locomotion-framework** project is a _suite_ of libraries for achie
 # :page_facing_up: Mandatory dependencies
 The **bipedal-locomotion-framework** project is versatile and can be used to compile only some components.
 
-The minimum required dependencies are `Eigen3` and `iDynTree`. If you want to build the tests please remember to install `Catch2`. If you are interested in the python bindings generation please install `python3` and `pybind11` in your system.
+The minimum required dependencies are `Eigen3`, `iDynTree` and `spdlog`. If you want to build the tests please remember to install `Catch2`. If you are interested in the python bindings generation please install `python3` and `pybind11` in your system.
 
 # :orange_book: Exported components
 

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -12,6 +12,8 @@ find_package(iDynTree 1.1.0 REQUIRED) #Right now, all the packages built in the 
                                       #(which is an iDynTree dependency by the way)
 find_package(Eigen3 3.2.92 REQUIRED)
 
+find_package(spdlog REQUIRED)
+
 find_package(YARP QUIET)
 checkandset_dependency(YARP)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+add_subdirectory(TextLogging)
 add_subdirectory(GenericContainer)
 add_subdirectory(YarpUtilities)
 add_subdirectory(ParametersHandler)

--- a/src/ParametersHandler/CMakeLists.txt
+++ b/src/ParametersHandler/CMakeLists.txt
@@ -8,5 +8,5 @@ add_bipedal_locomotion_library(
   NAME                  ParametersHandler
   PUBLIC_HEADERS        ${H_PREFIX}/IParametersHandler.h ${H_PREFIX}/StdImplementation.h ${H_PREFIX}/StdImplementation.tpp
   SOURCES                src/StdImplementation.cpp
-  PUBLIC_LINK_LIBRARIES BipedalLocomotion::GenericContainer
+  PUBLIC_LINK_LIBRARIES BipedalLocomotion::GenericContainer BipedalLocomotion::TextLogging
   SUBDIRECTORIES        tests YarpImplementation)

--- a/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/StdImplementation.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotion/ParametersHandler/StdImplementation.tpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 
 #include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
 
 namespace BipedalLocomotion
 {
@@ -20,11 +21,12 @@ namespace ParametersHandler
 template <typename T>
 bool StdImplementation::getParameterPrivate(const std::string& parameterName, T& parameter) const
 {
+    constexpr auto logPrefix = "[StdImplementation::getParameterPrivate]";
+
     auto parameterAny = m_map.find(parameterName);
     if (parameterAny == m_map.end())
     {
-        std::cerr << "[StdImplementation::getParameterPrivate] Parameter named " << parameterName
-                  << " not found." << std::endl;
+        log()->error("{} Parameter named '{}' not found.", logPrefix, parameterName);
         return false;
     }
 
@@ -35,9 +37,10 @@ bool StdImplementation::getParameterPrivate(const std::string& parameterName, T&
             parameter = std::any_cast<T>(parameterAny->second);
         } catch (const std::bad_any_cast& exception)
         {
-            std::cerr << "[StdImplementation::getParameterPrivate] The type of the parameter "
-                         "named "
-                      << parameterName << " is different from the one expected" << std::endl;
+            log()->error("{} The type of the parameter named '{}' is different from the one "
+                         "expected.",
+                         logPrefix,
+                         parameterName);
             return false;
         }
     } else
@@ -49,9 +52,10 @@ bool StdImplementation::getParameterPrivate(const std::string& parameterName, T&
             castedParameter = std::any_cast<std::vector<elementType>>(parameterAny->second);
         } catch (const std::bad_any_cast& exception)
         {
-            std::cerr << "[StdImplementation::getParameterPrivate] The type of the parameter "
-                         "named "
-                      << parameterName << " is different from the one expected" << std::endl;
+            log()->error("{} The type of the parameter named {} is different from the one "
+                         "expected.",
+                         logPrefix,
+                         parameterName);
             return false;
         }
 
@@ -63,19 +67,23 @@ bool StdImplementation::getParameterPrivate(const std::string& parameterName, T&
             {
                 if (!parameter.resizeVector(castedParameter.size()))
                 {
-                    std::cerr << "[StdImplementation::getParameterPrivate] Unable to resize "
-                              << type_name<T>() << "List size: " << castedParameter.size()
-                              << ". Vector size: " << parameter.size() << std::endl;
+                    log()->error("{} Unable to resize {} List size: {}. Vector size: {}.",
+                                 logPrefix,
+                                 type_name<T>(),
+                                 castedParameter.size(),
+                                 parameter.size());
+
                     return false;
                 }
             } else if constexpr (is_resizable<T>::value)
                 parameter.resize(castedParameter.size());
             else
             {
-                std::cerr << "[StdImplementation::getParameterPrivate] The size of the "
-                             "vector does not match with the size of the list. List size: "
-                          << castedParameter.size() << ". Vector size: " << parameter.size()
-                          << std::endl;
+                log()->error("{} The size of the vector does not match with the size of the list. "
+                             "List size: {}. Vector size: {}.",
+                             logPrefix,
+                             castedParameter.size(),
+                             parameter.size());
                 return false;
             }
         }

--- a/src/ParametersHandler/src/StdImplementation.cpp
+++ b/src/ParametersHandler/src/StdImplementation.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
 
 using namespace BipedalLocomotion::ParametersHandler;
 
@@ -113,9 +114,8 @@ bool StdImplementation::setGroup(const std::string& name, IParametersHandler::sh
     auto downcastedPtr = std::dynamic_pointer_cast<StdImplementation>(newGroup);
     if (downcastedPtr == nullptr)
     {
-        std::cerr << "[StdImplementation::setGroup] Unable to downcast the pointer to "
-                     "StdImplementation."
-                  << std::endl;
+        BipedalLocomotion::log()->error("[StdImplementation::setGroup] Unable to downcast the "
+                                        "pointer to StdImplementation.");
         return false;
     }
 
@@ -136,8 +136,10 @@ IParametersHandler::weak_ptr StdImplementation::getGroup(const std::string& name
         map = std::any_cast<shared_ptr>(group->second);
     } catch (const std::bad_any_cast& exception)
     {
-        std::cerr << "[StdImplementation::getGroup] The element named " << name
-                  << " is not a 'std::unordered_map<std::string, std::any>'" << std::endl;
+        log()->warn("[StdImplementation::getGroup] The element named '{}' is not a "
+                    "'std::unordered_map<std::string, std::any>'",
+                    name);
+
         return std::make_shared<StdImplementation>();
     }
 

--- a/src/Planners/CMakeLists.txt
+++ b/src/Planners/CMakeLists.txt
@@ -11,7 +11,7 @@ if (FRAMEWORK_COMPILE_Planners)
     PUBLIC_HEADERS         ${H_PREFIX}/ConvexHullHelper.h ${H_PREFIX}/DCMPlanner.h ${H_PREFIX}/TimeVaryingDCMPlanner.h ${H_PREFIX}/QuinticSpline.h ${H_PREFIX}/SO3Planner.h ${H_PREFIX}/SO3Planner.tpp ${H_PREFIX}/SwingFootPlanner.h
     SOURCES                src/ConvexHullHelper.cpp  src/DCMPlanner.cpp src/TimeVaryingDCMPlanner.cpp src/QuinticSpline.cpp src/SwingFootPlanner.cpp
     PUBLIC_LINK_LIBRARIES  Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::System BipedalLocomotion::Contacts
-    PRIVATE_LINK_LIBRARIES Qhull::qhullcpp Qhull::qhullstatic_r casadi BipedalLocomotion::Math
+    PRIVATE_LINK_LIBRARIES Qhull::qhullcpp Qhull::qhullstatic_r casadi BipedalLocomotion::Math BipedalLocomotion::TextLogging
     INSTALLATION_FOLDER    Planners)
 
   add_subdirectory(tests)

--- a/src/TextLogging/CMakeLists.txt
+++ b/src/TextLogging/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+add_bipedal_locomotion_library(
+  NAME                   TextLogging
+  PUBLIC_HEADERS         include/BipedalLocomotion/TextLogging/Logger.h
+  SOURCES                src/Logger.cpp
+  PUBLIC_LINK_LIBRARIES  spdlog::spdlog)

--- a/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
+++ b/src/TextLogging/include/BipedalLocomotion/TextLogging/Logger.h
@@ -1,0 +1,29 @@
+/**
+ * @file Logger.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_TEXT_LOGGING_LOGGER_H
+#define BIPEDAL_LOCOMOTION_TEXT_LOGGING_LOGGER_H
+
+#include <spdlog/spdlog.h>
+
+namespace BipedalLocomotion
+{
+namespace TextLogging
+{
+
+using Logger = spdlog::logger;
+
+} // namespace TextLogging
+
+/**
+ * Get an the instance of the log
+ */
+TextLogging::Logger* const log();
+
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_TEXT_LOGGING_LOGGER_H

--- a/src/TextLogging/src/Logger.cpp
+++ b/src/TextLogging/src/Logger.cpp
@@ -8,24 +8,26 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include <BipedalLocomotion/TextLogging/Logger.h>
-#include <iostream>
+
 namespace BipedalLocomotion
 {
 
 TextLogging::Logger* const log()
 {
-    auto logger = spdlog::get("console");
+    auto logger = spdlog::get("blf");
 
     // if the logger does not exist, create it. spdlog already handle the logger as singleton.
     if (logger == nullptr)
     {
-        // create the logger called console
-        auto console = spdlog::stderr_color_mt("console");
+        // create the logger called blf
+        auto console = spdlog::stderr_color_mt("blf");
 
         // get the logger
-        logger = spdlog::get("console");
+        logger = spdlog::get("blf");
+
+        // customize the logger
         logger->set_level(spdlog::level::info);
-        logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v");
+        logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] %^[%l]%$ %v");
     }
 
     return logger.get();

--- a/src/TextLogging/src/Logger.cpp
+++ b/src/TextLogging/src/Logger.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file Logger.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+#include <BipedalLocomotion/TextLogging/Logger.h>
+#include <iostream>
+namespace BipedalLocomotion
+{
+
+TextLogging::Logger* const log()
+{
+    auto logger = spdlog::get("console");
+
+    // if the logger does not exist, create it. spdlog already handle the logger as singleton.
+    if (logger == nullptr)
+    {
+        // create the logger called console
+        auto console = spdlog::stderr_color_mt("console");
+
+        // get the logger
+        logger = spdlog::get("console");
+        logger->set_level(spdlog::level::info);
+        logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v");
+    }
+
+    return logger.get();
+}
+
+} // namespace BipedalLocomotion


### PR DESCRIPTION
This pr should be seen as a point where we can discuss. Then if we found a common agreement we may think to merge it.

In this PR I added [`spdlog`](ttps://github.com/gabime/spdlog). It is a nice log that can be used to print stuff in the terminal.
The dependency can be installed with `apt` `vcpkg` and `brew`. 

This is the output of the `TimeVaryingDCMTest` with the code implemented in this PR.
![image](https://user-images.githubusercontent.com/16744101/109862914-4cf92380-7c61-11eb-806e-830d1c034d75.png)

We can further customize the output: https://github.com/gabime/spdlog/wiki/3.-Custom-formatting.

It's also possible to automatically print the name of the function, name of the file and line. However, we should define some macros.
The nice thing is that it can be used in a multithread application https://cran.r-project.org/web/packages/RcppSpdlog/vignettes/introduction.html

cc @traversaro @prashanthr05 @S-Dafarra 

