### PR TITLE
conda-forge-ci: Switch to use official robotology channel

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -36,7 +36,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology-staging idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull casadi cppad spdlog catch2
+        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull casadi cppad spdlog catch2
 
     - name: Dependencies [manif - Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
As https://github.com/robotology/robotology-superbuild/pull/652 has been merged, we now have officially generated packages coming from the robotology-superbuild in the [robotology anaconda channel](https://anaconda.org/robotology), so we can switch to use that instead of the experimental and test-only `robotology-staging`. 