### PR TITLE
Implement Clock class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project are documented in this file.
 - Implement `PerceptionFeatures` library and implement `ArucoDetector`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/159)
 - Implement FixedBaseDynamics class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/242)
 - Implemented Sink and Source classes (https://github.com/dic-iit/bipedal-locomotion-framework/pull/267)
+- Implement the IClock, StdClock and YarpClock classes (https://github.com/dic-iit/bipedal-locomotion-framework/pull/269)
 
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)

--- a/src/System/CMakeLists.txt
+++ b/src/System/CMakeLists.txt
@@ -10,10 +10,10 @@ if(FRAMEWORK_COMPILE_System)
   # set target name
   add_bipedal_locomotion_library(
     NAME                   System
-    PUBLIC_HEADERS         ${H_PREFIX}/Advanceable.h ${H_PREFIX}/Source.h ${H_PREFIX}/Sink.h ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h
-    SOURCES                src/VariablesHandler.cpp src/LinearTask.cpp
+    PUBLIC_HEADERS         ${H_PREFIX}/Advanceable.h ${H_PREFIX}/Source.h ${H_PREFIX}/Sink.h ${H_PREFIX}/VariablesHandler.h ${H_PREFIX}/LinearTask.h ${H_PREFIX}/IClock.h ${H_PREFIX}/StdClock.h ${H_PREFIX}/Clock.h
+    SOURCES                src/VariablesHandler.cpp src/LinearTask.cpp src/StdClock.cpp src/Clock.cpp
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler Eigen3::Eigen
-    SUBDIRECTORIES         tests
+    SUBDIRECTORIES         tests YarpImplementation
     )
 
 endif()

--- a/src/System/YarpImplementation/CMakeLists.txt
+++ b/src/System/YarpImplementation/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+if(FRAMEWORK_COMPILE_YarpImplementation)
+
+  add_bipedal_locomotion_library(
+    NAME                   SystemYarpImplementation
+    SOURCES                src/YarpClock.cpp
+    PUBLIC_HEADERS         include/BipedalLocomotion/System/YarpClock.h
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::System
+    PRIVATE_LINK_LIBRARIES YARP::YARP_os
+    INSTALLATION_FOLDER    System)
+
+endif()

--- a/src/System/YarpImplementation/CMakeLists.txt
+++ b/src/System/YarpImplementation/CMakeLists.txt
@@ -8,7 +8,7 @@ if(FRAMEWORK_COMPILE_YarpImplementation)
     NAME                   SystemYarpImplementation
     SOURCES                src/YarpClock.cpp
     PUBLIC_HEADERS         include/BipedalLocomotion/System/YarpClock.h
-    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::System
+    PUBLIC_LINK_LIBRARIES  BipedalLocomotion::System YARP::YARP_init
     PRIVATE_LINK_LIBRARIES YARP::YARP_os
     INSTALLATION_FOLDER    System)
 

--- a/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
+++ b/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
@@ -48,6 +48,18 @@ public:
      * @return the current time computed from `yarp::os::Time::now()`
      */
     std::chrono::duration<double> now() final;
+
+    /**
+     * Blocks the execution of the current thread for at least the specified sleepDuration.
+     * @param time duration to sleep
+     */
+    void sleepFor(const std::chrono::duration<double>& sleepDuration) final;
+
+    /**
+     * Blocks the execution of the current thread until specified sleepTime has been reached.
+     * @param time to block until
+     */
+    void sleepUntil(const std::chrono::duration<double>& sleepTime) final;
 };
 
 class YarpClockFactory final : public ClockFactory

--- a/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
+++ b/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
@@ -10,6 +10,8 @@
 
 #include <BipedalLocomotion/System/IClock.h>
 
+#include <yarp/os/Network.h>
+
 #include <chrono>
 
 namespace BipedalLocomotion
@@ -24,8 +26,6 @@ namespace System
  * #include <BipedalLocomotion/System/Clock.h>
  * #include <BipedalLocomotion/System/YarpClock.h>
  *
- * yarp::os::Network::init(); //<------ This is required by yarp to use the clock
- *
  * // Change the clock
  * BipedalLocomotion::System::ClockBuilder::setFactory(std::make_shared<BipedalLocomotion::System::YarpClockFactory>()));
  *
@@ -34,11 +34,14 @@ namespace System
  * auto end = BipedalLocomotion::clock().now();
  * std::chrono::duration<double, std::milli> elapsed = end-start;
  * \endcode
- * @note Please call `yarp::os::Network::init();` before using the clock. `YARP::YARP_init`
- * component is required.
  */
 class YarpClock final : public IClock
 {
+    /**
+     * A yarp network instance. This automatically call some function required by yarp::os::Time
+     */
+    yarp::os::Network m_network;
+
 public:
     /**
      * Get YARP current time

--- a/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
+++ b/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
@@ -1,0 +1,63 @@
+/**
+ * @file YarpClock.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_YARP_CLOCK_H
+#define BIPEDAL_LOCOMOTION_SYSTEM_YARP_CLOCK_H
+
+#include <BipedalLocomotion/System/IClock.h>
+
+#include <chrono>
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+
+/**
+ * YarpClock implements a the IClock interface using yarp functions.
+ * The clock can be easily used as follows
+ * \code{.cpp}
+ * #include <BipedalLocomotion/System/Clock.h>
+ * #include <BipedalLocomotion/System/YarpClock.h>
+ *
+ * yarp::os::Network::init(); //<------ This is required by yarp to use the clock
+ *
+ * // Change the clock
+ * BipedalLocomotion::System::ClockBuilder::setFactory(std::make_shared<BipedalLocomotion::System::YarpClockFactory>()));
+ *
+ * auto start = BipedalLocomotion::clock().now();
+ * foo();
+ * auto end = BipedalLocomotion::clock().now();
+ * std::chrono::duration<double, std::milli> elapsed = end-start;
+ * \endcode
+ * @note Please call `yarp::os::Network::init();` before using the clock. `YARP::YARP_init`
+ * component is required.
+ */
+class YarpClock final : public IClock
+{
+public:
+    /**
+     * Get YARP current time
+     * @return the current time computed from `yarp::os::Time::now()`
+     */
+    std::chrono::duration<double> now() final;
+};
+
+class YarpClockFactory final : public ClockFactory
+{
+public:
+    /**
+     * Create the YARP clock as a singleton
+     * @return the reference to a System::YarpClock
+     */
+    IClock& createClock() final;
+};
+
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_YARP_CLOCK_H

--- a/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
+++ b/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
@@ -46,6 +46,8 @@ public:
     /**
      * Get YARP current time
      * @return the current time computed from `yarp::os::Time::now()`
+     * @note `BipedalLocomotion::clock().now().count()` returns a double containing the seconds
+     * since epoch.
      */
     std::chrono::duration<double> now() final;
 

--- a/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
+++ b/src/System/YarpImplementation/include/BipedalLocomotion/System/YarpClock.h
@@ -20,7 +20,7 @@ namespace System
 {
 
 /**
- * YarpClock implements a the IClock interface using yarp functions.
+ * YarpClock implements the IClock interface using yarp functions.
  * The clock can be easily used as follows
  * \code{.cpp}
  * #include <BipedalLocomotion/System/Clock.h>

--- a/src/System/YarpImplementation/src/YarpClock.cpp
+++ b/src/System/YarpImplementation/src/YarpClock.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file YarpClock.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <yarp/os/Time.h>
+
+#include <BipedalLocomotion/System/YarpClock.h>
+
+using namespace BipedalLocomotion::System;
+
+std::chrono::duration<double> YarpClock::now()
+{
+    // The yarp now function  returns the time in seconds
+    return std::chrono::duration<double>(yarp::os::Time::now());
+}
+
+IClock& YarpClockFactory::createClock()
+{
+    // Create the singleton. Meyers' implementation. It is automatically threadsafe
+    static YarpClock clock;
+    return clock;
+}

--- a/src/System/YarpImplementation/src/YarpClock.cpp
+++ b/src/System/YarpImplementation/src/YarpClock.cpp
@@ -17,6 +17,18 @@ std::chrono::duration<double> YarpClock::now()
     return std::chrono::duration<double>(yarp::os::Time::now());
 }
 
+void YarpClock::sleepFor(const std::chrono::duration<double>& sleepDuration)
+{
+    // std::chrono::duration store the time in second
+    yarp::os::Time::delay(sleepDuration.count());
+}
+
+void YarpClock::sleepUntil(const std::chrono::duration<double>& sleepTime)
+{
+    yarp::os::Time::delay(
+        (sleepTime - std::chrono::duration<double>(yarp::os::Time::now())).count());
+}
+
 IClock& YarpClockFactory::createClock()
 {
     // Create the singleton. Meyers' implementation. It is automatically threadsafe

--- a/src/System/include/BipedalLocomotion/System/Clock.h
+++ b/src/System/include/BipedalLocomotion/System/Clock.h
@@ -33,7 +33,7 @@ class ClockBuilder
 
 public:
     /**
-    * Set a custom factory..
+    * Set a custom factory.
     * @param factory. A pointer to an existing factory.
     * @return True in case success, false otherwise.
     */

--- a/src/System/include/BipedalLocomotion/System/Clock.h
+++ b/src/System/include/BipedalLocomotion/System/Clock.h
@@ -1,0 +1,48 @@
+/**
+ * @file Clock.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_CLOCK_H
+#define BIPEDAL_LOCOMOTION_SYSTEM_CLOCK_H
+
+#include <memory>
+
+#include <BipedalLocomotion/System/IClock.h>
+#include <BipedalLocomotion/System/StdClock.h>
+
+namespace BipedalLocomotion
+{
+
+/**
+ * Get the clock singleton.
+ */
+System::IClock& clock();
+
+namespace System
+{
+
+class ClockBuilder
+{
+    /**
+     * Pointer to factory used to build the clock
+     */
+    inline static std::shared_ptr<ClockFactory> m_factory{std::make_shared<StdClockFactory>()};
+
+public:
+    /**
+    * Set a custom factory..
+    * @param factory. A pointer to an existing factory.
+    * @return True in case success, false otherwise.
+    */
+    static bool setFactory(std::shared_ptr<ClockFactory> factory);
+
+    friend IClock& ::BipedalLocomotion::clock();
+};
+
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_CLOCK_H

--- a/src/System/include/BipedalLocomotion/System/IClock.h
+++ b/src/System/include/BipedalLocomotion/System/IClock.h
@@ -1,0 +1,69 @@
+/**
+ * @file IClock.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_ICLOCK_H
+#define BIPEDAL_LOCOMOTION_SYSTEM_ICLOCK_H
+
+#include <chrono>
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+
+/**
+ * IClock is the interface to the clock. The Clock is considered as a singleton. Please use the
+ * ClockBuilder to create a clock. The default clock built is the System::StdClock which uses only
+ * the std methods. To get the current time you can simply use the following line of code
+ * \code{.cpp}
+ * BipedalLocomotion::clock().now();
+ * \endcode
+ */
+class IClock
+{
+protected:
+
+    /**
+     * The constructor is protected. Please create the clock with ClockBulder.
+     */
+    IClock() = default;
+
+public:
+    /**
+     * Destructor
+     */
+    virtual ~IClock() = default;
+
+    /**
+     * Get the current time
+     * @return The current time. The output of the function depends on the concrete implementation.
+     */
+    virtual std::chrono::duration<double> now() = 0;
+};
+
+/**
+ * ClockFactory is an interface that implements the factory paradigm. Please inherit from clock
+ * class if you want to build your custom clock.
+ */
+class ClockFactory
+{
+public:
+    /**
+     * Destructor
+     */
+    virtual ~ClockFactory() = default;
+
+    /**
+     * Create a clock
+     */
+    virtual IClock& createClock() = 0;
+};
+
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_ICLOCK_H

--- a/src/System/include/BipedalLocomotion/System/IClock.h
+++ b/src/System/include/BipedalLocomotion/System/IClock.h
@@ -43,6 +43,18 @@ public:
      * @return The current time. The output of the function depends on the concrete implementation.
      */
     virtual std::chrono::duration<double> now() = 0;
+
+    /**
+     * Blocks the execution of the current thread for at least the specified sleepDuration.
+     * @param time duration to sleep
+     */
+    virtual void sleepFor(const std::chrono::duration<double>& sleepDuration) = 0;
+
+    /**
+     * Blocks the execution of the current thread until specified sleepTime has been reached.
+     * @param time to block until
+     */
+    virtual void sleepUntil(const std::chrono::duration<double>& time) = 0;
 };
 
 /**

--- a/src/System/include/BipedalLocomotion/System/IClock.h
+++ b/src/System/include/BipedalLocomotion/System/IClock.h
@@ -17,7 +17,7 @@ namespace System
 
 /**
  * IClock is the interface to the clock. The Clock is considered as a singleton. Please use the
- * ClockBuilder to create a clock. The default clock built is the System::StdClock which uses only
+ * ClockBuilder to create a clock. The default clock is the System::StdClock which uses only
  * the std methods. To get the current time you can simply use the following line of code
  * \code{.cpp}
  * BipedalLocomotion::clock().now();

--- a/src/System/include/BipedalLocomotion/System/IClock.h
+++ b/src/System/include/BipedalLocomotion/System/IClock.h
@@ -41,6 +41,8 @@ public:
     /**
      * Get the current time
      * @return The current time. The output of the function depends on the concrete implementation.
+     * @note `BipedalLocomotion::clock().now().count()` returns a double containing the seconds
+     * since epoch.
      */
     virtual std::chrono::duration<double> now() = 0;
 

--- a/src/System/include/BipedalLocomotion/System/StdClock.h
+++ b/src/System/include/BipedalLocomotion/System/StdClock.h
@@ -1,0 +1,56 @@
+/**
+ * @file StdClock.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_STD_CLOCK_H
+#define BIPEDAL_LOCOMOTION_SYSTEM_STD_CLOCK_H
+
+#include <BipedalLocomotion/System/IClock.h>
+
+#include <chrono>
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+
+/**
+ * StdClock implements a the IClock interface using.
+ * The clock can be easily used as follows
+ * \code{.cpp}
+ * #include <BipedalLocomotion/System/Clock.h>
+ *
+ *
+ * auto start = BipedalLocomotion::clock().now();
+ * foo();
+ * auto end = BipedalLocomotion::clock().now();
+ * std::chrono::duration<double, std::milli> elapsed = end-start;
+ * \endcode
+ */
+class StdClock final : public IClock
+{
+public:
+    /**
+     * Get the system current time
+     * @return the current time since epoch computed with std::chrono::system_clock
+     */
+    std::chrono::duration<double> now() final;
+};
+
+class StdClockFactory final : public ClockFactory
+{
+public:
+    /**
+     * Create the std clock as a singleton
+     * @return the reference to a System::StdClock
+     */
+    IClock& createClock() final;
+};
+
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_STD_CLOCK_H

--- a/src/System/include/BipedalLocomotion/System/StdClock.h
+++ b/src/System/include/BipedalLocomotion/System/StdClock.h
@@ -38,6 +38,20 @@ public:
      * @return the current time since epoch computed with std::chrono::system_clock
      */
     std::chrono::duration<double> now() final;
+
+    /**
+     * Blocks the execution of the current thread for at least the specified sleepDuration.
+     * @param time duration to sleep
+     * @note std::this_tread::sleep_for() function is used.
+     */
+    void sleepFor(const std::chrono::duration<double>& sleepDuration) final;
+
+    /**
+     * Blocks the execution of the current thread until specified sleepTime has been reached.
+     * @param time to block until
+     * @note sleepTime is the duration since epoch
+     */
+    void sleepUntil(const std::chrono::duration<double>& sleepTime) final;
 };
 
 class StdClockFactory final : public ClockFactory

--- a/src/System/include/BipedalLocomotion/System/StdClock.h
+++ b/src/System/include/BipedalLocomotion/System/StdClock.h
@@ -18,7 +18,7 @@ namespace System
 {
 
 /**
- * StdClock implements a the IClock interface using.
+ * StdClock implements the IClock interface using `<chrono>` from c++std library.
  * The clock can be easily used as follows
  * \code{.cpp}
  * #include <BipedalLocomotion/System/Clock.h>

--- a/src/System/include/BipedalLocomotion/System/StdClock.h
+++ b/src/System/include/BipedalLocomotion/System/StdClock.h
@@ -36,6 +36,8 @@ public:
     /**
      * Get the system current time
      * @return the current time since epoch computed with std::chrono::system_clock
+     * @note `BipedalLocomotion::clock().now().count()` returns a double containing the seconds
+     * since epoch
      */
     std::chrono::duration<double> now() final;
 

--- a/src/System/src/Clock.cpp
+++ b/src/System/src/Clock.cpp
@@ -1,0 +1,29 @@
+/**
+ * @file Clock.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <BipedalLocomotion/System/Clock.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+BipedalLocomotion::System::IClock& BipedalLocomotion::clock()
+{
+    // m_factory is always initialized.
+    assert(BipedalLocomotion::System::ClockBuilder::m_factory);
+    return BipedalLocomotion::System::ClockBuilder::m_factory->createClock();
+}
+
+bool BipedalLocomotion::System::ClockBuilder::setFactory(std::shared_ptr<ClockFactory> factory)
+{
+    constexpr auto logPrefix = "[ClockBuilder::setFactory]";
+    if (factory == nullptr)
+    {
+        log()->error("{} The factory is not valid.", logPrefix);
+        return false;
+    }
+
+    m_factory = factory;
+    return true;
+}

--- a/src/System/src/StdClock.cpp
+++ b/src/System/src/StdClock.cpp
@@ -1,0 +1,24 @@
+/**
+ * @file StdClock.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <chrono>
+
+#include <BipedalLocomotion/System/StdClock.h>
+
+using namespace BipedalLocomotion::System;
+
+std::chrono::duration<double> StdClock::now()
+{
+    return std::chrono::system_clock::now().time_since_epoch();
+}
+
+IClock& StdClockFactory::createClock()
+{
+    // Create the singleton. Meyers' implementation. It is automatically threadsafe
+    static StdClock clock;
+    return clock;
+}

--- a/src/System/src/StdClock.cpp
+++ b/src/System/src/StdClock.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <chrono>
+#include <thread>
 
 #include <BipedalLocomotion/System/StdClock.h>
 
@@ -14,6 +15,16 @@ using namespace BipedalLocomotion::System;
 std::chrono::duration<double> StdClock::now()
 {
     return std::chrono::system_clock::now().time_since_epoch();
+}
+
+void StdClock::sleepFor(const std::chrono::duration<double>& sleepDuration)
+{
+    std::this_thread::sleep_for(sleepDuration);
+}
+
+void StdClock::sleepUntil(const std::chrono::duration<double>& time)
+{
+    std::this_thread::sleep_for(time - std::chrono::system_clock::now().time_since_epoch());
 }
 
 IClock& StdClockFactory::createClock()


### PR DESCRIPTION
Another piece required for the block runner is a clock. Here I introduced the interface IClock and two concrete implementations `StdClock` and `YarpClock`. The former is useful for standalone applications while the latter becomes pivotal when you want to simulate your system with gazebo and using a shared clock. 

The clocks, both yarp, and std are implemented using singleton and they are instantiated using the factory paradigm. The `std` lof is the default clock. If you want to use the `yarp` one you should set the associated factory in the `ClockBuilder`.

Long story short. 
1. Do you want to use a normal std clock?
   ```cpp
   // this will return the time since the epoch
   auto now = BipedalLocomotion::clock().now();
   ```
2. Do you want to use yarp clock?
   ```cpp
   // Change the clock. Call it only once in your main. From now on you will use the yarp clock 
 
BipedalLocomotionnnn::System::ClockBuilder::setFactory(std::make_shared<BipedalLocomotion::System::YarpClockFactory>()));
    
   auto start = BipedalLocomotion::clock().now();
   ```