### PR TITLE
Avoid to set a shared_ptr of kinDyn object in ContinuousDynamicalSystem classes 

### DIFF
--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
@@ -60,14 +60,14 @@ namespace ContinuousDynamicalSystem
  */
 class FixedBaseDynamics : public DynamicalSystem<FixedBaseDynamics>
 {
-    std::shared_ptr<iDynTree::KinDynComputations> m_kinDyn; /**< Pointer to an existing instance of
-                                                               kinDynComputations object */
+    iDynTree::KinDynComputations m_kinDyn; /**< kinDynComputations object */
     std::size_t m_actuatedDoFs{0}; /**< Number of actuated degree of freedom */
 
     Eigen::Vector3d m_gravity{0, 0, -Math::StandardAccelerationOfGravitation}; /**< Gravity vector
                                                                                 */
 
     Eigen::MatrixXd m_massMatrix; /**< Floating-base mass matrix  */
+    std::string m_robotBase; /**< Name of the frame associated to the robot base */
 
     // quantities useful to avoid dynamic allocation in the dynamic allocation in the
     // FixedBaseDynamics::dynamics() method
@@ -88,16 +88,17 @@ public:
      * | Parameter Name |   Type   |                                          Description                                         | Mandatory |
      * |:--------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
      * |    `gravity`   | `double` |     Value of the Gravity. If not defined Math::StandardAccelerationOfGravitation is used     |    No     |
+     * |  `base_frame`  | `string` |  Name of the frame considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
      * @return true in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
 
     /**
-     * Set a kinDynComputations object.
-     * @param kinDyn a pointer to the kinDynComputations object.
+     * Set the model of the robot.
+     * @param model an iDynTree robot model.
      * @return true in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setRobotModel(const iDynTree::Model& model);
 
     /**
      * Set the mass matrix regularization term. i.e. $\f\bar{M} = M + M _ {reg}\f$. Where  $\fM\f$

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FixedBaseDynamics.h
@@ -88,7 +88,7 @@ public:
      * | Parameter Name |   Type   |                                          Description                                         | Mandatory |
      * |:--------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
      * |    `gravity`   | `double` |     Value of the Gravity. If not defined Math::StandardAccelerationOfGravitation is used     |    No     |
-     * |  `base_frame`  | `string` |  Name of the frame considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
+     * |  `base_link`  | `string` |  Name of the link considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
      * @return true in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
@@ -115,7 +115,7 @@ public:
      * |:--------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
      * |    `gravity`   | `double` |     Value of the Gravity. If not defined Math::StandardAccelerationOfGravitation is used     |    No     |
      * |      `rho`     | `double` |       Baumgarte stabilization parameter over the SO(3) group. The default value is 0.01      |    No     |
-     * |  `base_frame`  | `string` |  Name of the frame considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
+     * |  `base_link`  | `string` |  Name of the link considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
      * @return true in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);

--- a/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
+++ b/src/ContinuousDynamicalSystem/include/BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseDynamicsWithCompliantContacts.h
@@ -80,12 +80,13 @@ class FloatingBaseDynamicsWithCompliantContacts
     static constexpr size_t m_baseDoFs = 6; /**< Number of degree of freedom associated to the
                                                floating base */
 
-    std::shared_ptr<iDynTree::KinDynComputations> m_kinDyn; /**< Pointer to an existing instance of
-                                                               kinDynComputations object */
+    iDynTree::KinDynComputations m_kinDyn; /**< kinDynComputations object */
     std::size_t m_actuatedDoFs{0}; /**< Number of actuated degree of freedom */
 
     Eigen::Vector3d m_gravity{0, 0, -Math::StandardAccelerationOfGravitation}; /**< Gravity vector
                                                                                 */
+
+    std::string m_robotBase; /**< Name of the frame associated to the robot base */
 
     Eigen::MatrixXd m_massMatrix; /**< Floating-base mass matrix  */
 
@@ -114,16 +115,17 @@ public:
      * |:--------------:|:--------:|:--------------------------------------------------------------------------------------------:|:---------:|
      * |    `gravity`   | `double` |     Value of the Gravity. If not defined Math::StandardAccelerationOfGravitation is used     |    No     |
      * |      `rho`     | `double` |       Baumgarte stabilization parameter over the SO(3) group. The default value is 0.01      |    No     |
+     * |  `base_frame`  | `string` |  Name of the frame considered as fixed base in the model. If not defined the default link will be used. Please check [here](https://robotology.github.io/idyntree/master/classiDynTree_1_1Model.html#a1a8dc1c97b99ffc51dbf93ecff20e8c1)    |    No     |
      * @return true in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
 
     /**
-     * Set a kinDynComputations object.
-     * @param kinDyn a pointer to the kinDynComputations object.
+     * Set the model of the robot.
+     * @param model an iDynTree robot model.
      * @return true in case of success, false otherwise.
      */
-    bool setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn);
+    bool setRobotModel(const iDynTree::Model& model);
 
     /**
      * Set the mass matrix regularization term. i.e. $\f\bar{M} = M + M _ {reg}\f$. Where  $\fM\f$

--- a/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
@@ -38,13 +38,13 @@ bool FixedBaseDynamics::initialize(std::weak_ptr<IParametersHandler> handler)
                     m_gravity.transpose());
     }
 
-    if (ptr->getParameter("base_frame", m_robotBase))
+    if (ptr->getParameter("base_link", m_robotBase))
     {
         if (m_kinDyn.isValid())
         {
             if (!m_kinDyn.setFloatingBase(m_robotBase))
             {
-                log()->error("{} Unable to set the floating base named {}.",
+                log()->error("{} Unable to set the floating base link named: {}.",
                              logPrefix,
                              m_robotBase);
                 return false;
@@ -52,7 +52,7 @@ bool FixedBaseDynamics::initialize(std::weak_ptr<IParametersHandler> handler)
         }
     } else
     {
-        log()->info("{} The base_frame name is not found. The default one stored in the model will "
+        log()->info("{} The base_link name is not found. The default one stored in the model will "
                     "be used.",
                     logPrefix);
     }

--- a/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
+++ b/src/ContinuousDynamicalSystem/src/FixedBaseDynamics.cpp
@@ -32,28 +32,65 @@ bool FixedBaseDynamics::initialize(std::weak_ptr<IParametersHandler> handler)
 
     if (!ptr->getParameter("gravity", m_gravity))
     {
-        log()->info("{} The gravity vector  not found. The default one will be "
+        log()->info("{} The gravity vector is not found. The default one will be "
                     "used {}.",
                     logPrefix,
                     m_gravity.transpose());
     }
 
+    if (ptr->getParameter("base_frame", m_robotBase))
+    {
+        if (m_kinDyn.isValid())
+        {
+            if (!m_kinDyn.setFloatingBase(m_robotBase))
+            {
+                log()->error("{} Unable to set the floating base named {}.",
+                             logPrefix,
+                             m_robotBase);
+                return false;
+            }
+        }
+    } else
+    {
+        log()->info("{} The base_frame name is not found. The default one stored in the model will "
+                    "be used.",
+                    logPrefix);
+    }
+
     return true;
 }
 
-bool FixedBaseDynamics::setKinDyn(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+bool FixedBaseDynamics::setRobotModel(const iDynTree::Model& model)
 {
-    constexpr auto logPrefix = "[FixedBaseDynamics::setKinDyn]";
+    constexpr auto logPrefix = "[FixedBaseDynamics::setRobotModel]";
     constexpr std::size_t spatialVelocitySize = 6;
 
-    if (kinDyn == nullptr)
+    if (!m_kinDyn.loadRobotModel(model))
     {
-        log()->error("{} The kinDyn computation object is not valid.", logPrefix);
+        log()->error("{} Unable to load the robot model.", logPrefix);
         return false;
     }
 
-    m_kinDyn = kinDyn;
-    m_actuatedDoFs = m_kinDyn->model().getNrOfDOFs();
+    // if the floating base name string is not empty it will be set the in model
+    if(!m_robotBase.empty())
+    {
+        log()->info("{} Trying to set the floating base named {} into the kinDynComputations "
+                    "object.",
+                    logPrefix,
+                    m_robotBase);
+        if (!m_kinDyn.setFloatingBase(m_robotBase))
+        {
+            log()->error("{} Unable to set the floating base named {}.", logPrefix, m_robotBase);
+            return false;
+        }
+    } else
+    {
+        log()->info("{} The following link will be used as robot base: {}.",
+                    logPrefix,
+                    m_kinDyn.getFloatingBase());
+    }
+
+    m_actuatedDoFs = model.getNrOfDOFs();
 
     // resize matrices
     m_massMatrix.resize(m_actuatedDoFs + spatialVelocitySize, m_actuatedDoFs + spatialVelocitySize);
@@ -66,9 +103,11 @@ bool FixedBaseDynamics::setMassMatrixRegularization(const Eigen::Ref<const Eigen
 {
     constexpr auto logPrefix = "[FixedBaseDynamics::setMassMatrixRegularization]";
 
-    if (m_kinDyn == nullptr)
+    m_useMassMatrixRegularizationTerm = false;
+
+    if (!m_kinDyn.isValid())
     {
-        log()->error("{} Please call setKinDyn() before.", logPrefix);
+        log()->error("{} Please call setRobotModel() before.", logPrefix);
         return false;
     }
 
@@ -94,9 +133,9 @@ bool FixedBaseDynamics::dynamics(const double& time, StateDerivative& stateDeriv
 {
     constexpr auto logPrefix = "[FixedBaseDynamics::dynamics]";
 
-    if (m_kinDyn == nullptr)
+    if (!m_kinDyn.isValid())
     {
-        log()->error("{} Please call setKinDyn() before.", logPrefix);
+        log()->error("{} Please call setRobotModel() before.", logPrefix);
         return false;
     }
 
@@ -119,14 +158,14 @@ bool FixedBaseDynamics::dynamics(const double& time, StateDerivative& stateDeriv
     jointVelocityOutput = jointVelocity;
 
     // update kindyncomputations object
-    if (!m_kinDyn->setRobotState(jointPositions, jointVelocity, m_gravity))
+    if (!m_kinDyn.setRobotState(jointPositions, jointVelocity, m_gravity))
     {
         log()->error("{} Unable to update the kinDyn object.", logPrefix);
         return false;
     }
 
     // compute the mass matrix
-    if (!m_kinDyn->getFreeFloatingMassMatrix(m_massMatrix))
+    if (!m_kinDyn.getFreeFloatingMassMatrix(m_massMatrix))
     {
         log()->error("{} Unable to get the mass matrix.", logPrefix);
         return false;
@@ -136,7 +175,7 @@ bool FixedBaseDynamics::dynamics(const double& time, StateDerivative& stateDeriv
     // here we want to compute the robot acceleration as
     // robotAcceleration = M^-1 (-h + J' F + tau) = M^-1 * m_knownCoefficent
 
-    if (!m_kinDyn->generalizedBiasForces(m_knownCoefficent))
+    if (!m_kinDyn.generalizedBiasForces(m_knownCoefficent))
     {
         log()->error("{} Unable to get the bias forces.", logPrefix);
         return false;

--- a/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
+++ b/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
@@ -47,22 +47,59 @@ bool FloatingBaseDynamicsWithCompliantContacts::initialize(std::weak_ptr<IParame
                     m_gravity.transpose());
     }
 
+    if (ptr->getParameter("base_frame", m_robotBase))
+    {
+        if (m_kinDyn.isValid())
+        {
+            if (!m_kinDyn.setFloatingBase(m_robotBase))
+            {
+                log()->error("{} Unable to set the floating base named {}.",
+                             logPrefix,
+                             m_robotBase);
+                return false;
+            }
+        }
+    } else
+    {
+        log()->info("{} The base_frame name is not found. The default one stored in the model will "
+                    "be used.",
+                    logPrefix);
+    }
+
+
     return true;
 }
 
-bool FloatingBaseDynamicsWithCompliantContacts::setKinDyn(
-    std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
+bool FloatingBaseDynamicsWithCompliantContacts::setRobotModel(const iDynTree::Model& model)
 {
-    constexpr auto logPrefix = "[FloatingBaseDynamicsWithCompliantContacts::setKinDyn]";
+    constexpr auto logPrefix = "[FloatingBaseDynamicsWithCompliantContacts::setRobotModel]";
 
-    if (kinDyn == nullptr)
+    if (!m_kinDyn.loadRobotModel(model))
     {
-        log()->error("{} The kinDyn computation object is not valid.", logPrefix);
+        log()->error("{} Unable to load the robot model.", logPrefix);
         return false;
     }
 
-    m_kinDyn = kinDyn;
-    m_actuatedDoFs = m_kinDyn->model().getNrOfDOFs();
+    // if the floating base name string is not empty it will be set the in model
+    if(!m_robotBase.empty())
+    {
+        log()->info("{} Trying to set the floating base named {} into the kinDynComputations "
+                    "object.",
+                    logPrefix,
+                    m_robotBase);
+        if (!m_kinDyn.setFloatingBase(m_robotBase))
+        {
+            log()->error("{} Unable to set the floating base named {}.", logPrefix, m_robotBase);
+            return false;
+        }
+    } else
+    {
+        log()->info("{} The following link will be used as robot base: {}.",
+                    logPrefix,
+                    m_kinDyn.getFloatingBase());
+    }
+
+    m_actuatedDoFs = model.getNrOfDOFs();
 
     // resize matrices
     m_massMatrix.resize(m_actuatedDoFs + m_baseDoFs, m_actuatedDoFs + m_baseDoFs);
@@ -79,9 +116,9 @@ bool FloatingBaseDynamicsWithCompliantContacts::setMassMatrixRegularization(
     constexpr auto logPrefix = "[FloatingBaseDynamicsWithCompliantContacts::"
                                "setMassMatrixRegularization]";
 
-    if (m_kinDyn == nullptr)
+    if (!m_kinDyn.isValid())
     {
-        log()->error("{} Please call setKinDyn() before.", logPrefix);
+        log()->error("{} Please call setRobotModel() before.", logPrefix);
         return false;
     }
 
@@ -110,7 +147,7 @@ bool FloatingBaseDynamicsWithCompliantContacts::dynamics(const double& time,
 {
     constexpr auto logPrefix = "[FloatingBaseDynamicsWithCompliantContacts::dynamics]";
 
-    if (m_kinDyn == nullptr)
+    if (!m_kinDyn.isValid())
     {
         log()->error("{} Please call setKinDyn() before.", logPrefix);
         return false;
@@ -147,16 +184,18 @@ bool FloatingBaseDynamicsWithCompliantContacts::dynamics(const double& time,
     jointVelocityOutput = jointVelocity;
 
     // update kindyncomputations object
-    const Eigen::Matrix4d baseTransform = Conversions::toEigenPose(baseOrientation, basePosition);
-    if (!m_kinDyn
-             ->setRobotState(baseTransform, jointPositions, baseVelocity, jointVelocity, m_gravity))
+    if (!m_kinDyn.setRobotState(Conversions::toEigenPose(baseOrientation, basePosition),
+                                jointPositions,
+                                baseVelocity,
+                                jointVelocity,
+                                m_gravity))
     {
         log()->error("{} Unable to update the kinDyn object.", logPrefix);
         return false;
     }
 
     // compute the mass matrix
-    if (!m_kinDyn->getFreeFloatingMassMatrix(m_massMatrix))
+    if (!m_kinDyn.getFreeFloatingMassMatrix(m_massMatrix))
     {
         log()->error("{} Unable to get the mass matrix.", logPrefix);
         return false;
@@ -166,7 +205,7 @@ bool FloatingBaseDynamicsWithCompliantContacts::dynamics(const double& time,
     // here we want to compute the robot acceleration as
     // robotAcceleration = M^-1 (-h + J' F + B tau) = M^-1 * m_knownCoefficent
 
-    if (!m_kinDyn->generalizedBiasForces(m_knownCoefficent))
+    if (!m_kinDyn.generalizedBiasForces(m_knownCoefficent))
     {
         log()->error("{} Unable to get the bias forces.", logPrefix);
         return false;
@@ -178,11 +217,11 @@ bool FloatingBaseDynamicsWithCompliantContacts::dynamics(const double& time,
     for (const auto& contactWrench : contactWrenches)
     {
         // compute the contact jacobian
-        if (!m_kinDyn->getFrameFreeFloatingJacobian(contactWrench.index(), m_jacobianMatrix))
+        if (!m_kinDyn.getFrameFreeFloatingJacobian(contactWrench.index(), m_jacobianMatrix))
         {
             log()->error("{} Unable to get the jacobian of the frame named: {}.",
                          logPrefix,
-                         m_kinDyn->model().getFrameLink(contactWrench.index()));
+                         m_kinDyn.model().getFrameLink(contactWrench.index()));
             return false;
         }
 
@@ -192,12 +231,12 @@ bool FloatingBaseDynamicsWithCompliantContacts::dynamics(const double& time,
         {
             log()->error("{} The contact model associated to the frame named {} is expired",
                          logPrefix,
-                         m_kinDyn->model().getFrameLink(contactWrench.index()));
+                         m_kinDyn.model().getFrameLink(contactWrench.index()));
             return false;
         }
 
-        contactPtr->setState(m_kinDyn->getFrameVel(contactWrench.index()),
-                             m_kinDyn->getWorldTransform(contactWrench.index()));
+        contactPtr->setState(m_kinDyn.getFrameVel(contactWrench.index()),
+                             m_kinDyn.getWorldTransform(contactWrench.index()));
 
         m_knownCoefficent.noalias()
             += m_jacobianMatrix.transpose() * iDynTree::toEigen(contactPtr->getContactWrench());

--- a/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
+++ b/src/ContinuousDynamicalSystem/src/FloatingBaseDynamicsWithCompliantContacts.cpp
@@ -47,13 +47,13 @@ bool FloatingBaseDynamicsWithCompliantContacts::initialize(std::weak_ptr<IParame
                     m_gravity.transpose());
     }
 
-    if (ptr->getParameter("base_frame", m_robotBase))
+    if (ptr->getParameter("base_link", m_robotBase))
     {
         if (m_kinDyn.isValid())
         {
             if (!m_kinDyn.setFloatingBase(m_robotBase))
             {
-                log()->error("{} Unable to set the floating base named {}.",
+                log()->error("{} Unable to set the floating base link named {}.",
                              logPrefix,
                              m_robotBase);
                 return false;
@@ -61,7 +61,7 @@ bool FloatingBaseDynamicsWithCompliantContacts::initialize(std::weak_ptr<IParame
         }
     } else
     {
-        log()->info("{} The base_frame name is not found. The default one stored in the model will "
+        log()->info("{} The base_link name is not found. The default one stored in the model will "
                     "be used.",
                     logPrefix);
     }


### PR DESCRIPTION
This PR attempts to fix part of #273. In details the `FixedBaseDynamics::setKinDyn()` and `FloatingBaseDynamicsWithCompliantContacts::setKinDyn()` has been remove and 
`FixedBaseDynamics::setRobotModel()` and `FloatingBaseDynamicsWithCompliantContacts::setRobotModel()` has been implemented. 