### PR TITLE
Use std::optional instead of raw pointer in ISensorBridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented in this file.
 - The DCMPlanner and TimeVaryingDCMPlanner initialize functions take as input an std::weak_ptr. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/208)
 - Use `Math::StandardAccelerationOfGravitation` instead of hardcoding 9.81. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/211)
 - Convert iDynTree types in FloatingBaseEstimators component to Eigen/manif types (https://github.com/dic-iit/bipedal-locomotion-framework/pull/215)
+- Use std::optional instead of raw pointer in ISensorBridge. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/226)
 
 ### Fixed
 - Fix missing implementation of `YarpSensorBridge::getFailedSensorReads()`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/202)

--- a/bindings/python/RobotInterface.cpp
+++ b/bindings/python/RobotInterface.cpp
@@ -224,7 +224,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
             "get_joint_position",
             [](YarpSensorBridge& impl, const std::string& jointName) {
                 double joint, receiveTimeInSeconds;
-                bool ok = impl.getJointPosition(jointName, joint, &receiveTimeInSeconds);
+                bool ok = impl.getJointPosition(jointName, joint, receiveTimeInSeconds);
                 return std::make_tuple(ok, joint, receiveTimeInSeconds);
             },
             py::arg("joint_name"))
@@ -232,14 +232,14 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
              [](YarpSensorBridge& impl) {
                  Eigen::VectorXd joints(impl.get().bridgeOptions.nrJoints);
                  double receiveTimeInSeconds;
-                 bool ok = impl.getJointPositions(joints, &receiveTimeInSeconds);
+                 bool ok = impl.getJointPositions(joints, receiveTimeInSeconds);
                  return std::make_tuple(ok, joints, receiveTimeInSeconds);
              })
         .def(
             "get_joint_velocity",
             [](YarpSensorBridge& impl, const std::string& name) {
                 double joint, receiveTimeInSeconds;
-                bool ok = impl.getJointVelocity(name, joint, &receiveTimeInSeconds);
+                bool ok = impl.getJointVelocity(name, joint, receiveTimeInSeconds);
                 return std::make_tuple(ok, joint, receiveTimeInSeconds);
             },
             py::arg("joint_name"))
@@ -247,7 +247,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
              [](YarpSensorBridge& impl) {
                  Eigen::VectorXd joints(impl.get().bridgeOptions.nrJoints);
                  double receiveTimeInSeconds;
-                 bool ok = impl.getJointVelocities(joints, &receiveTimeInSeconds);
+                 bool ok = impl.getJointVelocities(joints, receiveTimeInSeconds);
                  return std::make_tuple(ok, joints, receiveTimeInSeconds);
              })
         .def(
@@ -255,7 +255,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
             [](YarpSensorBridge& impl, const std::string& name) {
                 Eigen::Matrix<double, 12, 1> measurement;
                 double receiveTimeInSeconds;
-                bool ok = impl.getIMUMeasurement(name, measurement, &receiveTimeInSeconds);
+                bool ok = impl.getIMUMeasurement(name, measurement, receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("sensor_name"))
@@ -266,7 +266,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
                 double receiveTimeInSeconds;
                 bool ok = impl.getLinearAccelerometerMeasurement(name,
                                                                  measurement,
-                                                                 &receiveTimeInSeconds);
+                                                                 receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("sensor_name"))
@@ -275,7 +275,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
             [](YarpSensorBridge& impl, const std::string& name) {
                 Eigen::Vector3d measurement;
                 double receiveTimeInSeconds;
-                bool ok = impl.getGyroscopeMeasure(name, measurement, &receiveTimeInSeconds);
+                bool ok = impl.getGyroscopeMeasure(name, measurement, receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("sensor_name"))
@@ -286,7 +286,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
                 double receiveTimeInSeconds;
                 bool ok = impl.getOrientationSensorMeasurement(name,
                                                                measurement,
-                                                               &receiveTimeInSeconds);
+                                                               receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("sensor_name"))
@@ -295,7 +295,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
             [](YarpSensorBridge& impl, const std::string& name) {
                 Eigen::Vector3d measurement;
                 double receiveTimeInSeconds;
-                bool ok = impl.getMagnetometerMeasurement(name, measurement, &receiveTimeInSeconds);
+                bool ok = impl.getMagnetometerMeasurement(name, measurement, receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("sensor_name"))
@@ -306,7 +306,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
                 double receiveTimeInSeconds;
                 bool ok = impl.getSixAxisForceTorqueMeasurement(name,
                                                                 measurement,
-                                                                &receiveTimeInSeconds);
+                                                                receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("sensor_name"))
@@ -317,7 +317,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
                 double receiveTimeInSeconds;
                 bool ok = impl.getThreeAxisForceTorqueMeasurement(name,
                                                                   measurement,
-                                                                  &receiveTimeInSeconds);
+                                                                  receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("sensor_name"))
@@ -326,7 +326,7 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
             [](YarpSensorBridge& impl, const std::string& name) {
                 Eigen::Matrix<double, 6, 1> measurement;
                 double receiveTimeInSeconds;
-                bool ok = impl.getCartesianWrench(name, measurement, &receiveTimeInSeconds);
+                bool ok = impl.getCartesianWrench(name, measurement, receiveTimeInSeconds);
                 return std::make_tuple(ok, measurement, receiveTimeInSeconds);
             },
             py::arg("wrench_name"))
@@ -334,14 +334,14 @@ void BipedalLocomotion::bindings::CreateYarpSensorBridge(pybind11::module& modul
             "get_motor_current",
             [](YarpSensorBridge& impl, const std::string& jointName) {
                 double joint, receiveTimeInSeconds;
-                bool ok = impl.getMotorCurrent(jointName, joint, &receiveTimeInSeconds);
+                bool ok = impl.getMotorCurrent(jointName, joint, receiveTimeInSeconds);
                 return std::make_tuple(ok, joint, receiveTimeInSeconds);
             },
             py::arg("motor_name"))
         .def("get_motor_currents", [](YarpSensorBridge& impl) {
             Eigen::VectorXd joints(impl.get().bridgeOptions.nrJoints);
             double receiveTimeInSeconds;
-            bool ok = impl.getMotorCurrents(joints, &receiveTimeInSeconds);
+            bool ok = impl.getMotorCurrents(joints, receiveTimeInSeconds);
             return std::make_tuple(ok, joints, receiveTimeInSeconds);
         });
 }

--- a/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
+++ b/devices/FloatingBaseEstimatorDevice/src/FloatingBaseEstimatorDevice.cpp
@@ -319,14 +319,14 @@ bool FloatingBaseEstimatorDevice::updateContactStates()
     Eigen::Matrix<double, 6, 1> lfWrench, rfWrench;
     double lfTimeStamp, rfTimeStamp;
     bool ok{true};
-    ok = ok && m_robotSensorBridge->getCartesianWrench(m_leftFootWrenchName, lfWrench, &lfTimeStamp);
+    ok = ok && m_robotSensorBridge->getCartesianWrench(m_leftFootWrenchName, lfWrench, lfTimeStamp);
     if (ok)
     {
         m_currentlContactNormal = lfWrench(2);
         m_lFootCSM->contactMeasurementUpdate(lfTimeStamp, lfWrench(2)); // fz
     }
 
-    ok = ok && m_robotSensorBridge->getCartesianWrench(m_rightFootWrenchName, rfWrench, &rfTimeStamp);
+    ok = ok && m_robotSensorBridge->getCartesianWrench(m_rightFootWrenchName, rfWrench, rfTimeStamp);
     if (ok)
     {
         m_currentrContactNormal = rfWrench(2);

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -9,7 +9,9 @@
 #define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_SENSOR_BRIDGE_H
 
 // std
+#include <functional>
 #include <memory>
+#include <optional>
 
 // YARP
 #include <yarp/dev/PolyDriverList.h>

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -199,7 +199,7 @@ public:
      */
     bool getJointPosition(const std::string& jointName,
                           double& jointPosition,
-                          double* receiveTimeInSeconds = nullptr) final;
+                          OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get all joints' positions in radians
@@ -213,7 +213,7 @@ public:
      * @return true/false in case of success/failure
      */
     bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
-                           double* receiveTimeInSeconds = nullptr) final;
+                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get joint velocity in rad/s
@@ -224,7 +224,7 @@ public:
      */
     bool getJointVelocity(const std::string& jointName,
                           double& jointVelocity,
-                          double* receiveTimeInSeconds = nullptr) final;
+                          OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get all joints' velocities in rad/s
@@ -238,7 +238,7 @@ public:
      * @return true/false in case of success/failure
      */
     bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
-                            double* receiveTimeInSeconds = nullptr) final;
+                            OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get IMU measurement
@@ -255,7 +255,7 @@ public:
      */
     bool getIMUMeasurement(const std::string& imuName,
                            Eigen::Ref<Vector12d> imuMeasurement,
-                           double* receiveTimeInSeconds = nullptr) final;
+                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get linear accelerometer measurement in m/s^2
@@ -266,7 +266,7 @@ public:
      */
     bool getLinearAccelerometerMeasurement(const std::string& accName,
                                            Eigen::Ref<Eigen::Vector3d> accMeasurement,
-                                           double* receiveTimeInSeconds = nullptr) final;
+                                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get gyroscope measurement in rad/s
@@ -277,7 +277,7 @@ public:
      */
     bool getGyroscopeMeasure(const std::string& gyroName,
                              Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
-                             double* receiveTimeInSeconds = nullptr) final;
+                             OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
    /**
      * Get orientation sensor measurement in radians as roll pitch yaw Euler angles
@@ -288,7 +288,7 @@ public:
      */
     bool getOrientationSensorMeasurement(const std::string& rpyName,
                                          Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
-                                         double* receiveTimeInSeconds = nullptr) final;
+                                         OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
    /**
      * Get magentometer measurement in tesla
@@ -299,7 +299,7 @@ public:
      */
     bool getMagnetometerMeasurement(const std::string& magName,
                                     Eigen::Ref<Eigen::Vector3d> magMeasurement,
-                                    double* receiveTimeInSeconds = nullptr) final;
+                                    OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get six axis force torque measurement
@@ -310,7 +310,7 @@ public:
      */
     bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
                                           Eigen::Ref<Vector6d> ftMeasurement,
-                                          double* receiveTimeInSeconds = nullptr) final;
+                                          OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get three axis force-torque measurement containing normal force (N) and tangential moments (Nm)
@@ -321,7 +321,7 @@ public:
      */
     bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
                                             Eigen::Ref<Eigen::Vector3d> ftMeasurement,
-                                            double* receiveTimeInSeconds = nullptr) final;
+                                            OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
    /**
      * Get 6D end effector wrenches in N and Nm for forces and torques respectively
@@ -332,7 +332,7 @@ public:
      */
     bool getCartesianWrench(const std::string& cartesianWrenchName,
                             Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
-                            double* receiveTimeInSeconds = nullptr) final;
+                            OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get motor current in ampere
@@ -343,7 +343,7 @@ public:
      */
     bool getMotorCurrent(const std::string& jointName,
                           double& motorCurrent,
-                          double* receiveTimeInSeconds = nullptr) final;
+                          OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
      * Get all motors' currents in ampere
@@ -357,7 +357,7 @@ public:
      * @return true/false in case of success/failure
      */
     bool getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
-                           double* receiveTimeInSeconds = nullptr) final;
+                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
 private:
     /** Private implementation */

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -12,7 +12,8 @@ using namespace BipedalLocomotion::RobotInterface;
 using namespace BipedalLocomotion::GenericContainer;
 using namespace BipedalLocomotion::ParametersHandler;
 
-YarpSensorBridge::YarpSensorBridge() : m_pimpl(std::make_unique<Impl>())
+YarpSensorBridge::YarpSensorBridge()
+    : m_pimpl(std::make_unique<Impl>())
 {
 }
 
@@ -30,54 +31,69 @@ bool YarpSensorBridge::initialize(std::weak_ptr<IParametersHandler> handler)
         return false;
     }
 
-
-    if(!ptr->getParameter("check_for_nan", m_pimpl->checkForNAN))
+    if (!ptr->getParameter("check_for_nan", m_pimpl->checkForNAN))
     {
-        std::cerr << logPrefix << "Unable to get check_for_nan."
-                  << std ::endl;
+        std::cerr << logPrefix << "Unable to get check_for_nan." << std ::endl;
         return false;
     }
 
     bool ret{true};
-    ret = m_pimpl->subConfigLoader("stream_joint_states", "RemoteControlBoardRemapper",
-                                    &YarpSensorBridge::Impl::configureRemoteControlBoardRemapper,
-                                    handler,
-                                    m_pimpl->metaData,
-                                    m_pimpl->metaData.bridgeOptions.isKinematicsEnabled);
+    ret = m_pimpl->subConfigLoader("stream_joint_states",
+                                   "RemoteControlBoardRemapper",
+                                   &YarpSensorBridge::Impl::configureRemoteControlBoardRemapper,
+                                   handler,
+                                   m_pimpl->metaData,
+                                   m_pimpl->metaData.bridgeOptions.isKinematicsEnabled);
     if (!ret)
     {
-        std::cout << logPrefix << " Skipping the configuration of RemoteControlBoardRemapper. YarpSensorBridge will not stream relevant measures." << std::endl;
+        std::cout << logPrefix
+                  << " Skipping the configuration of RemoteControlBoardRemapper. YarpSensorBridge "
+                     "will not stream relevant measures."
+                  << std::endl;
     }
 
     bool useInertialSensors{false};
-    ret = m_pimpl->subConfigLoader("stream_inertials", "InertialSensors",
-                                    &YarpSensorBridge::Impl::configureInertialSensors,
-                                    handler,
-                                    m_pimpl->metaData,
-                                    useInertialSensors);
+    ret = m_pimpl->subConfigLoader("stream_inertials",
+                                   "InertialSensors",
+                                   &YarpSensorBridge::Impl::configureInertialSensors,
+                                   handler,
+                                   m_pimpl->metaData,
+                                   useInertialSensors);
     if (!ret)
     {
-        std::cout << logPrefix << " Skipping the configuration of InertialSensors. YarpSensorBridge will not stream relevant measures." << std::endl;
+        std::cout << logPrefix
+                  << " Skipping the configuration of InertialSensors. YarpSensorBridge will not "
+                     "stream relevant measures."
+                  << std::endl;
     }
 
-    ret = m_pimpl->subConfigLoader("stream_forcetorque_sensors", "SixAxisForceTorqueSensors",
-                                    &YarpSensorBridge::Impl::configureSixAxisForceTorqueSensors,
-                                    handler,
-                                    m_pimpl->metaData,
-                                    m_pimpl->metaData.bridgeOptions.isSixAxisForceTorqueSensorEnabled);
+    ret = m_pimpl
+              ->subConfigLoader("stream_forcetorque_sensors",
+                                "SixAxisForceTorqueSensors",
+                                &YarpSensorBridge::Impl::configureSixAxisForceTorqueSensors,
+                                handler,
+                                m_pimpl->metaData,
+                                m_pimpl->metaData.bridgeOptions.isSixAxisForceTorqueSensorEnabled);
     if (!ret)
     {
-        std::cout << logPrefix << " Skipping the configuration of SixAxisForceTorqueSensors. YarpSensorBridge will not stream relevant measures." << std::endl;
+        std::cout << logPrefix
+                  << " Skipping the configuration of SixAxisForceTorqueSensors. YarpSensorBridge "
+                     "will not stream relevant measures."
+                  << std::endl;
     }
 
-    ret = m_pimpl->subConfigLoader("stream_cartesian_wrenches", "CartesianWrenches",
-                                    &YarpSensorBridge::Impl::configureCartesianWrenches,
-                                    handler,
-                                    m_pimpl->metaData,
-                                    m_pimpl->metaData.bridgeOptions.isCartesianWrenchEnabled);
+    ret = m_pimpl->subConfigLoader("stream_cartesian_wrenches",
+                                   "CartesianWrenches",
+                                   &YarpSensorBridge::Impl::configureCartesianWrenches,
+                                   handler,
+                                   m_pimpl->metaData,
+                                   m_pimpl->metaData.bridgeOptions.isCartesianWrenchEnabled);
     if (!ret)
     {
-        std::cout << logPrefix << " Skipping the configuration of CartesianWrenches. YarpSensorBridge will not stream relevant measures." << std::endl;
+        std::cout << logPrefix
+                  << " Skipping the configuration of CartesianWrenches. YarpSensorBridge will not "
+                     "stream relevant measures."
+                  << std::endl;
     }
 
     m_pimpl->bridgeInitialized = true;
@@ -90,7 +106,8 @@ bool YarpSensorBridge::setDriversList(const yarp::dev::PolyDriverList& deviceDri
 
     if (!m_pimpl->bridgeInitialized)
     {
-        std::cerr << logPrefix << "Please initialize YarpSensorBridge before calling setDriversList(...)."
+        std::cerr << logPrefix
+                  << "Please initialize YarpSensorBridge before calling setDriversList(...)."
                   << std ::endl;
         return false;
     }
@@ -103,8 +120,7 @@ bool YarpSensorBridge::setDriversList(const yarp::dev::PolyDriverList& deviceDri
 
     if (!ret)
     {
-        std::cerr << logPrefix << "Failed to attach to one or more device drivers."
-                  << std ::endl;
+        std::cerr << logPrefix << "Failed to attach to one or more device drivers." << std ::endl;
         return false;
     }
     m_pimpl->driversAttached = true;
@@ -161,7 +177,8 @@ bool YarpSensorBridge::getIMUsList(std::vector<std::string>& IMUsList)
     return true;
 }
 
-bool YarpSensorBridge::getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList)
+bool YarpSensorBridge::getLinearAccelerometersList(
+    std::vector<std::string>& linearAccelerometersList)
 {
     if (!m_pimpl->checkValid("[YarpSensorBridge::getLinearAccelerometersList]"))
     {
@@ -201,7 +218,8 @@ bool YarpSensorBridge::getMagnetometersList(std::vector<std::string>& magnetomet
     return true;
 }
 
-bool YarpSensorBridge::getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList)
+bool YarpSensorBridge::getSixAxisForceTorqueSensorsList(
+    std::vector<std::string>& sixAxisForceTorqueSensorsList)
 {
     if (!m_pimpl->checkValid("[YarpSensorBridge::getSixAxisForceTorqueSensorsList]"))
     {
@@ -223,213 +241,244 @@ bool YarpSensorBridge::getCartesianWrenchesList(std::vector<std::string>& cartes
 
 bool YarpSensorBridge::getJointPosition(const std::string& jointName,
                                         double& jointPosition,
-                                        double* receiveTimeInSeconds)
+                                        OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
-    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList,
-                                     jointName, idx))
+    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
     {
         std::cerr << "[YarpSensorBridge::getJointPosition] " << jointName
-                  <<  " could not be found in the configured list of joints" << std::endl;
+                  << " could not be found in the configured list of joints" << std::endl;
         return false;
     }
 
     jointPosition = m_pimpl->controlBoardRemapperMeasures.jointPositions[idx];
-    receiveTimeInSeconds = &m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
 
     return true;
 }
 
 bool YarpSensorBridge::getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
-                                         double* receiveTimeInSeconds)
+                                         OptionalDoubleRef receiveTimeInSeconds)
 {
 
     jointPositions = yarp::eigen::toEigen(m_pimpl->controlBoardRemapperMeasures.jointPositions);
-    receiveTimeInSeconds = &m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
     return true;
 }
 
 bool YarpSensorBridge::getJointVelocity(const std::string& jointName,
                                         double& jointVelocity,
-                                        double* receiveTimeInSeconds)
+                                        OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
-    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList,
-                                     jointName, idx))
+    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
     {
         std::cerr << "[YarpSensorBridge::getJointVelocity] " << jointName
-                  <<  " could not be found in the configured list of joints" << std::endl;
+                  << " could not be found in the configured list of joints" << std::endl;
         return false;
     }
 
     jointVelocity = m_pimpl->controlBoardRemapperMeasures.jointVelocities[idx];
-    receiveTimeInSeconds = &m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
 
     return true;
 }
 
 bool YarpSensorBridge::getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
-                                          double* receiveTimeInSeconds)
+                                          OptionalDoubleRef receiveTimeInSeconds)
 {
     jointVelocties = yarp::eigen::toEigen(m_pimpl->controlBoardRemapperMeasures.jointVelocities);
-    receiveTimeInSeconds = &m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
     return true;
 }
 
 bool YarpSensorBridge::getIMUMeasurement(const std::string& imuName,
                                          Eigen::Ref<Vector12d> imuMeasurement,
-                                         double* receiveTimeInSeconds)
+                                         OptionalDoubleRef receiveTimeInSeconds)
 {
     if (!m_pimpl->checkValidSensorMeasure("YarpSensorBridge::getIMUMeasurement ",
-                                       m_pimpl->wholeBodyIMUMeasures, imuName))
+                                          m_pimpl->wholeBodyIMUMeasures,
+                                          imuName))
     {
         return false;
     }
 
     auto iter = m_pimpl->wholeBodyIMUMeasures.find(imuName);
     imuMeasurement = yarp::eigen::toEigen(iter->second.first);
-    receiveTimeInSeconds = &iter->second.second;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get() = iter->second.second;
     return true;
 }
 
 bool YarpSensorBridge::getLinearAccelerometerMeasurement(const std::string& accName,
                                                          Eigen::Ref<Eigen::Vector3d> accMeasurement,
-                                                         double* receiveTimeInSeconds)
+                                                         OptionalDoubleRef receiveTimeInSeconds)
 {
     if (!m_pimpl->checkValidSensorMeasure("YarpSensorBridge::getLinearAccelerometerMeasurement ",
-                                           m_pimpl->wholeBodyInertialMeasures, accName))
+                                          m_pimpl->wholeBodyInertialMeasures,
+                                          accName))
     {
         return false;
     }
 
     auto iter = m_pimpl->wholeBodyInertialMeasures.find(accName);
     accMeasurement = yarp::eigen::toEigen(iter->second.first);
-    receiveTimeInSeconds = &iter->second.second;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get() = iter->second.second;
     return true;
 }
 
 bool YarpSensorBridge::getGyroscopeMeasure(const std::string& gyroName,
                                            Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
-                                           double* receiveTimeInSeconds)
+                                           OptionalDoubleRef receiveTimeInSeconds)
 {
     if (!m_pimpl->checkValidSensorMeasure("YarpSensorBridge::getGyroscopeMeasure ",
-                                           m_pimpl->wholeBodyInertialMeasures, gyroName))
+                                          m_pimpl->wholeBodyInertialMeasures,
+                                          gyroName))
     {
         return false;
     }
 
     auto iter = m_pimpl->wholeBodyInertialMeasures.find(gyroName);
     gyroMeasurement = yarp::eigen::toEigen(iter->second.first);
-    receiveTimeInSeconds = &iter->second.second;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get() = iter->second.second;
     return true;
 }
 
-
 bool YarpSensorBridge::getOrientationSensorMeasurement(const std::string& rpyName,
                                                        Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
-                                                       double* receiveTimeInSeconds)
+                                                       OptionalDoubleRef receiveTimeInSeconds)
 {
     if (!m_pimpl->checkValidSensorMeasure("YarpSensorBridge::getOrientationSensorMeasurement ",
-                                           m_pimpl->wholeBodyInertialMeasures, rpyName))
+                                          m_pimpl->wholeBodyInertialMeasures,
+                                          rpyName))
     {
         return false;
     }
 
     auto iter = m_pimpl->wholeBodyInertialMeasures.find(rpyName);
     rpyMeasurement = yarp::eigen::toEigen(iter->second.first);
-    receiveTimeInSeconds = &iter->second.second;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get() = iter->second.second;
     return true;
 }
 
 bool YarpSensorBridge::getMagnetometerMeasurement(const std::string& magName,
                                                   Eigen::Ref<Eigen::Vector3d> magMeasurement,
-                                                  double* receiveTimeInSeconds)
+                                                  OptionalDoubleRef receiveTimeInSeconds)
 {
     if (!m_pimpl->checkValidSensorMeasure("YarpSensorBridge::getMagnetometerMeasurement ",
-                                           m_pimpl->wholeBodyInertialMeasures, magName))
+                                          m_pimpl->wholeBodyInertialMeasures,
+                                          magName))
     {
         return false;
     }
 
     auto iter = m_pimpl->wholeBodyInertialMeasures.find(magName);
     magMeasurement = yarp::eigen::toEigen(iter->second.first);
-    receiveTimeInSeconds = &iter->second.second;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get() = iter->second.second;
     return true;
 }
 
 bool YarpSensorBridge::getSixAxisForceTorqueMeasurement(const std::string& ftName,
                                                         Eigen::Ref<Vector6d> ftMeasurement,
-                                                        double* receiveTimeInSeconds)
+                                                        OptionalDoubleRef receiveTimeInSeconds)
 {
     if (!m_pimpl->checkValidSensorMeasure("YarpSensorBridge::getSixAxisForceTorqueMeasurement ",
-                                           m_pimpl->wholeBodyFTMeasures, ftName))
+                                          m_pimpl->wholeBodyFTMeasures,
+                                          ftName))
     {
         return false;
     }
 
     auto iter = m_pimpl->wholeBodyFTMeasures.find(ftName);
     ftMeasurement = yarp::eigen::toEigen(iter->second.first);
-    receiveTimeInSeconds = &iter->second.second;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get() = iter->second.second;
     return true;
 }
 
 bool YarpSensorBridge::getCartesianWrench(const std::string& cartesianWrenchName,
                                           Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
-                                          double* receiveTimeInSeconds)
+                                          OptionalDoubleRef receiveTimeInSeconds)
 {
     if (!m_pimpl->checkValidSensorMeasure("YarpSensorBridge::getCartesianWrench ",
-                                           m_pimpl->wholeBodyCartesianWrenchMeasures, cartesianWrenchName))
+                                          m_pimpl->wholeBodyCartesianWrenchMeasures,
+                                          cartesianWrenchName))
     {
         return false;
     }
 
     auto iter = m_pimpl->wholeBodyCartesianWrenchMeasures.find(cartesianWrenchName);
     cartesianWrenchMeasurement = yarp::eigen::toEigen(iter->second.first);
-    receiveTimeInSeconds = &iter->second.second;
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get() = iter->second.second;
     return true;
 }
 
 bool YarpSensorBridge::getThreeAxisForceTorqueMeasurement(const std::string& ftName,
                                                           Eigen::Ref<Eigen::Vector3d> ftMeasurement,
-                                                          double* receiveTimeInSeconds)
+                                                          OptionalDoubleRef receiveTimeInSeconds)
 {
-    constexpr std::string_view error = "[YarpSensorBridge::getThreeAxisForceTorqueMeasurement] Currently unimplemented";
-    std::cerr << error <<  std::endl;
+    constexpr std::string_view error = "[YarpSensorBridge::getThreeAxisForceTorqueMeasurement] "
+                                       "Currently unimplemented";
+    std::cerr << error << std::endl;
     return false;
 }
 
-bool YarpSensorBridge::getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList)
+bool YarpSensorBridge::getThreeAxisForceTorqueSensorsList(
+    std::vector<std::string>& threeAxisForceTorqueSensorsList)
 {
-    constexpr std::string_view error = "[YarpSensorBridge::getThreeAxisForceTorqueSensorsList] Currently unimplemented";
-    std::cerr << error <<  std::endl;
+    constexpr std::string_view error = "[YarpSensorBridge::getThreeAxisForceTorqueSensorsList] "
+                                       "Currently unimplemented";
+    std::cerr << error << std::endl;
 
     return false;
 }
 
 bool YarpSensorBridge::getMotorCurrent(const std::string& jointName,
-                                        double& motorCurrent,
-                                        double* receiveTimeInSeconds)
+                                       double& motorCurrent,
+                                       OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
-    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList,
-                                     jointName, idx))
+    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
     {
         std::cerr << "[YarpSensorBridge::getJointCurrent] " << jointName
-                  <<  " could not be found in the configured list of joints" << std::endl;
+                  << " could not be found in the configured list of joints" << std::endl;
         return false;
     }
 
     motorCurrent = m_pimpl->controlBoardRemapperMeasures.motorCurrents[idx];
-    receiveTimeInSeconds = &m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
 
     return true;
 }
 
 bool YarpSensorBridge::getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
-                                         double* receiveTimeInSeconds)
+                                        OptionalDoubleRef receiveTimeInSeconds)
 {
 
     motorCurrents = yarp::eigen::toEigen(m_pimpl->controlBoardRemapperMeasures.motorCurrents);
-    receiveTimeInSeconds = &m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
     return true;
 }

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -8,10 +8,12 @@
 #ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_ISENSOR_BRIDGE_H
 #define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_ISENSOR_BRIDGE_H
 
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include <Eigen/Dense>
 

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -83,6 +83,8 @@ public:
 
     using weak_ptr = std::weak_ptr<ISensorBridge>;
 
+    using OptionalDoubleRef = std::optional<std::reference_wrapper<double>>;
+
     /**
      * Initialize estimator
      * @param[in] handler Parameters handler
@@ -161,7 +163,7 @@ public:
      */
     virtual bool getJointPosition(const std::string& jointName,
                                   double& jointPosition,
-                                  double* receiveTimeInSeconds = nullptr) { return false; };
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get all joints' positions in radians
@@ -175,7 +177,7 @@ public:
      * @return true/false in case of success/failure
      */
     virtual bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
-                                   double* receiveTimeInSeconds = nullptr) { return false; };
+                                   OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get joint velocity in rad/s
@@ -186,7 +188,7 @@ public:
      */
     virtual bool getJointVelocity(const std::string& jointName,
                                   double& jointVelocity,
-                                  double* receiveTimeInSeconds = nullptr) { return false; };
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get all joints' velocities in rad/s
@@ -200,7 +202,7 @@ public:
      * @return true/false in case of success/failure
      */
     virtual bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
-                                    double* receiveTimeInSeconds = nullptr) { return false; };
+                                    OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get IMU measurement
@@ -217,7 +219,7 @@ public:
      */
     virtual bool getIMUMeasurement(const std::string& imuName,
                                    Eigen::Ref<Vector12d> imuMeasurement,
-                                   double* receiveTimeInSeconds = nullptr) { return false; };
+                                   OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get linear accelerometer measurement in m/s^2
@@ -228,7 +230,7 @@ public:
      */
     virtual bool getLinearAccelerometerMeasurement(const std::string& accName,
                                                    Eigen::Ref<Eigen::Vector3d> accMeasurement,
-                                                   double* receiveTimeInSeconds = nullptr) { return false; };
+                                                   OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get gyroscope measurement in rad/s
@@ -239,7 +241,7 @@ public:
      */
     virtual bool getGyroscopeMeasure(const std::string& gyroName,
                                      Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
-                                     double* receiveTimeInSeconds = nullptr) { return false; };
+                                     OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
    /**
      * Get orientation sensor measurement in radians as roll pitch yaw Euler angles
@@ -250,7 +252,7 @@ public:
      */
     virtual bool getOrientationSensorMeasurement(const std::string& rpyName,
                                                  Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
-                                                 double* receiveTimeInSeconds = nullptr) { return false; };
+                                                 OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
    /**
      * Get magentometer measurement in tesla
@@ -261,7 +263,7 @@ public:
      */
     virtual bool getMagnetometerMeasurement(const std::string& magName,
                                             Eigen::Ref<Eigen::Vector3d> magMeasurement,
-                                            double* receiveTimeInSeconds = nullptr) { return false; };
+                                            OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get six axis force torque measurement
@@ -272,7 +274,7 @@ public:
      */
     virtual bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
                                                   Eigen::Ref<Vector6d> ftMeasurement,
-                                                  double* receiveTimeInSeconds = nullptr) { return false; };
+                                                  OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Get three axis force-torque measurement containing normal force (N) and tangential moments (Nm)
@@ -283,7 +285,7 @@ public:
      */
     virtual bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
                                                     Eigen::Ref<Eigen::Vector3d> ftMeasurement,
-                                                    double* receiveTimeInSeconds = nullptr) { return false; };
+                                                    OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
    /**
      * Get 6D end effector wrenches in N and Nm for forces and torques respectively
@@ -294,7 +296,7 @@ public:
      */
     virtual bool getCartesianWrench(const std::string& cartesianWrenchName,
                                     Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
-                                    double* receiveTimeInSeconds = nullptr) { return false; };
+                                    OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
 
     /**
      * Destructor
@@ -347,7 +349,7 @@ protected:
      */
     virtual bool getMotorCurrent(const std::string& jointName,
                                   double& motorCurrent,
-                                  double* receiveTimeInSeconds = nullptr)
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -364,7 +366,7 @@ protected:
      * @return true/false in case of success/failure
      */
     virtual bool getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
-                                   double* receiveTimeInSeconds = nullptr)
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -74,10 +74,6 @@ struct SensorBridgeMetaData
  */
 class ISensorBridge
 {
-protected:
-    using Vector12d = Eigen::Matrix<double, 12, 1>;
-    using Vector6d = Eigen::Matrix<double, 6, 1>;
-
 public:
     using unique_ptr = std::unique_ptr<ISensorBridge>;
 
@@ -86,6 +82,9 @@ public:
     using weak_ptr = std::weak_ptr<ISensorBridge>;
 
     using OptionalDoubleRef = std::optional<std::reference_wrapper<double>>;
+
+    using Vector12d = Eigen::Matrix<double, 12, 1>;
+    using Vector6d = Eigen::Matrix<double, 6, 1>;
 
     /**
      * Initialize estimator

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -17,9 +17,6 @@
 
 #include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
 
-using Vector12d = Eigen::Matrix<double, 12, 1>;
-using Vector6d = Eigen::Matrix<double, 6, 1>;
-
 namespace BipedalLocomotion
 {
 namespace RobotInterface
@@ -75,6 +72,10 @@ struct SensorBridgeMetaData
  */
 class ISensorBridge
 {
+protected:
+    using Vector12d = Eigen::Matrix<double, 12, 1>;
+    using Vector6d = Eigen::Matrix<double, 6, 1>;
+
 public:
     using unique_ptr = std::unique_ptr<ISensorBridge>;
 

--- a/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
+++ b/src/RobotInterface/tests/DummyImplementation/DummySensorBridge.h
@@ -95,21 +95,21 @@ public:
 
     virtual bool getJointPosition(const std::string& jointName,
                                   double& jointPosition,
-                                  double* receiveTimeInSeconds = nullptr) override { return true; };
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
-                                   double* receiveTimeInSeconds = nullptr) override { return true; };
+                                   OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getJointVelocity(const std::string& jointName,
                                   double& jointVelocity,
-                                  double* receiveTimeInSeconds = nullptr) override { return true; };
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
-                                    double* receiveTimeInSeconds = nullptr) override { return true; };
+                                    OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getIMUMeasurement(const std::string& imuName,
                                    Eigen::Ref<Vector12d> imuMeasurement,
-                                   double* receiveTimeInSeconds = nullptr) override { return true; };
+                                   OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
 
     virtual bool getLinearAccelerometerMeasurement(const std::string& accName,
                                                    Eigen::Ref<Eigen::Vector3d> accMeasurement,
-                                                   double* receiveTimeInSeconds = nullptr) override
+                                                   OptionalDoubleRef receiveTimeInSeconds = {}) override
     {
         if (!m_initialized)
         {
@@ -129,28 +129,30 @@ public:
 
         // pass dummy measurements now
         accMeasurement << 0, 0, -9.8;
-        *receiveTimeInSeconds = 10.0;
+        if (receiveTimeInSeconds)
+            receiveTimeInSeconds.value().get() = 10.0;
+
         return true;
     };
 
     virtual bool getGyroscopeMeasure(const std::string& gyroName,
                                      Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
-                                     double* receiveTimeInSeconds = nullptr) override { return true; };
+                                     OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getOrientationSensorMeasurement(const std::string& rpyName,
                                                  Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
-                                                 double* receiveTimeInSeconds = nullptr) override { return true; };
+                                                 OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getMagnetometerMeasurement(const std::string& magName,
                                             Eigen::Ref<Eigen::Vector3d> magMeasurement,
-                                            double* receiveTimeInSeconds = nullptr) override { return true; };
+                                            OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
                                                   Eigen::Ref<Vector6d> ftMeasurement,
-                                                  double* receiveTimeInSeconds = nullptr) override { return true; };
+                                                  OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
                                                     Eigen::Ref<Eigen::Vector3d> ftMeasurement,
-                                                    double* receiveTimeInSeconds = nullptr) override { return true; };
+                                                    OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
     virtual bool getCartesianWrench(const std::string& cartesianWrenchName,
                                     Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
-                                    double* receiveTimeInSeconds = nullptr) override { return true; };
+                                    OptionalDoubleRef receiveTimeInSeconds = {}) override { return true; };
 
 protected:
     virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,

--- a/src/RobotInterface/tests/DummyImplementation/DummySensorBridgeTest.cpp
+++ b/src/RobotInterface/tests/DummyImplementation/DummySensorBridgeTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Test Sensor Bridge Interface")
     double accRecvTime;
     Eigen::Vector3d acc;
     std::string someName{"dummy"};
-    REQUIRE(dummyBridge->getLinearAccelerometerMeasurement(someName, acc, &accRecvTime));
+    REQUIRE(dummyBridge->getLinearAccelerometerMeasurement(someName, acc, accRecvTime));
     REQUIRE(acc(2) == -9.8);
     REQUIRE(accRecvTime == 10.0);
 }


### PR DESCRIPTION
**THIS PR BREAKS THE API**


This PR attempts to remove the usage of raw pointers in ISensorBridge. This can be done using `std::optional<std::reference_wrapper<double>>`. 
You can find further information in https://stackoverflow.com/questions/62454934/optionalreference-wrappert-vs-optionalt-practical-examples

cc @isorrentino @traversaro @S-Dafarra 