### PR TITLE
Add YarpCameraBridge to PerceptionInterfaceYarpImplementation library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 - Implement FixedBaseDynamics class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/242)
 - Implemented Sink and Source classes (https://github.com/dic-iit/bipedal-locomotion-framework/pull/267)
 - Implement the IClock, StdClock and YarpClock classes (https://github.com/dic-iit/bipedal-locomotion-framework/pull/269)
+- Implement `YarpCameraBridge` class for Yarp implementation of ICameraBridge (https://github.com/dic-iit/bipedal-locomotion-framework/pull/237)
 
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)

--- a/src/RobotInterface/YarpImplementation/CMakeLists.txt
+++ b/src/RobotInterface/YarpImplementation/CMakeLists.txt
@@ -12,4 +12,13 @@ if(FRAMEWORK_COMPILE_YarpImplementation)
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::RobotInterface BipedalLocomotion::System YARP::YARP_dev YARP::YARP_os YARP::YARP_sig
     INSTALLATION_FOLDER    RobotInterface)
 
+  if(FRAMEWORK_COMPILE_Perception)
+    add_bipedal_locomotion_library(
+      NAME                   PerceptionInterfaceYarpImplementation
+      SOURCES                src/YarpCameraBridge.cpp
+      PUBLIC_HEADERS         include/BipedalLocomotion/RobotInterface/YarpCameraBridge.h
+      PUBLIC_LINK_LIBRARIES  BipedalLocomotion::PerceptionInterface BipedalLocomotion::TextLogging YARP::YARP_dev YARP::YARP_os YARP::YARP_sig
+      INSTALLATION_FOLDER    RobotInterface)
+  endif()
+
 endif()

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpCameraBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpCameraBridge.h
@@ -1,0 +1,145 @@
+/**
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_CAMERA_BRIDGE_H
+#define BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_CAMERA_BRIDGE_H
+
+// std
+#include <memory>
+
+// YARP
+#include <yarp/dev/PolyDriverList.h>
+
+#include <BipedalLocomotion/RobotInterface/ICameraBridge.h>
+
+namespace BipedalLocomotion
+{
+namespace RobotInterface
+{
+
+
+/**
+ * YarpCameraBridge Yarp implementation of the ICameraBridge interface
+ * Currently available interfaces
+ * - Depth Cameras through RGBD sensor interface
+ * - Camera images through OpenCV Grabber interface
+ *
+ * The YarpCameraBridge expects a list of device drivers through the yarp::dev::PolyDriverList object.
+ * Each PolyDriver object in the list is compared with the configured sensor names and the assumptions listed below
+ * to infer the sensor types and relevant interfaces in order to to read the relevant data.
+ *
+ * MAJOR ASSUMPTIONS
+ * - Every sensor unit(device driver) attached to this Bridge is identified by a unique name
+ * - The images are available through a FrameGrabber interface (RGB only) and a RGBD interface (RGB and Depth).
+ * - The current internal design (read all sensors in a serial fashion) may not be suitable for a heavy measurement set
+ *
+ * The parameters for writing the configuration file for this class is given as,
+ * |     Group                  |         Parameter               | Type              |                   Description                   |
+ * |:--------------------------:|:-------------------------------:|:-----------------:|:---------------------------------------------- :|
+ * |Cameras                     |                                 |                   |Expects cameras to be opened either as remote frame grabber ("RemoteFrameGrabber") with IFrameGrabber interface or rgbd sensor ("RGBDSensorClient") with IRGBDSensor interface|
+ * |                            |rgbd_cameras_list                        | vector of strings |list containing the devices opened as RGBDSensorClients containing the IRGBD sensor interface      |
+ * |                            |rgbd_image_width                 | vector of strings |list containing the image width dimensions of RGBD cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgbd_list |
+ * |                            |rgbd_image_height                | vector of strings |list containing the image height dimensions of RGBD cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgbd_list |
+ * |                            |rgb_cameras_list                 | vector of strings |list containing the devices opened as RemoteFrameGrabber devices containing the IFrameGrabber interface|
+ * |                            |rgb_image_width                  | vector of strings |list containing the image width dimensions of RGB cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgb_list |
+ * |                            |rgb_image_height                 | vector of strings |list containing the image height dimensions of RGB cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgb_list |
+ *
+ */
+class YarpCameraBridge : public BipedalLocomotion::RobotInterface::ICameraBridge
+{
+public:
+    /**
+     * Constructor
+     */
+    YarpCameraBridge();
+
+    /**
+     * Destructor
+     */
+    ~YarpCameraBridge();
+
+    /**
+     * Initialize estimator
+     * @param[in] handler Parameters handler
+     */
+    bool initialize(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler) final;
+
+    /**
+     * Set the list of device drivers from which the sensor measurements need to be streamed
+     * @param deviceDriversList device drivers holding the pointer to sensor interfaces
+     * @return True/False in case of success/failure.
+     */
+    bool setDriversList(const yarp::dev::PolyDriverList& deviceDriversList);
+
+    /**
+     * @brief Determines the validity of the object retrieved with get()
+     * @return True if the object is valid, false otherwise.
+     */
+    bool isValid() const;
+
+    /**
+     * @brief Get the object.
+     * @return a const reference of the requested object.
+     */
+    const BipedalLocomotion::RobotInterface::CameraBridgeMetaData& get() const;
+
+    /**
+     * Get rgb cameras
+     * @param[out] rgbCamerasList list of rgb cameras attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getRGBCamerasList(std::vector<std::string>& rgbCamerasList) final;
+
+    /**
+     * Get RGBD cameras
+     * @param[out] rgbdCamerasList list of depth cameras attached to the bridge
+     * @return  true/false in case of success/failure
+     */
+    bool getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList) final;
+
+
+    /**
+     * Get color image from the camera
+     * @param[in] camName name of the camera
+     * @param[out] colorImg image as cv Mat object
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "colorImg" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getColorImage(const std::string& camName,
+                       cv::Mat& colorImg,
+                       std::optional<std::reference_wrapper<double>> receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get depth image
+     * @param[in] camName name of the gyroscope
+     * @param[out] depthImg depth image as cv Mat object
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "depthImg" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getDepthImage(const std::string& camName,
+                       cv::Mat& depthImg,
+                       std::optional<std::reference_wrapper<double>> receiveTimeInSeconds = {}) final;
+
+private:
+    /** Private implementation */
+    struct Impl;
+    std::unique_ptr<Impl> m_pimpl;
+};
+
+} // namespace RobotInterface
+} // namespace BipedalLocomotion
+
+
+#endif // BIPEDAL_LOCOMOTION_ROBOT_INTERFACE_YARP_CAMERA_BRIDGE_H

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpCameraBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpCameraBridge.h
@@ -36,15 +36,15 @@ namespace RobotInterface
  * - The current internal design (read all sensors in a serial fashion) may not be suitable for a heavy measurement set
  *
  * The parameters for writing the configuration file for this class is given as,
- * |     Group                  |         Parameter               | Type              |                   Description                   |
- * |:--------------------------:|:-------------------------------:|:-----------------:|:---------------------------------------------- :|
- * |Cameras                     |                                 |                   |Expects cameras to be opened either as remote frame grabber ("RemoteFrameGrabber") with IFrameGrabber interface or rgbd sensor ("RGBDSensorClient") with IRGBDSensor interface|
- * |                            |rgbd_cameras_list                        | vector of strings |list containing the devices opened as RGBDSensorClients containing the IRGBD sensor interface      |
- * |                            |rgbd_image_width                 | vector of strings |list containing the image width dimensions of RGBD cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgbd_list |
- * |                            |rgbd_image_height                | vector of strings |list containing the image height dimensions of RGBD cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgbd_list |
- * |                            |rgb_cameras_list                 | vector of strings |list containing the devices opened as RemoteFrameGrabber devices containing the IFrameGrabber interface|
- * |                            |rgb_image_width                  | vector of strings |list containing the image width dimensions of RGB cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgb_list |
- * |                            |rgb_image_height                 | vector of strings |list containing the image height dimensions of RGB cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgb_list |
+ * |     Group                  |         Parameter               | Type               |                   Description                   |
+ * |:--------------------------:|:-------------------------------:|:------------------:|:---------------------------------------------- :|
+ * |Cameras                     |                                 |                    |Expects cameras to be opened either as remote frame grabber ("RemoteFrameGrabber") with IFrameGrabber interface or rgbd sensor ("RGBDSensorClient") with IRGBDSensor interface|
+ * |                            |rgbd_cameras_list                | vector of strings  |list containing the devices opened as RGBDSensorClients containing the IRGBD sensor interface      |
+ * |                            |rgbd_image_width                 | vector of integers |list containing the image width dimensions of RGBD cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgbd_list |
+ * |                            |rgbd_image_height                | vector of integers |list containing the image height dimensions of RGBD cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgbd_list |
+ * |                            |rgb_cameras_list                 | vector of strings  |list containing the devices opened as RemoteFrameGrabber devices containing the IFrameGrabber interface|
+ * |                            |rgb_image_width                  | vector of integers |list containing the image width dimensions of RGB cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgb_list |
+ * |                            |rgb_image_height                 | vector of integers |list containing the image height dimensions of RGB cameras. Required parameter if cameras are enabled. The list must be the same size and order as rgb_list |
  *
  */
 class YarpCameraBridge : public BipedalLocomotion::RobotInterface::ICameraBridge

--- a/src/RobotInterface/YarpImplementation/src/YarpCameraBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpCameraBridge.cpp
@@ -1,0 +1,627 @@
+/**
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/RobotInterface/YarpCameraBridge.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+// YARP os
+#include <yarp/os/Time.h>
+
+// YARP sig
+#include <yarp/sig/Image.h>
+
+// YARP Camera Interfaces
+#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IRGBDSensor.h>
+#include <yarp/cv/Cv.h>
+#include <yarp/os/LogStream.h>
+// std
+#include <cmath>
+#include <set>
+#include <algorithm>
+
+using namespace BipedalLocomotion::RobotInterface;
+using namespace BipedalLocomotion::GenericContainer;
+using namespace BipedalLocomotion::ParametersHandler;
+
+
+struct YarpCameraBridge::Impl
+{
+    template <typename PixelCode>
+    using StampedYARPImage = std::pair< yarp::sig::ImageOf<PixelCode>, double>;
+
+    using StampedYARPFlexImage = std::pair<yarp::sig::FlexImage, double>;
+
+    std::unordered_map<std::string, yarp::dev::IFrameGrabberImage*> wholeBodyFrameGrabberInterface; /** < map of cameras attached through frame grabber interfaces */
+    std::unordered_map<std::string, yarp::dev::IRGBDSensor*> wholeBodyRGBDInterface; /** < map of cameras attached through RGBD interfaces */
+
+
+    CameraBridgeMetaData metaData; /**< struct holding meta data **/
+    bool bridgeInitialized{false}; /**< flag set to true if the bridge is successfully initialized */
+    bool driversAttached{false}; /**< flag set to true if the bridge is successfully attached to required device drivers */
+
+    StampedYARPImage<yarp::sig::PixelFloat> depthImage;
+    StampedYARPFlexImage flexImage;
+    StampedYARPImage<yarp::sig::PixelRgb> rgbImage;
+
+    /**
+     * Check if sensor is available in the relevant sensor map
+     */
+    template <typename SensorType>
+    bool checkSensor(const std::unordered_map<std::string, SensorType* >& sensorMap,
+                     const std::string& sensorName)
+    {
+        if (sensorMap.find(sensorName) == sensorMap.end())
+        {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Check if sensor is available in the relevant sensor measurement map
+     */
+    template <typename YARPDataType>
+    bool checkValidSensorMeasure(std::string_view logPrefix,
+                                 const std::unordered_map<std::string, YARPDataType >& sensorMap,
+                                 const std::string& sensorName)
+    {
+        if (!checkValid(logPrefix))
+        {
+            return false;
+        }
+
+        if (sensorMap.find(sensorName) == sensorMap.end())
+        {
+            log()->error("{} {} sensor unavailable in the measurement map.", logPrefix, sensorName);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the bridge is successfully initialized and attached to required device drivers
+     */
+    bool checkValid(const std::string_view methodName)
+    {
+        if (!(bridgeInitialized && driversAttached))
+        {
+            log()->error("{} CameraBridge is not ready. Please initialize and set drivers list.", methodName);
+            return false;
+        }
+        return true;
+    }
+
+
+    using SubConfigLoader = bool (YarpCameraBridge::Impl::*)(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler>,
+                                                             CameraBridgeMetaData&);
+    /**
+     * Checks is a stream is enabled in configuration and
+     * loads the relevant stream group from configuration
+     */
+    bool subConfigLoader(const std::string& enableStreamString,
+                         const std::string& streamGroupString,
+                         const SubConfigLoader loader,
+                         std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
+                         CameraBridgeMetaData& metaData,
+                         bool& enableStreamFlag)
+    {
+        constexpr std::string_view logPrefix = "[YarpCameraBridge::Impl::subConfigLoader] ";
+
+        auto ptr = handler.lock();
+        if (ptr == nullptr)
+        {
+            log()->error("{}"
+                         "The handler is not pointing to an already initialized memory.",
+                         logPrefix);
+            return false;
+        }
+
+        enableStreamFlag = false;
+        if (ptr->getParameter(enableStreamString, enableStreamFlag) && enableStreamFlag)
+        {
+            auto groupHandler = ptr->getGroup(streamGroupString);
+            if (!(this->*loader)(groupHandler, metaData))
+            {
+                log()->error("{} {}"
+                             " group could not be initialized from the configuration file.",
+                             logPrefix, streamGroupString);
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Configure cameras meta data
+     */
+    bool configureCameras(std::weak_ptr<BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
+                          CameraBridgeMetaData& metaData)
+    {
+        constexpr std::string_view logPrefix = "[YarpCameraBridge::Impl::configureCameras] ";
+        auto ptr = handler.lock();
+        if (ptr == nullptr) { return false; }
+
+        if (ptr->getParameter("rgb_cameras_list", metaData.sensorsList.rgbCamerasList))
+        {
+            metaData.bridgeOptions.isRGBCameraEnabled = true;
+
+            std::vector<int> rgbWidth, rgbHeight;
+            if (!ptr->getParameter("rgb_image_width", rgbWidth))
+            {
+                log()->error("{}"
+                             "Required parameter \"rgb_image_width\" not available in the configuration.",
+                             logPrefix);
+                return false;
+            }
+
+            if (!ptr->getParameter("rgb_image_height", rgbHeight))
+            {
+                log()->error("{}"
+                             "Required parameter \"rgb_image_height\" not available in the configuration.",
+                             logPrefix);
+                return false;
+            }
+
+            if ( (rgbWidth.size() != metaData.sensorsList.rgbCamerasList.size()) ||
+                (rgbHeight.size() != metaData.sensorsList.rgbCamerasList.size()) )
+            {
+                log()->error("{}"
+                             "Parameters list size mismatch.",
+                             logPrefix);
+                return false;
+            }
+
+            for (int idx = 0; idx < rgbHeight.size(); idx++)
+            {
+                std::pair<int, int> imgDimensions(rgbWidth[idx], rgbHeight[idx]);
+                auto cameraName{metaData.sensorsList.rgbCamerasList[idx]};
+                metaData.bridgeOptions.rgbImgDimensions[cameraName] = imgDimensions;
+            }
+        }
+
+        if (ptr->getParameter("rgbd_cameras_list", metaData.sensorsList.rgbdCamerasList))
+        {
+            metaData.bridgeOptions.isRGBDCameraEnabled = true;
+
+            std::vector<int> rgbdCamWidth, rgbdCamHeight;
+            if (!ptr->getParameter("rgbd_image_width", rgbdCamWidth))
+            {
+                log()->error("{}"
+                             "Required parameter \"rgbd_image_width\" not available in the configuration.",
+                             logPrefix);
+                return false;
+            }
+
+            if (!ptr->getParameter("rgbd_image_height", rgbdCamHeight))
+            {
+                log()->error("{}"
+                             "Required parameter \"rgbd_image_height\" not available in the configuration.",
+                             logPrefix);
+                return false;
+            }
+
+            if ( (rgbdCamWidth.size() != metaData.sensorsList.rgbdCamerasList.size()) ||
+                (rgbdCamHeight.size() != metaData.sensorsList.rgbdCamerasList.size()) )
+            {
+                log()->error("{}"
+                             "Parameters list size mismatch.",
+                             logPrefix);
+                return false;
+            }
+
+            for (int idx = 0; idx < rgbdCamHeight.size(); idx++)
+            {
+                std::pair<int, int> imgDimensions(rgbdCamWidth[idx], rgbdCamHeight[idx]);
+                auto cameraName{metaData.sensorsList.rgbdCamerasList[idx]};
+                metaData.bridgeOptions.rgbdImgDimensions[cameraName] = imgDimensions;
+            }
+        }
+
+        if (!metaData.bridgeOptions.isRGBCameraEnabled  && !metaData.bridgeOptions.isRGBDCameraEnabled)
+        {
+            log()->error("{}"
+                         "None of the camera types configured. Cannot use Camera bridge.",
+                         logPrefix);
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Attach cameras
+     */
+    template <typename CameraType>
+    bool attachCamera(const yarp::dev::PolyDriverList& devList,
+                      const std::string sensorName,
+                      std::unordered_map<std::string, CameraType* >& sensorMap)
+    {
+        constexpr std::string_view logPrefix = "[YarpCameraBridge::Impl::attachCamera] ";
+        for (int devIdx = 0; devIdx < devList.size(); devIdx++)
+        {
+            if (sensorName != devList[devIdx]->key)
+            {
+                continue;
+            }
+
+            CameraType* cameraInterface{nullptr};
+            if (devList[devIdx]->poly->view(cameraInterface))
+            {
+                if (cameraInterface == nullptr)
+                {
+                    log()->error("{} Could not view interface.", logPrefix);
+                    return false;
+                }
+                sensorMap[devList[devIdx]->key] = cameraInterface;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Attach all cameras
+     */
+    bool attachAllCameras(const yarp::dev::PolyDriverList& devList)
+    {
+        std::string_view printPrefix{"[YarpCameraBridge::attachAllCameras] "};
+        if (!metaData.bridgeOptions.isRGBCameraEnabled && 
+            !metaData.bridgeOptions.isRGBDCameraEnabled)
+        {
+             // do nothing
+            log()->error("{} No camera types enaable. Not attaching any cameras.", printPrefix);
+            return false;
+        }
+
+        if (metaData.bridgeOptions.isRGBCameraEnabled)
+        {
+            std::string_view interfaceType{"RGB Cameras"};
+            if (!attachAllCamerasOfSpecificType(devList,
+                                                metaData.sensorsList.rgbCamerasList,
+                                                interfaceType,
+                                                wholeBodyFrameGrabberInterface))
+            {
+                return false;
+            }
+        }
+
+        if (metaData.bridgeOptions.isRGBDCameraEnabled)
+        {
+            std::string_view interfaceTypeDepth{"RGBD Cameras"};
+            if (!attachAllCamerasOfSpecificType(devList,
+                                                metaData.sensorsList.rgbdCamerasList,
+                                                interfaceTypeDepth,
+                                                wholeBodyRGBDInterface))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Attach all cameras of specific type and resize image buffers
+     */
+    template <typename CameraType>
+    bool attachAllCamerasOfSpecificType(const yarp::dev::PolyDriverList& devList,
+                                        const std::vector<std::string>& camList,
+                                        std::string_view interfaceType,
+                                        std::unordered_map<std::string, CameraType* >& sensorMap)
+    {
+        constexpr std::string_view logPrefix = "[YarpCameraBridge::Impl::attachAllCamerasOfSpecificType] ";
+        for (auto cam : camList)
+        {
+            if (!attachCamera(devList, cam, sensorMap))
+            {
+                return false;
+            }
+        }
+
+        if (sensorMap.size() != camList.size())
+        {
+            log()->error("{} could not attach all desired cameras of type {}.", logPrefix, interfaceType);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Resize image buffers ImageOf<PixelType>
+     */
+    template <typename PixelType>
+    bool resizeImageBuffer(const std::string& cam,
+                           const std::unordered_map<std::string, std::pair<std::size_t, std::size_t> >& imgDimensionsMap,
+                           StampedYARPImage<PixelType>& img)
+    {
+        auto iter = imgDimensionsMap.find(cam);
+        if (iter == imgDimensionsMap.end())
+        {
+            return false;
+        }
+        auto imgDim = iter->second;
+        if (img.first.width() != imgDim.first || img.first.height() != imgDim.second)
+        {
+            img.first.resize(imgDim.first, imgDim.second);
+        }
+        return true;
+    }
+
+    /**
+     * Resize image buffers - Flex Image
+     */
+    bool resizeImageBuffer(const std::string& cam,
+                           const std::unordered_map<std::string, std::pair<std::size_t, std::size_t> >& imgDimensionsMap,
+                           StampedYARPFlexImage& img)
+    {
+        auto iter = imgDimensionsMap.find(cam);
+        if (iter == imgDimensionsMap.end())
+        {
+            return false;
+        }
+        auto imgDim = iter->second;
+        img.first.setPixelCode(VOCAB_PIXEL_RGB);
+        if (img.first.width() != imgDim.first || img.first.height() != imgDim.second)
+        {
+            img.first.resize(imgDim.first, imgDim.second);
+        }
+        return true;
+    }
+
+
+    template<typename CameraType, typename PixelType>
+    bool readCameraImage(const std::string& cameraName,
+                         std::unordered_map<std::string, CameraType*>& interfaceMap,
+                         StampedYARPImage<PixelType>& image)
+    {
+        bool ok{true};
+        constexpr std::string_view logPrefix = "[YarpCameraBridge::Impl::readCameraImage] ";
+
+        if (!checkSensor(interfaceMap, cameraName))
+        {
+            return false;
+        }
+
+        auto iter = interfaceMap.find(cameraName);
+        auto interface = iter->second;
+
+        // StampedYARPImage is defined as a pair of yarp::sig::image and double
+        yarp::os::Stamp* txTimestamp{nullptr};
+        if constexpr (std::is_same_v<CameraType, yarp::dev::IFrameGrabberImage>)
+        {
+            if constexpr (!std::is_same_v<PixelType, yarp::sig::PixelRgb>) // (imageType != "RGB")
+            {
+                log()->error("{} Frame Grabber {} handles only RGB image.", logPrefix, cameraName);
+                return false;
+            }
+            ok = interface->getImage(image.first);
+        }
+        else if constexpr (std::is_same_v<CameraType, yarp::dev::IRGBDSensor>)
+        {
+            if constexpr (std::is_same_v<PixelType, yarp::sig::PixelFloat>)// (imageType == "DEPTH")
+            {
+                ok = interface->getDepthImage(image.first, txTimestamp);
+            }
+        }
+
+        if (!ok)
+        {
+            log()->error("{} Unable to read from {}, use previous image.", logPrefix, cameraName);
+            return false;
+        }
+
+        image.second = yarp::os::Time::now();
+        return true;
+    }
+
+    template<typename CameraType>
+    bool readCameraImage(const std::string& cameraName,
+                         std::unordered_map<std::string, CameraType*>& interfaceMap,
+                         StampedYARPFlexImage& img)
+    {
+        bool ok{true};
+        constexpr std::string_view logPrefix = "[YarpCameraBridge::Impl::readCameraImage] ";
+
+        if (!checkSensor(interfaceMap, cameraName))
+        {
+            return false;
+        }
+
+        auto iter = interfaceMap.find(cameraName);
+        auto interface = iter->second;
+
+        yarp::os::Stamp* txTimestamp{nullptr};
+        if constexpr (std::is_same_v<CameraType, yarp::dev::IRGBDSensor>)
+        {
+            ok = interface->getRgbImage(img.first, txTimestamp);
+        }
+
+        if (!ok)
+        {
+            log()->error("{} Unable to read from {}, use previous image.", logPrefix, cameraName);
+            return false;
+        }
+
+        img.second = yarp::os::Time::now();
+        return true;
+    }
+
+}; // end YarpCameraBridge::Impl
+
+YarpCameraBridge::YarpCameraBridge() : m_pimpl(std::make_unique<Impl>())
+{
+}
+
+YarpCameraBridge::~YarpCameraBridge() = default;
+
+bool YarpCameraBridge::initialize(std::weak_ptr<IParametersHandler> handler)
+{
+    constexpr std::string_view logPrefix = "[YarpCameraBridge::initialize] ";
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} The handler is not pointing to an already initialized memory.", logPrefix);
+        return false;
+    }
+
+    bool ret{true};
+    bool useCameras{false};
+    ret = m_pimpl->subConfigLoader("stream_cameras", "Cameras",
+                                    &YarpCameraBridge::Impl::configureCameras,
+                                    handler,
+                                    m_pimpl->metaData,
+                                    useCameras);
+    if (!ret)
+    {
+        log()->error("{} Skipping the configuration of Cameras."
+                     "YarpCameraBridge will not stream relevant measures.", logPrefix);
+    }
+
+
+    m_pimpl->bridgeInitialized = true;
+    return true;
+}
+
+bool YarpCameraBridge::setDriversList(const yarp::dev::PolyDriverList& deviceDriversList)
+{
+    constexpr std::string_view logPrefix = "[YarpCameraBridge::setDriversList] ";
+
+    if (!m_pimpl->bridgeInitialized)
+    {
+        log()->error("{} Please initialize YarpCameraBridge before calling setDriversList().", logPrefix);
+        return false;
+    }
+
+    bool ret{true};
+    ret = ret && m_pimpl->attachAllCameras(deviceDriversList);
+
+    if (!ret)
+    {
+        log()->error("{} Failed to attach to one or more device drivers.", logPrefix);
+        return false;
+    }
+    m_pimpl->driversAttached = true;
+    return true;
+}
+
+bool YarpCameraBridge::isValid() const
+{
+    return m_pimpl->checkValid("[YarpCameraBridge::isValid]");
+}
+
+const CameraBridgeMetaData& YarpCameraBridge::get() const { return m_pimpl->metaData; }
+
+
+bool YarpCameraBridge::getRGBCamerasList(std::vector<std::string>& rgbCamerasList)
+{
+    if (!m_pimpl->checkValid("[YarpCameraBridge::getRGBCamerasList]"))
+    {
+        return false;
+    }
+    rgbCamerasList = m_pimpl->metaData.sensorsList.rgbCamerasList;
+    return true;
+}
+
+bool YarpCameraBridge::getRGBDCamerasList(std::vector<std::string>& rgbdCamerasList)
+{
+    if (!m_pimpl->checkValid("[YarpCameraBridge::getRGBDCamerasList]"))
+    {
+        return false;
+    }
+    rgbdCamerasList = m_pimpl->metaData.sensorsList.rgbdCamerasList;
+    return true;
+}
+
+
+bool YarpCameraBridge::getColorImage(const std::string& camName,
+                                     cv::Mat& colorImg,
+                                     std::optional<std::reference_wrapper<double>> receiveTimeInSeconds)
+{
+    if (!m_pimpl->checkValid("YarpCameraBridge::getColorImage "))
+    {
+        return false;
+    }
+
+    m_pimpl->rgbImage.first.zero();
+    if (m_pimpl->resizeImageBuffer(camName, m_pimpl->metaData.bridgeOptions.rgbImgDimensions, m_pimpl->rgbImage))
+    {
+        if (!m_pimpl->readCameraImage(camName, m_pimpl->wholeBodyFrameGrabberInterface, m_pimpl->rgbImage))
+        {
+            log()->error("[YarpCameraBridge::getColorImage] {} could not read image.", camName);
+            return false;
+        }
+
+        colorImg = yarp::cv::toCvMat(m_pimpl->rgbImage.first);
+        receiveTimeInSeconds = m_pimpl->rgbImage.second;
+    }
+    else 
+    {
+        m_pimpl->flexImage.first.zero();
+        if (!m_pimpl->resizeImageBuffer(camName, m_pimpl->metaData.bridgeOptions.rgbdImgDimensions, m_pimpl->flexImage))
+        {
+            log()->error("[YarpCameraBridge::getColorImage] {} could not resize image buffers.", camName);
+            return false;
+        }
+
+        if (!m_pimpl->readCameraImage(camName, m_pimpl->wholeBodyRGBDInterface, m_pimpl->flexImage))
+        {
+            log()->error("[YarpCameraBridge::getColorImage] {} could not read image.", camName);
+            return false;
+        }
+
+        auto& yarpImage = m_pimpl->flexImage.first;
+        colorImg = cv::Mat(yarpImage.height(), yarpImage.width(), yarp::cv::type_code<yarp::sig::PixelRgb>::value,
+                           yarpImage.getRawImage(), yarpImage.getRowSize());
+        receiveTimeInSeconds = m_pimpl->flexImage.second;
+    }
+
+    if (colorImg.rows <= 0 || colorImg.cols <= 0)
+    {
+        log()->error("[YarpCameraBridge::getColorImage] {} image with invalid size.", camName);
+        return false;
+    }
+
+    return true;
+}
+
+bool YarpCameraBridge::getDepthImage(const std::string& camName,
+                                     cv::Mat& depthImg,
+                                     std::optional<std::reference_wrapper<double>> receiveTimeInSeconds)
+{
+    if (!m_pimpl->checkValid("YarpCameraBridge::getDepthImage "))
+    {
+        return false;
+    }
+
+    m_pimpl->depthImage.first.zero();
+    if (!m_pimpl->resizeImageBuffer(camName, m_pimpl->metaData.bridgeOptions.rgbdImgDimensions, m_pimpl->depthImage))
+    {
+        log()->error("[YarpCameraBridge::getDepthImage] {} could not resize image buffers.", camName);
+        return false;
+    }
+
+    if (!m_pimpl->readCameraImage(camName, m_pimpl->wholeBodyRGBDInterface, m_pimpl->depthImage))
+    {
+        log()->error("[YarpCameraBridge::getDepthImage] {} could not read image.", camName);
+        return false;
+    }
+
+    depthImg = yarp::cv::toCvMat(m_pimpl->depthImage.first);
+    receiveTimeInSeconds = m_pimpl->depthImage.second;
+
+    if (depthImg.rows <= 0 || depthImg.cols <= 0)
+    {
+        log()->error("[YarpCameraBridge::getDepthImage] {} image with invalid size.", camName);
+        return false;
+    }
+
+    return true;
+}

--- a/src/RobotInterface/YarpImplementation/src/YarpCameraBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpCameraBridge.cpp
@@ -271,7 +271,7 @@ struct YarpCameraBridge::Impl
     bool attachAllCameras(const yarp::dev::PolyDriverList& devList)
     {
         std::string_view printPrefix{"[YarpCameraBridge::attachAllCameras] "};
-        if (!metaData.bridgeOptions.isRGBCameraEnabled && 
+	if (!metaData.bridgeOptions.isRGBCameraEnabled &&
             !metaData.bridgeOptions.isRGBDCameraEnabled)
         {
              // do nothing
@@ -562,7 +562,7 @@ bool YarpCameraBridge::getColorImage(const std::string& camName,
         colorImg = yarp::cv::toCvMat(m_pimpl->rgbImage.first);
         receiveTimeInSeconds = m_pimpl->rgbImage.second;
     }
-    else 
+    else
     {
         m_pimpl->flexImage.first.zero();
         if (!m_pimpl->resizeImageBuffer(camName, m_pimpl->metaData.bridgeOptions.rgbdImgDimensions, m_pimpl->flexImage))


### PR DESCRIPTION
YarpCameraBridge allows to access YARP based camera devices.

Currently available interfaces
  - Depth Cameras through RGBD sensor interface
  - Camera images through OpenCV Grabber interface

Related results in https://github.com/dic-iit/bipedal-locomotion-framework/issues/94#issuecomment-739954442

- [x] Update CHANGELOG