### PR TITLE
[FloatingBaseEstimator] Bug fix in  initialization LeggedOdometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project are documented in this file.
 - Fixed the installation path of public headers related to perception libraries. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/245)
 - Fixed InstallBasicPackageFiles to avoid the same problem of https://github.com/dic-iit/matio-cpp/pull/41 (https://github.com/dic-iit/bipedal-locomotion-framework/pull/253)
 - Call `positionInterface->setRefSpeeds()` only once when a position reference is set in `YarpRobotControl` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/271)
+- Fix initialization of reference frame for world in `LeggedOdometry` class. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/289)
 
 ## [0.1.0] - 2021-02-22
 ### Added

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -202,6 +202,7 @@ bool LeggedOdometry::customInitialization(std::weak_ptr<BipedalLocomotion::Param
         "The parameter handler could not find \"initial_ref_frame_for_world \" in the configuration file. Setting \"initial_fixed_frame\" as reference frame for world"
         << std::endl;
         m_pimpl->m_initialRefFrameForWorld = m_pimpl->m_initialFixedFrame;
+        m_pimpl->m_initialRefFrameForWorldIdx = m_pimpl->m_initialFixedFrameIdx;
     }
     else
     {


### PR DESCRIPTION
The frame index for world reference frame was not initialized to a proper value when it is not specified in the parameter configuration.

This PR fixes #287.