### PR TITLE
Implement IParameterHandler::YarpImplementation::setFromFile()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project are documented in this file.
 - Implement the possibility to set the default contact in the `ContactList` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/297)
 - Implement `FixedFootDetector` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/284)
 - Implement QPFixedBaseTSID class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/251)
+- Implement `YarpImplementation::setFromFile()` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/307)
 
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotion/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotion/ParametersHandler/YarpImplementation.h
@@ -76,9 +76,16 @@ public:
 
     /**
      * Set the handler from an object.
-     * @param object The object to copy
+     * @param searchable The object to copy
      */
     void set(const yarp::os::Searchable& searchable);
+
+    /**
+     * Set the handler from a file.
+     * @param filename the name of the file that should be loaded.
+     * @return true/false in case of success/failure.
+     */
+    bool setFromFile(const std::string& filename);
 
     /**
      * Get a parameter [int]

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -144,6 +144,25 @@ void YarpImplementation::set(const yarp::os::Searchable& searchable)
     }
 }
 
+bool YarpImplementation::setFromFile(const std::string& filename)
+{
+    // load the configuration file
+    yarp::os::Property prop;
+    if (!prop.fromConfigFile(filename))
+    {
+        log()->error("[YarpImplementation::setFromFile] Unable to interpret the file named '{}' as "
+                     "a configuration file.",
+                     filename);
+
+        return false;
+    }
+
+    // set the parameters handler
+    this->set(prop);
+
+    return true;
+}
+
 YarpImplementation::weak_ptr YarpImplementation::getGroup(const std::string& name) const
 {
     if (m_lists.find(name) != m_lists.end())

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -138,6 +138,59 @@ TEST_CASE("Get parameters")
         REQUIRE(expected == 10);
     }
 
+    SECTION("Set from file")
+    {
+        parameterHandler->clear();
+
+        REQUIRE(originalHandler->setFromFile(getConfigPath()));
+
+        {
+            int element;
+            REQUIRE(parameterHandler->getParameter("answer_to_the_ultimate_question_of_life", //
+                                                   element));
+            REQUIRE(element == 42);
+        }
+
+        {
+            double element;
+            REQUIRE(parameterHandler->getParameter("pi", element));
+            REQUIRE(element == 3.14);
+        }
+
+        {
+            std::string element;
+            REQUIRE(parameterHandler->getParameter("John", element));
+            REQUIRE(element == "Smith");
+        }
+
+        {
+            std::vector<int> element;
+            REQUIRE(parameterHandler->getParameter("Fibonacci Numbers", element));
+            REQUIRE(element == fibonacciNumbers);
+        }
+
+        auto cartoonsGroup = parameterHandler->getGroup("CARTOONS").lock();
+        REQUIRE(cartoonsGroup);
+
+        {
+            std::vector<std::string> element;
+            REQUIRE(cartoonsGroup->getParameter("Donald's nephews", element));
+            REQUIRE(element == donaldsNephews);
+        }
+
+        {
+            std::vector<int> element(fibonacciNumbers.size());
+            REQUIRE(cartoonsGroup->getParameter("Fibonacci_Numbers", element));
+            REQUIRE(element == fibonacciNumbers);
+        }
+
+        {
+            std::string element;
+            REQUIRE(cartoonsGroup->getParameter("John", element));
+            REQUIRE(element == "Doe");
+        }
+    }
+
     SECTION("Set from RF")
     {
         yarp::os::ResourceFinder &rf = yarp::os::ResourceFinder::getResourceFinderSingleton();


### PR DESCRIPTION
This PR implements `YarpImplementation::setFromFile()`. This method can be used to easily load a configuration file from the path. 

It will simplify the implementation of the python bindings for `IParameterHandler::YarpImplementation`

cc @paolo-viceconte 