### PR TITLE
bug fix: YarpSensorBridge attach FT sensors 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 - Fix missing implementation of `YarpSensorBridge::getFailedSensorReads()`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/202)
 - Fixed `mas-imu-test` configuration files after FW fix.
+- Fixed the implementation ``YarpSensorBridge::attachAllSixAxisForceTorqueSensors()`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/231)
 
 ## [0.1.0] - 2021-02-22
 ### Added


### PR DESCRIPTION
This PR fixes bugs in `YarpSensorBridge::attachAllSixAxisForceTorqueSensors()`,

- fix the wrong usage of ` set_intersection` with `set_difference`
- call `checkAttachedMASSensors` on the MAS FT interface to update internal name/index buffers