### PR TITLE
Some improvements in sensorbridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project are documented in this file.
 - Add Input template class to `System::Advanceable` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/267)
 - Add support for landmarks and kinematics-free estimation in `FloatingBaseEstimators`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/254)
 - If FRAMEWORK_DETECT_ACTIVE_PYTHON_SITEPACKAGES is OFF, for Python bindings use installation directory provided by sysconfig Python module. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/274)
+- Reduce memory allocation in `YarpSensorBridge` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/278)
 
 ### Fixed
 - Fix missing implementation of `YarpSensorBridge::getFailedSensorReads()`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/202)

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -137,9 +137,7 @@ bool YarpSensorBridge::advance()
         return false;
     }
 
-    m_pimpl->readAllSensors(m_pimpl->failedSensorReads);
-
-    return true;
+    return m_pimpl->readAllSensors(m_pimpl->failedSensorReads);
 }
 
 bool YarpSensorBridge::isOutputValid() const
@@ -264,7 +262,7 @@ bool YarpSensorBridge::getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositi
                                          OptionalDoubleRef receiveTimeInSeconds)
 {
 
-    jointPositions = yarp::eigen::toEigen(m_pimpl->controlBoardRemapperMeasures.jointPositions);
+    jointPositions = m_pimpl->controlBoardRemapperMeasures.jointPositions;
     if (receiveTimeInSeconds)
         receiveTimeInSeconds.value().get()
             = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
@@ -294,7 +292,7 @@ bool YarpSensorBridge::getJointVelocity(const std::string& jointName,
 bool YarpSensorBridge::getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
                                           OptionalDoubleRef receiveTimeInSeconds)
 {
-    jointVelocties = yarp::eigen::toEigen(m_pimpl->controlBoardRemapperMeasures.jointVelocities);
+    jointVelocties = m_pimpl->controlBoardRemapperMeasures.jointVelocities;
 
     if (receiveTimeInSeconds)
         receiveTimeInSeconds.value().get()
@@ -474,7 +472,7 @@ bool YarpSensorBridge::getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrent
                                         OptionalDoubleRef receiveTimeInSeconds)
 {
 
-    motorCurrents = yarp::eigen::toEigen(m_pimpl->controlBoardRemapperMeasures.motorCurrents);
+    motorCurrents = m_pimpl->controlBoardRemapperMeasures.motorCurrents;
 
     if (receiveTimeInSeconds)
         receiveTimeInSeconds.value().get()


### PR DESCRIPTION
This pr changes a bit the implementation of sensor bridge. In details:
1. In https://github.com/dic-iit/bipedal-locomotion-framework/commit/ca31b8968dd422c3e6d2a70c5c8cc3012939a478 I avoid creating temporary yarp::sig::vector every time the joint state is read from the yarpinterface. Furthermore, the motors current was not ordered using `remappedJointIndices`
2. In cf44af6 I run `clang_format` and I start using spdlog instead of court to prints info and errors 