### PR TITLE
Fix pybind11 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         sudo apt-get install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
                              libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev \
                              libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python3-dev valgrind coinor-libipopt-dev \
-                             libmatio-dev python3-pytest python3-numpy python3-scipy python3-setuptools libspdlog-dev libopencv-dev  libpcl-dev
+                             libmatio-dev python3-pytest python3-numpy python3-scipy python3-setuptools libspdlog-dev libopencv-dev  libpcl-dev python3-pybind11
         # install realsense from apt (see https://github.com/IntelRealSense/librealsense/blob/master/doc/distribution_linux.md#installing-the-packages)
         sudo apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE
         sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo focal main" -u
@@ -395,13 +395,6 @@ jobs:
               -DBUILD_TESTING=OFF ..
 
         cmake --build . --config ${{ matrix.build_type }} --target install
-
-    # Ubuntu bionic has a too old version of pybind11 in the repo
-    - name: Install pybind11 [Ubuntu]
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        pip3 install pathlib pybind11
-        echo "CMAKE_PREFIX_PATH=$(python3 -c 'import pybind11; from pathlib import Path; print(Path(pybind11.__file__).parent)'):$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
 
     - name: Install manifpy [Ubintu/macOS]
       if: startsWith(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -43,34 +43,34 @@ PYBIND11_MODULE(bindings, m)
 
     m.doc() = "BipedalLocomotionFramework bindings";
 
-    py::module_ parametersHandlerModule = m.def_submodule("parameters_handler");
+    py::module parametersHandlerModule = m.def_submodule("parameters_handler");
     bindings::ParametersHandler::CreateModule(parametersHandlerModule);
 
-    py::module_ mathModule = m.def_submodule("math");
+    py::module mathModule = m.def_submodule("math");
     bindings::Math::CreateModule(mathModule);
 
     @cmakeif FRAMEWORK_COMPILE_System
-    py::module_ systemModule = m.def_submodule("system");
+    py::module systemModule = m.def_submodule("system");
     bindings::System::CreateModule(systemModule);
     @endcmakeif FRAMEWORK_COMPILE_System
 
     @cmakeif FRAMEWORK_COMPILE_Contact
-    py::module_ contactsModule = m.def_submodule("contacts");
+    py::module contactsModule = m.def_submodule("contacts");
     bindings::Contacts::CreateModule(contactsModule);
     @endcmakeif FRAMEWORK_COMPILE_Contact
 
     @cmakeif FRAMEWORK_COMPILE_Planners
-    py::module_ plannersModule = m.def_submodule("planners");
+    py::module plannersModule = m.def_submodule("planners");
     bindings::Planners::CreateModule(plannersModule);
     @endcmakeif FRAMEWORK_COMPILE_Planners
 
     @cmakeif FRAMEWORK_COMPILE_RobotInterfaceBindings
-    py::module_ robotInterfaceModule = m.def_submodule("robot_interface");
+    py::module robotInterfaceModule = m.def_submodule("robot_interface");
     bindings::RobotInterface::CreateModule(robotInterfaceModule);
     @endcmakeif FRAMEWORK_COMPILE_RobotInterfaceBindings
 
     @cmakeif FRAMEWORK_COMPILE_FloatingBaseEstimators
-    py::module_ floatingBaseEstimatorModule = m.def_submodule("floating_base_estimators");
+    py::module floatingBaseEstimatorModule = m.def_submodule("floating_base_estimators");
     bindings::FloatingBaseEstimators::CreateModule(floatingBaseEstimatorModule);
     @endcmakeif FRAMEWORK_COMPILE_FloatingBaseEstimators
 }

--- a/cmake/BipedalLocomotionFrameworkDependencies.cmake
+++ b/cmake/BipedalLocomotionFrameworkDependencies.cmake
@@ -46,7 +46,7 @@ dependency_classifier(OsqpEigen MINIMUM_VERSION 0.6.3 IS_USED ${FRAMEWORK_USE_Os
 find_package(Python3 3.6 COMPONENTS Interpreter Development QUIET)
 checkandset_dependency(Python3 MINIMUM_VERSION 3.6 COMPONENTS Interpreter Development)
 
-find_package(pybind11 2.6.0 CONFIG QUIET)
+find_package(pybind11 2.4.3 CONFIG QUIET)
 checkandset_dependency(pybind11)
 
 find_package(matioCpp QUIET)


### PR DESCRIPTION
This follows https://github.com/dic-iit/bipedal-locomotion-framework/issues/246#issuecomment-808711753

Now we can use pybind11 installed from apt in ubuntu 20.04