### PR TITLE
Fix copy-constructor and copy-assignment operator in  `ContactPhaseList` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project are documented in this file.
 - Call `positionInterface->setRefSpeeds()` only once when a position reference is set in `YarpRobotControl` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/271)
 - Fix initialization of reference frame for world in `LeggedOdometry` class. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/289)
 - `LeggedOdometry::Impl::updateInternalContactStates()` is now called even if the legged odometry is not initialize. This was required to have a meaningful base estimation the first time `LeggedOdometry::changeFixedFrame()` is called. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/292)
+- Avoid to use the default copy-constructor and copy-assignment operator in `ContactPhaseList` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/295)
 
 ## [0.1.0] - 2021-02-22
 ### Added

--- a/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
+++ b/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h
@@ -1,7 +1,7 @@
 /**
  * @file ContactPhase.h
- * @authors Stefano Dafarra
- * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @authors Stefano Dafarra, Giulio Romualdi
+ * @copyright 2020, 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
 
@@ -42,6 +42,59 @@ public:
 
     using const_iterator = std::vector<ContactPhase>::const_iterator;
     using const_reverse_iterator = std::vector<ContactPhase>::const_reverse_iterator;
+
+    /**
+     * @brief Constructor.
+     * @note This definition is necessary because the Copy constructor and the Move constructor are
+     * manually defined.
+     */
+    ContactPhaseList() = default;
+
+    /**
+     * @brief Destructor.
+     * @note This definition is necessary to satisfy the rule of five.
+     */
+    ~ContactPhaseList() = default;
+
+    /**
+     * @brief Copy constructor.
+     * @param other another ContactPhaseList.
+     * @note When the copy constructor operator is called  the content of `other.m_contactList` will
+     * be copied in `this->m_contactList`, while `this->m_phases` will be regenerated using the
+     * content of `this->m_contactList`. Notice that Contacts::ContactPhase class stores an
+     * std::unordered_map<std::string, ContactList::const_iterator> called
+     * Contacts::ContactPhase::activeContacts. So copying the content of `other.m_phases` into
+     * `this->m_phases` is wrong since all the iterators stored inside the contact phases should
+     * refer to the lists stored within this class, not the original input lists.
+     */
+    ContactPhaseList(const ContactPhaseList& other);
+
+    /**
+     * @brief Move constructor.
+     * @param other another ContactPhaseList.
+     * @note This definition is necessary to satisfy the rule of five.
+     */
+    ContactPhaseList(ContactPhaseList&& other) = default;
+
+    /**
+     * @brief Copy assignment operator.
+     * @param other another ContactPhaseList.
+     * @note When the copy assignment operator is called  the content of `other.m_contactList` will
+     * be copied in `this->m_contactList`, while `this->m_phases` will be regenerated using the
+     * content of `this->m_contactList`. Notice that Contacts::ContactPhase class stores an
+     * std::unordered_map<std::string, ContactList::const_iterator> called
+     * Contacts::ContactPhase::activeContacts. So copying the content of `other.m_phases` into
+     * `this->m_phases` is wrong since all the iterators stored inside the contact phases should
+     * refer to the lists stored within this class, not the original input lists.
+     */
+    ContactPhaseList& operator=(const ContactPhaseList& other);
+
+    /**
+     * @brief Move assignment operator.
+     * @param other another ContactPhaseList.
+     * @note This definition is necessary to satisfy the rule of five.
+     */
+    ContactPhaseList& operator=(ContactPhaseList&& other) = default;
 
     /**
      * @brief Set the input lists

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -7,9 +7,9 @@
 
 #include <BipedalLocomotion/Contacts/ContactPhaseList.h>
 
+#include <cassert>
 #include <iostream>
 #include <map>
-#include <cassert>
 
 using namespace BipedalLocomotion::Contacts;
 
@@ -17,15 +17,19 @@ void BipedalLocomotion::Contacts::ContactPhaseList::createPhases()
 {
     m_phases.clear();
 
-    std::map<double, std::unordered_map<std::string, ContactList::const_iterator>> activations, deactivations;
+    std::map<double, std::unordered_map<std::string, ContactList::const_iterator>> activations,
+        deactivations;
 
-    for (ContactListMap::iterator list = m_contactLists.begin(); list != m_contactLists.end(); ++list)
+    for (ContactListMap::iterator list = m_contactLists.begin(); list != m_contactLists.end();
+         ++list)
     {
         const std::string& key = list->first;
-        for (ContactList::const_iterator step = list->second.begin(); step != list->second.end(); ++step)
+        for (ContactList::const_iterator step = list->second.begin(); step != list->second.end();
+             ++step)
         {
-            activations[step->activationTime][key] =  step; //By construction, there is only a step given a key and activationTime
-            deactivations[step->deactivationTime][key] =  step;
+            activations[step->activationTime][key] = step; // By construction, there is only a step
+                                                           // given a key and activationTime
+            deactivations[step->deactivationTime][key] = step;
         }
     }
 
@@ -42,9 +46,10 @@ void BipedalLocomotion::Contacts::ContactPhaseList::createPhases()
 
     while ((activations.size() + deactivations.size()) > 1)
     {
-        if ((activations.size() == 0) || (deactivations.begin()->first <= activations.begin()->first))
+        if ((activations.size() == 0)
+            || (deactivations.begin()->first <= activations.begin()->first))
         {
-            //Here I need to remove from the current phase the contacts that are going to end
+            // Here I need to remove from the current phase the contacts that are going to end
             currentPhase.endTime = deactivations.begin()->first;
             m_phases.push_back(currentPhase);
 
@@ -52,7 +57,9 @@ void BipedalLocomotion::Contacts::ContactPhaseList::createPhases()
 
             for (auto& toBeRemoved : deactivations.begin()->second)
             {
-                currentPhase.activeContacts.erase(toBeRemoved.first); //Erase all the contacts which are deactivativated in this instant
+                currentPhase.activeContacts.erase(toBeRemoved.first); // Erase all the contacts
+                                                                      // which are deactivativated
+                                                                      // in this instant
             }
 
             deactivations.erase(deactivations.begin());
@@ -60,45 +67,54 @@ void BipedalLocomotion::Contacts::ContactPhaseList::createPhases()
             if (activations.size() && (deactivations.begin()->first == activations.begin()->first))
             {
                 currentPhase.activeContacts.insert(activations.begin()->second.begin(),
-                                                   activations.begin()->second.end()); //Add the new contacts to the list.
+                                                   activations.begin()->second.end()); // Add the
+                                                                                       // new
+                                                                                       // contacts
+                                                                                       // to the
+                                                                                       // list.
 
                 activations.erase(activations.begin());
             }
-        }
-        else // (activations.begin()->first < deactivations.begin()->first)
+        } else // (activations.begin()->first < deactivations.begin()->first)
         {
             currentPhase.endTime = activations.begin()->first;
             m_phases.push_back(currentPhase);
 
             currentPhase.beginTime = activations.begin()->first;
             currentPhase.activeContacts.insert(activations.begin()->second.begin(),
-                                               activations.begin()->second.end()); //Add the new contacts to the list.
+                                               activations.begin()->second.end()); // Add the new
+                                                                                   // contacts to
+                                                                                   // the list.
 
             activations.erase(activations.begin());
         }
     }
 
-    assert(deactivations.size() == 1); //Only one element should be left (deactivations and activations were equal in number, but the head of activations was deleted at the beginning).
+    assert(deactivations.size() == 1); // Only one element should be left (deactivations and
+                                       // activations were equal in number, but the head of
+                                       // activations was deleted at the beginning).
     currentPhase.endTime = deactivations.begin()->first;
     m_phases.push_back(currentPhase);
 }
 
-void ContactPhaseList::setLists(const ContactListMap &contactLists)
+void ContactPhaseList::setLists(const ContactListMap& contactLists)
 {
     m_contactLists = contactLists;
     createPhases();
 }
 
-bool ContactPhaseList::setLists(const std::initializer_list<ContactList> &contactLists)
+bool ContactPhaseList::setLists(const std::initializer_list<ContactList>& contactLists)
 {
     m_contactLists.clear();
     for (const ContactList& list : contactLists)
     {
-        std::pair<ContactListMap::iterator, bool> res = m_contactLists.insert(ContactListMap::value_type(list.defaultName(), list));
+        std::pair<ContactListMap::iterator, bool> res
+            = m_contactLists.insert(ContactListMap::value_type(list.defaultName(), list));
 
         if (!res.second)
         {
-            std::cerr << "[ContactPhaseList::setLists] Multiple items have the same defaultName." <<std::endl;
+            std::cerr << "[ContactPhaseList::setLists] Multiple items have the same defaultName."
+                      << std::endl;
             return false;
         }
     }
@@ -108,7 +124,8 @@ bool ContactPhaseList::setLists(const std::initializer_list<ContactList> &contac
     return true;
 }
 
-const BipedalLocomotion::Contacts::ContactListMap &BipedalLocomotion::Contacts::ContactPhaseList::lists() const
+const BipedalLocomotion::Contacts::ContactListMap&
+BipedalLocomotion::Contacts::ContactPhaseList::lists() const
 {
     return m_contactLists;
 }
@@ -153,7 +170,7 @@ ContactPhaseList::const_reverse_iterator ContactPhaseList::crend() const
     return m_phases.crend();
 }
 
-const ContactPhase &ContactPhaseList::operator[](size_t index) const
+const ContactPhase& ContactPhaseList::operator[](size_t index) const
 {
     return m_phases[index];
 }

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -6,9 +6,9 @@
  */
 
 #include <BipedalLocomotion/Contacts/ContactPhaseList.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
 
 #include <cassert>
-#include <iostream>
 #include <map>
 
 using namespace BipedalLocomotion::Contacts;
@@ -130,8 +130,7 @@ bool ContactPhaseList::setLists(const std::initializer_list<ContactList>& contac
 
         if (!res.second)
         {
-            std::cerr << "[ContactPhaseList::setLists] Multiple items have the same defaultName."
-                      << std::endl;
+            log()->error("[ContactPhaseList::setLists] Multiple items have the same defaultName.");
             return false;
         }
     }

--- a/src/Contacts/src/ContactPhaseList.cpp
+++ b/src/Contacts/src/ContactPhaseList.cpp
@@ -1,7 +1,7 @@
 /**
  * @file ContactPhase.cpp
- * @authors Stefano Dafarra
- * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @authors Stefano Dafarra, Giulio Romualdi
+ * @copyright 2020, 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
 
@@ -13,7 +13,24 @@
 
 using namespace BipedalLocomotion::Contacts;
 
-void BipedalLocomotion::Contacts::ContactPhaseList::createPhases()
+ContactPhaseList::ContactPhaseList(const ContactPhaseList& other)
+{
+    this->setLists(other.m_contactLists);
+}
+
+ContactPhaseList& ContactPhaseList::operator=(const ContactPhaseList& other)
+{
+    // if the objects are the same just return this
+    if (&other == this)
+    {
+        return *this;
+    }
+
+    this->setLists(other.m_contactLists);
+    return *this;
+}
+
+void ContactPhaseList::createPhases()
 {
     m_phases.clear();
 


### PR DESCRIPTION
This Implements the copy-constructor and copy-assignment operator for the `ContactPhaseList` class. 

`ContactPhaseList` has an attribute called `m_phases`

https://github.com/dic-iit/bipedal-locomotion-framework/blob/d916b56f71eca03a7d1e519e4f13d785665b79ed/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h#L37

where `ContactPhase` has a `std::unordered_map` of active contacts during a given phase.

https://github.com/dic-iit/bipedal-locomotion-framework/blob/d916b56f71eca03a7d1e519e4f13d785665b79ed/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhase.h#L37-L40

Accordingly to the `ContactPhaseList` documentation

https://github.com/dic-iit/bipedal-locomotion-framework/blob/d916b56f71eca03a7d1e519e4f13d785665b79ed/src/Contacts/include/BipedalLocomotion/Contacts/ContactPhaseList.h#L28-L31

all the iterators stored in `this->m_phases` should refer to `this->m_contactList`.
However when the default copy-constructor/copy-assignment operator are colled the content of `other.m_phases` is copied into `this->m_phases` and consequentially the iterators stored in `this->m_phases` will refer to `other.m_contactLists`.

I wrote an [ad-hoc test](https://github.com/dic-iit/bipedal-locomotion-framework/blob/5ec37f1d22af18f151e6c41541c37f795e2663bc/src/Contacts/tests/Contacts/ContactPhaseListTest.cpp#L15) to spot the bug. The test fails in Ubuntu 20.04 if Valgrind is used. Please check [here](https://github.com/dic-iit/bipedal-locomotion-framework/runs/2507414976).

----

In order to satisfy the rule of [five](https://en.cppreference.com/w/cpp/language/rule_of_three) the move-constructor move-assignment operator and destructor member functions must be defined.

----

I also introduced `TextLogging` in `ContactPhaseList`

Thank you @prashanthr05 for helping me in debugging 😃  