### PR TITLE
Bugfix in LeggedOdometry::updateKinematics()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project are documented in this file.
 - Fixed InstallBasicPackageFiles to avoid the same problem of https://github.com/dic-iit/matio-cpp/pull/41 (https://github.com/dic-iit/bipedal-locomotion-framework/pull/253)
 - Call `positionInterface->setRefSpeeds()` only once when a position reference is set in `YarpRobotControl` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/271)
 - Fix initialization of reference frame for world in `LeggedOdometry` class. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/289)
+- `LeggedOdometry::Impl::updateInternalContactStates()` is now called even if the legged odometry is not initialize. This was required to have a meaningful base estimation the first time `LeggedOdometry::changeFixedFrame()` is called. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/292)
 
 ## [0.1.0] - 2021-02-22
 ### Added

--- a/src/Estimators/src/LeggedOdometry.cpp
+++ b/src/Estimators/src/LeggedOdometry.cpp
@@ -783,6 +783,9 @@ bool LeggedOdometry::updateKinematics(FloatingBaseEstimators::Measurements& meas
         return false;
     }
 
+    // update the internal contact state
+    m_pimpl->updateInternalContactStates(meas, m_modelComp, m_state.supportFrameData);
+
     // initialization step
     if (!m_pimpl->m_odometryInitialized)
     {
@@ -808,8 +811,6 @@ bool LeggedOdometry::updateKinematics(FloatingBaseEstimators::Measurements& meas
     }
 
     // run step
-    m_pimpl->updateInternalContactStates(meas, m_modelComp, m_state.supportFrameData);
-
     if (m_pimpl->switching != LOSwitching::useExternalUpdate)
     {
         // change fixed frame depending on switch times


### PR DESCRIPTION
LeggedOdometry::Impl::updateInternalContactStates() is now called even if the legged odometry is not initialize. This was required to have a meaningful base estimation the first time `LeggedOdometry::changeFixedFrame()` is called.