### PR TITLE
Implement YarpParametersHandler bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project are documented in this file.
 - Implement QPFixedBaseTSID class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/251)
 - Implement `YarpImplementation::setFromFile()` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/307)
 - Implement `CoMTask` in TSID (https://github.com/dic-iit/bipedal-locomotion-framework/pull/304)
+- Implement `YarpParametersHandler` bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/309)
 
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)

--- a/bindings/python/ParametersHandler/CMakeLists.txt
+++ b/bindings/python/ParametersHandler/CMakeLists.txt
@@ -2,10 +2,28 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+set(H_PREFIX include/BipedalLocomotion/bindings/ParametersHandler)
+
 add_bipedal_locomotion_python_module(
   NAME ParametersHandlerBindings
   SOURCES src/ParametersHandler.cpp src/Module.cpp
-  HEADERS include/BipedalLocomotion/bindings/ParametersHandler/ParametersHandler.h include/BipedalLocomotion/bindings/ParametersHandler/Module.h
+  HEADERS ${H_PREFIX}/ParametersHandler.h ${H_PREFIX}/Module.h
   LINK_LIBRARIES BipedalLocomotion::ParametersHandler
   TESTS tests/test_parameters_handler_std.py
   )
+
+
+if(FRAMEWORK_COMPILE_YarpImplementation)
+
+  add_bipedal_locomotion_python_module(
+    NAME  ParametersHandlerYarpImplementationBindings
+    SOURCES src/YarpParametersHandler.cpp src/YarpModule.cpp
+    HEADERS ${H_PREFIX}/YarpParametersHandler.h ${H_PREFIX}/YarpModule.h
+    LINK_LIBRARIES BipedalLocomotion::ParametersHandlerYarpImplementation
+    TESTS tests/test_parameters_handler_yarp.py
+    )
+
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/config.ini ${PROJECT_BINARY_DIR}/config.ini COPYONLY)
+
+
+endif()

--- a/bindings/python/ParametersHandler/include/BipedalLocomotion/bindings/ParametersHandler/YarpModule.h
+++ b/bindings/python/ParametersHandler/include/BipedalLocomotion/bindings/ParametersHandler/YarpModule.h
@@ -1,0 +1,26 @@
+/**
+ * @file YarpModule.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_PARAMETERS_HANDLER_YARP_MODULE_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_PARAMETERS_HANDLER_YARP_MODULE_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ParametersHandler
+{
+
+void CreateYarpModule(pybind11::module& module);
+
+} // namespace ParametersHandler
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_PARAMETERS_HANDLER_YARP_MODULE_H

--- a/bindings/python/ParametersHandler/include/BipedalLocomotion/bindings/ParametersHandler/YarpParametersHandler.h
+++ b/bindings/python/ParametersHandler/include/BipedalLocomotion/bindings/ParametersHandler/YarpParametersHandler.h
@@ -1,0 +1,26 @@
+/**
+ * @file YarpParametersHandler
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_BINDINGS_PARAMETERS_HANDLER_YARP_PARAMETERS_HANDLER_H
+#define BIPEDAL_LOCOMOTION_BINDINGS_PARAMETERS_HANDLER_YARP_PARAMETERS_HANDLER_H
+
+#include <pybind11/pybind11.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ParametersHandler
+{
+
+void CreateYarpParameterHandler(pybind11::module& module);
+
+} // namespace ParametersHandler
+} // namespace bindings
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_BINDINGS_PARAMETERS_HANDLER_YARP_PARAMETERS_HANDLER_H

--- a/bindings/python/ParametersHandler/src/Module.cpp
+++ b/bindings/python/ParametersHandler/src/Module.cpp
@@ -1,5 +1,5 @@
 /**
- * @file ParametersHandler.cpp
+ * @file Module.cpp
  * @authors Giulio Romualdi, Diego Ferigo
  * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.

--- a/bindings/python/ParametersHandler/src/ParametersHandler.cpp
+++ b/bindings/python/ParametersHandler/src/ParametersHandler.cpp
@@ -25,70 +25,72 @@ void CreateIParameterHandler(pybind11::module& module)
     namespace py = ::pybind11;
     using namespace BipedalLocomotion::ParametersHandler;
 
-    py::class_<IParametersHandler, std::shared_ptr<IParametersHandler>>(module,
-                                                                        "IParametersHandler");
-}
-
-void CreateStdParameterHandler(pybind11::module& module)
-{
-    namespace py = ::pybind11;
-    using namespace BipedalLocomotion::ParametersHandler;
-
     py::class_<GenericContainer::Vector<const int>>(module, "GenericContainerVectorInt");
     py::class_<GenericContainer::Vector<const double>>(module, "GenericContainerVectorDouble");
 
-    py::class_<StdImplementation, //
-               std::shared_ptr<StdImplementation>,
-               IParametersHandler>(module, "StdParametersHandler")
-        .def(py::init())
+    py::class_<IParametersHandler, std::shared_ptr<IParametersHandler>>(module,
+                                                                        "IParametersHandler")
         // Note: the order of the following overloads matters!
         .def("set_parameter_bool",
-             py::overload_cast<const std::string&, const bool&>(&StdImplementation::setParameter),
+             py::overload_cast<const std::string&, const bool&>(&IParametersHandler::setParameter),
              py::arg("name"),
              py::arg("value"))
         .def("set_parameter_int",
-             py::overload_cast<const std::string&, const int&>(&StdImplementation::setParameter),
+             py::overload_cast<const std::string&, const int&>(&IParametersHandler::setParameter),
              py::arg("name"),
              py::arg("value"))
         .def("set_parameter_float",
-             py::overload_cast<const std::string&, const double&>(&StdImplementation::setParameter),
+             py::overload_cast<const std::string&, const double&>(
+                 &IParametersHandler::setParameter),
              py::arg("name"),
              py::arg("value"))
         .def("set_parameter_string",
              py::overload_cast<const std::string&, const std::string&>(
-                 &StdImplementation::setParameter),
+                 &IParametersHandler::setParameter),
              py::arg("name"),
              py::arg("value"))
         .def("set_parameter_vector_bool",
              py::overload_cast<const std::string&, const std::vector<bool>&>(
-                 &StdImplementation::setParameter),
+                 &IParametersHandler::setParameter),
              py::arg("name"),
              py::arg("value"))
         .def(
             "set_parameter_vector_int",
-            [](StdImplementation& impl, const std::string& name, const std::vector<int>& vec) {
+            [](IParametersHandler& impl, const std::string& name, const std::vector<int>& vec) {
                 impl.setParameter(name, vec);
             },
             py::arg("name"),
             py::arg("value"))
         .def(
             "set_parameter_vector_float",
-            [](StdImplementation& impl, const std::string& name, const std::vector<double>& vec) {
+            [](IParametersHandler& impl, const std::string& name, const std::vector<double>& vec) {
                 impl.setParameter(name, vec);
             },
             py::arg("name"),
             py::arg("value"))
         .def(
             "set_parameter_vector_string",
-            [](StdImplementation& impl,
+            [](IParametersHandler& impl,
                const std::string& name,
                const std::vector<std::string>& vec) { impl.setParameter(name, vec); },
             py::arg("name"),
             py::arg("value"))
-        .def("set_group", &StdImplementation::setGroup, py::arg("name"), py::arg("new_group"))
+        .def("set_group", &IParametersHandler::setGroup, py::arg("name"), py::arg("new_group"))
+        .def(
+            "get_group",
+            [](IParametersHandler& impl, const std::string& name) {
+                auto group = impl.getGroup(name).lock();
+                if (group == nullptr)
+                {
+                    throw py::value_error("Failed to find the group named " + name);
+                }
+
+                return group;
+            },
+            py::arg("name"))
         .def(
             "get_parameter_bool",
-            [](const StdImplementation& impl, const std::string& name) -> bool {
+            [](const IParametersHandler& impl, const std::string& name) -> bool {
                 bool ret;
 
                 if (!impl.getParameter(name, ret))
@@ -101,7 +103,7 @@ void CreateStdParameterHandler(pybind11::module& module)
             py::arg("name"))
         .def(
             "get_parameter_int",
-            [](const StdImplementation& impl, const std::string& name) -> int {
+            [](const IParametersHandler& impl, const std::string& name) -> int {
                 int ret;
 
                 if (!impl.getParameter(name, ret))
@@ -114,7 +116,7 @@ void CreateStdParameterHandler(pybind11::module& module)
             py::arg("name"))
         .def(
             "get_parameter_float",
-            [](const StdImplementation& impl, const std::string& name) -> double {
+            [](const IParametersHandler& impl, const std::string& name) -> double {
                 double ret;
 
                 if (!impl.getParameter(name, ret))
@@ -127,7 +129,7 @@ void CreateStdParameterHandler(pybind11::module& module)
             py::arg("name"))
         .def(
             "get_parameter_string",
-            [](const StdImplementation& impl, const std::string& name) -> std::string {
+            [](const IParametersHandler& impl, const std::string& name) -> std::string {
                 std::string ret;
 
                 if (!impl.getParameter(name, ret))
@@ -140,7 +142,7 @@ void CreateStdParameterHandler(pybind11::module& module)
             py::arg("name"))
         .def(
             "get_parameter_vector_bool",
-            [](const StdImplementation& impl, const std::string& name) {
+            [](const IParametersHandler& impl, const std::string& name) {
                 if (std::vector<bool> ret; !impl.getParameter(name, ret))
                 {
                     throw py::value_error("Failed to find a parameter that matches the type");
@@ -152,7 +154,7 @@ void CreateStdParameterHandler(pybind11::module& module)
             py::arg("name"))
         .def(
             "get_parameter_vector_int",
-            [](const StdImplementation& impl, const std::string& name) {
+            [](const IParametersHandler& impl, const std::string& name) {
                 if (std::vector<int> ret; !impl.getParameter(name, ret))
                 {
                     throw py::value_error("Failed to find a parameter that matches the type");
@@ -164,7 +166,7 @@ void CreateStdParameterHandler(pybind11::module& module)
             py::arg("name"))
         .def(
             "get_parameter_vector_float",
-            [](const StdImplementation& impl, const std::string& name) {
+            [](const IParametersHandler& impl, const std::string& name) {
                 if (std::vector<double> ret; !impl.getParameter(name, ret))
                 {
                     throw py::value_error("Failed to find a parameter that matches the type");
@@ -176,7 +178,7 @@ void CreateStdParameterHandler(pybind11::module& module)
             py::arg("name"))
         .def(
             "get_parameter_vector_string",
-            [](const StdImplementation& impl, const std::string& name) {
+            [](const IParametersHandler& impl, const std::string& name) {
                 if (std::vector<std::string> ret; !impl.getParameter(name, ret))
                 {
                     throw py::value_error("Failed to find a parameter that matches the type");
@@ -186,9 +188,19 @@ void CreateStdParameterHandler(pybind11::module& module)
                 }
             },
             py::arg("name"))
-        .def("clear", &StdImplementation::clear)
-        .def("is_empty", &StdImplementation::isEmpty)
-        .def("__repr__", &StdImplementation::toString);
+        .def("clear", &IParametersHandler::clear)
+        .def("is_empty", &IParametersHandler::isEmpty)
+        .def("__repr__", &IParametersHandler::toString);
+}
+
+void CreateStdParameterHandler(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace BipedalLocomotion::ParametersHandler;
+    py::class_<StdImplementation, //
+               std::shared_ptr<StdImplementation>,
+               IParametersHandler>(module, "StdParametersHandler")
+        .def(py::init());
 }
 
 } // namespace ParametersHandler

--- a/bindings/python/ParametersHandler/src/YarpModule.cpp
+++ b/bindings/python/ParametersHandler/src/YarpModule.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file YarpModule.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <BipedalLocomotion/bindings/ParametersHandler/YarpModule.h>
+#include <BipedalLocomotion/bindings/ParametersHandler/YarpParametersHandler.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ParametersHandler
+{
+void CreateYarpModule(pybind11::module& module)
+{
+    CreateYarpParameterHandler(module);
+}
+} // namespace ParametersHandler
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/ParametersHandler/src/YarpParametersHandler.cpp
+++ b/bindings/python/ParametersHandler/src/YarpParametersHandler.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file YarpParametersHandler.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/bindings/ParametersHandler/YarpParametersHandler.h>
+
+namespace BipedalLocomotion
+{
+namespace bindings
+{
+namespace ParametersHandler
+{
+
+void CreateYarpParameterHandler(pybind11::module& module)
+{
+    namespace py = ::pybind11;
+    using namespace BipedalLocomotion::ParametersHandler;
+    py::class_<YarpImplementation, //
+               std::shared_ptr<YarpImplementation>,
+               IParametersHandler>(module, "YarpParametersHandler")
+        .def(py::init())
+        .def("set_from_file", &YarpImplementation::setFromFile, py::arg("Filename"));
+}
+
+} // namespace ParametersHandler
+} // namespace bindings
+} // namespace BipedalLocomotion

--- a/bindings/python/ParametersHandler/tests/config.ini
+++ b/bindings/python/ParametersHandler/tests/config.ini
@@ -1,0 +1,10 @@
+answer_to_the_ultimate_question_of_life 42
+pi                                      3.14
+John                                    Smith
+"Fibonacci Numbers"                     (1, 1, 2, 3, 5, 8, 13, 21)
+
+[CARTOONS]
+"Donald's nephews"                      ("Huey", "Dewey", "Louie")
+Fibonacci_Numbers                       (1, 1, 2, 3, 5, 8, 13, 21)
+John                                    Doe
+

--- a/bindings/python/ParametersHandler/tests/test_parameters_handler_yarp.py
+++ b/bindings/python/ParametersHandler/tests/test_parameters_handler_yarp.py
@@ -1,0 +1,207 @@
+import pytest
+pytestmark = pytest.mark.parameters_handler_yarp
+
+import bipedal_locomotion_framework.bindings.parameters_handler as blf
+import numpy as np
+
+def test_bool():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_bool(name="my_bool", value=True)
+
+    assert handler.get_parameter_bool(name="my_bool") is True
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_int(name="my_bool")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_float(name="my_bool")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_string(name="my_bool")
+
+
+def test_int():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_int(name="my_int", value=42)
+
+    assert handler.get_parameter_int(name="my_int") == 42
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_bool(name="my_int")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_float(name="my_int")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_string(name="my_int")
+
+
+def test_float():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_float(name="my_float", value=3.1415)
+
+    assert handler.get_parameter_float(name="my_float") == pytest.approx(3.1415)
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_bool(name="my_float")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_int(name="my_float")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_string(name="my_float")
+
+
+def test_string():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_string(name="my_string", value="foo")
+
+    assert handler.get_parameter_string(name="my_string") == "foo"
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_bool(name="my_string")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_int(name="my_string")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_float(name="my_string")
+
+
+def test_vector_bool():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_vector_bool(name="my_vector_bool",value= [True, False, True])
+
+    assert handler.get_parameter_vector_bool(name="my_vector_bool") == [True, False, True]
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_int(name="my_vector_bool")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_float(name="my_vector_bool")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_string(name="my_vector_bool")
+
+
+def test_vector_int():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_vector_int(name="my_vector_int", value=[-1, 2, 10])
+
+    assert handler.get_parameter_vector_int(name="my_vector_int") == [-1, 2, 10]
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_bool(name="my_vector_int")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_float(name="my_vector_int")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_string(name="my_vector_int")
+
+
+def test_vector_float():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_vector_float(name="my_vector_float",
+                                       value=[-3.14, 2.7182, 42.0])
+
+    assert handler.get_parameter_vector_float(name="my_vector_float") == \
+           pytest.approx([-3.14, 2.7182, 42.0])
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_bool(name="my_vector_float")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_int(name="my_vector_float")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_string(name="my_vector_float")
+
+
+def test_vector_string():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_vector_string(name="my_vector_string",
+                                        value=["foo", "bar", "bipedal", "locomotion"])
+
+    assert handler.get_parameter_vector_string(name="my_vector_string") == \
+           ["foo", "bar", "bipedal", "locomotion"]
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_bool(name="my_vector_string")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_int(name="my_vector_string")
+
+    with pytest.raises(ValueError):
+        handler.get_parameter_vector_float(name="my_vector_string")
+
+
+def test_vector_mixed():
+
+    handler = blf.YarpParametersHandler()
+
+    # 1. Mixed vector: store as more general type float
+    handler.set_parameter_vector_float(name="to_float", value=[42.0, 1, -3.14, False])
+
+    assert handler.get_parameter_vector_float(name="to_float") == \
+           pytest.approx([42.0, 1.0, -3.14, 0.0])
+
+    # 2. Mixed vector: store as more general type int
+    handler.set_parameter_vector_float(name="to_int", value=[42, 1, -3, False])
+
+    assert handler.get_parameter_vector_float(name="to_int") == \
+           pytest.approx([42, 1, -3, 0])
+
+    # 3. Mixed vector: store as less general type int
+    with pytest.raises(TypeError):
+        handler.set_parameter_vector_int(name="to_int_fail",
+                                         value=[42.0, 1, -3.14, False])
+
+
+def test_clear():
+
+    handler = blf.YarpParametersHandler()
+
+    handler.set_parameter_bool(name="my_bool1", value=False)
+    handler.set_parameter_bool(name="my_bool2", value=True)
+    handler.set_parameter_float(name="my_float", value=-42.42)
+    handler.set_parameter_vector_string(name="my_vector_string", value=["bar", "foo"])
+
+    handler.clear()
+
+    with pytest.raises(ValueError):
+        _ = handler.get_parameter_bool(name="my_bool1")
+
+    with pytest.raises(ValueError):
+        _ = handler.get_parameter_bool(name="my_bool2")
+
+    with pytest.raises(ValueError):
+        _ = handler.get_parameter_float(name="my_float")
+
+    with pytest.raises(ValueError):
+        _ = handler.get_parameter_vector_string(name="my_float")
+
+
+def test_load_from_file():
+
+    handler = blf.YarpParametersHandler()
+    assert handler.set_from_file('config.ini') == True
+
+    assert handler.get_parameter_int("answer_to_the_ultimate_question_of_life") == 42
+    assert handler.get_group("CARTOONS").get_parameter_string("John") == "Doe"

--- a/bindings/python/bipedal_locomotion_framework.cpp.in
+++ b/bindings/python/bipedal_locomotion_framework.cpp.in
@@ -10,6 +10,10 @@
 #include <BipedalLocomotion/bindings/Math/Module.h>
 #include <BipedalLocomotion/bindings/ParametersHandler/Module.h>
 
+@cmakeif FRAMEWORK_COMPILE_YarpImplementation
+#include <BipedalLocomotion/bindings/ParametersHandler/YarpModule.h>
+@endcmakeif FRAMEWORK_COMPILE_YarpImplementation
+
 @cmakeif FRAMEWORK_COMPILE_System
 #include <BipedalLocomotion/bindings/System/Module.h>
 @endcmakeif FRAMEWORK_COMPILE_System
@@ -45,6 +49,10 @@ PYBIND11_MODULE(bindings, m)
 
     py::module parametersHandlerModule = m.def_submodule("parameters_handler");
     bindings::ParametersHandler::CreateModule(parametersHandlerModule);
+
+    @cmakeif FRAMEWORK_COMPILE_YarpImplementation
+    bindings::ParametersHandler::CreateYarpModule(parametersHandlerModule);
+    @endcmakeif FRAMEWORK_COMPILE_YarpImplementation
 
     py::module mathModule = m.def_submodule("math");
     bindings::Math::CreateModule(mathModule);


### PR DESCRIPTION
This PR implements the python bindings for the `YarpParametersHandler` class. 

It is possible to load the parameters directly from the configuration file thanks to `set_from_file` method. While writing the tests I noticed a bug in the `setParameter` method for the `YarpParametersHandler` #308. I think this is te reason why the test is failing:
```
40: =================================== FAILURES ===================================
40: __________________________________ test_bool ___________________________________
40: 
40:     def test_bool():
40:     
40:         handler = blf.YarpParametersHandler()
40:     
40:         handler.set_parameter_bool(name="my_bool", value=True)
40:     
40: >       assert handler.get_parameter_bool(name="my_bool") is True
40: E       ValueError: Failed to find a parameter that matches the type
40: 
40: ../../../src/bipedal-locomotion-framework/bindings/python/ParametersHandler/tests/test_parameters_handler_yarp.py:13: ValueError
40: ----------------------------- Captured stdout call -----------------------------
40: [2021-05-24 16:37:43.244] [thread: 80274] [blf] [error] [BipedalLocomotion::YarpUtilities::getElementFromSearchable] The value named: my_bool is not a bool.
40: _______________________________ test_vector_bool _______________________________
40: 
40:     def test_vector_bool():
40:     
40:         handler = blf.YarpParametersHandler()
40:     
40:         handler.set_parameter_vector_bool(name="my_vector_bool",value= [True, False, True])
40:     
40:         assert handler.get_parameter_vector_bool(name="my_vector_bool") == [True, False, True]
40:     
40:         with pytest.raises(ValueError):
40: >           handler.get_parameter_vector_int(name="my_vector_bool")
40: E           Failed: DID NOT RAISE <class 'ValueError'>
40: 
40: ../../../src/bipedal-locomotion-framework/bindings/python/ParametersHandler/tests/test_parameters_handler_yarp.py:88: Failed
40: _______________________________ test_vector_int ________________________________
40: 
40:     def test_vector_int():
40:     
40:         handler = blf.YarpParametersHandler()
40:     
40:         handler.set_parameter_vector_int(name="my_vector_int", value=[-1, 2, 10])
40:     
40:         assert handler.get_parameter_vector_int(name="my_vector_int") == [-1, 2, 10]
40:     
40:         with pytest.raises(ValueError):
40: >           handler.get_parameter_vector_bool(name="my_vector_int")
40: E           Failed: DID NOT RAISE <class 'ValueError'>
```


