### PR TITLE
Add `foot_take_off_acceleration` and `foot_take_off_velocity` parameters in the `SwingFootPlanner` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project are documented in this file.
 - Reduce memory allocation in `YarpSensorBridge` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/278)
 - Use `TextLogging` in `VariablesHandler` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/291)
 - Fix `YarpImplementation::setParameterPrivate()` when a boolean or a vector of boolean is passed (https://github.com/dic-iit/bipedal-locomotion-framework/pull/311)
+- Add `foot_take_off_acceleration` and `foot_take_off_velocity` parameters in the `SwingFootPlanner` class (https://github.com/dic-iit/bipedal-locomotion-framework/issues/323)
 
 ### Fixed
 - Fix missing implementation of `YarpSensorBridge::getFailedSensorReads()`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/202)

--- a/bindings/python/Planners/tests/test_swing_foot_planner.py
+++ b/bindings/python/Planners/tests/test_swing_foot_planner.py
@@ -75,6 +75,8 @@ def test_swing_foot_planner():
     parameters_handler.set_parameter_float("foot_apex_time", 0.5)
     parameters_handler.set_parameter_float("foot_landing_velocity", 0.0)
     parameters_handler.set_parameter_float("foot_landing_acceleration", 0.0)
+    parameters_handler.set_parameter_float("foot_take_off_velocity", 0.0)
+    parameters_handler.set_parameter_float("foot_take_off_acceleration", 0.0)
 
     planner = blf.planners.SwingFootPlanner()
     assert planner.initialize(handler=parameters_handler)

--- a/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
@@ -70,13 +70,15 @@ public:
      * Initialize the planner.
      * @param handler pointer to the parameter handler.
      * @note the following parameters are required by the class
-     * |        Parameter Name       |   Type   |                                                      Description                                                     | Mandatory |
-     * |:---------------------------:|:--------:|:--------------------------------------------------------------------------------------------------------------------:|:---------:|
-     * |       `sampling_time`       | `double` |                                        Sampling time of the planner in seconds                                       |    Yes    |
-     * |        `step_height`        | `double` | Height of the swing foot. It is not the maximum height of the foot. If apex time is 0.5 `step_height` is the maximum |    Yes    |
-     * |       `foot_apex_time`      | `double` |   Number between 0 and 1 representing the foot apex instant. If 0 the apex happens at take off if 1 at touch down    |    Yes    |
-     * |   `foot_landing_velocity`   | `double` |                                               Landing vertical velocity                                              |    Yes    |
-     * | `foot_landing_acceleration` | `double` |                                             Landing vertical acceleration                                            |    Yes    |
+     * |         Parameter Name       |   Type   |                                                      Description                                                     | Mandatory |
+     * |:----------------------------:|:--------:|:--------------------------------------------------------------------------------------------------------------------:|:---------:|
+     * |        `sampling_time`       | `double` |                                        Sampling time of the planner in seconds                                       |    Yes    |
+     * |         `step_height`        | `double` | Height of the swing foot. It is not the maximum height of the foot. If apex time is 0.5 `step_height` is the maximum |    Yes    |
+     * |        `foot_apex_time`      | `double` |   Number between 0 and 1 representing the foot apex instant. If 0 the apex happens at take off if 1 at touch down    |    Yes    |
+     * |    `foot_landing_velocity`   | `double` |                                               Landing vertical velocity                                              |    Yes    |
+     * |  `foot_landing_acceleration` | `double` |                                             Landing vertical acceleration                                            |    Yes    |
+     * |   `foot_take_off_velocity`   | `double` |                                              Take-off vertical velocity                                              |    Yes    |
+     * | `foot_take_off_acceleration` | `double` |                                            Take-off vertical acceleration                                            |    Yes    |
      * @return True in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) final;

--- a/src/Planners/src/SwingFootPlanner.cpp
+++ b/src/Planners/src/SwingFootPlanner.cpp
@@ -43,6 +43,20 @@ bool SwingFootPlanner::initialize(std::weak_ptr<const ParametersHandler::IParame
         return false;
     }
 
+    double footTakeOffVelocity;
+    if (!ptr->getParameter("foot_take_off_velocity", footTakeOffVelocity))
+    {
+        log()->error("{} Unable to initialize the foot take-off velocity.", logPrefix);
+        return false;
+    }
+
+    double footTakeOffAcceleration;
+    if (!ptr->getParameter("foot_take_off_acceleration", footTakeOffAcceleration))
+    {
+        log()->error("{} Unable to initialize the foot take-off acceleration.", logPrefix);
+        return false;
+    }
+
     double footLandingVelocity;
     if (!ptr->getParameter("foot_landing_velocity", footLandingVelocity))
     {
@@ -58,7 +72,7 @@ bool SwingFootPlanner::initialize(std::weak_ptr<const ParametersHandler::IParame
     }
 
     // check the parameters passed to the planner
-    bool ok = (m_dT > 0) && ((m_footApexTime > 0) && (m_footApexTime < 1));
+    const bool ok = (m_dT > 0) && ((m_footApexTime > 0) && (m_footApexTime < 1));
     if (!ok)
     {
         log()->error("{} The sampling time should be a positive number and the foot_apex_time must "
@@ -70,7 +84,8 @@ bool SwingFootPlanner::initialize(std::weak_ptr<const ParametersHandler::IParame
     m_planarPlanner.setInitialConditions(Eigen::Vector2d::Zero(), Eigen::Vector2d::Zero());
     m_planarPlanner.setFinalConditions(Eigen::Vector2d::Zero(), Eigen::Vector2d::Zero());
 
-    m_heightPlanner.setInitialConditions(Vector1d::Zero(), Vector1d::Zero());
+    m_heightPlanner.setInitialConditions(Vector1d::Constant(footTakeOffVelocity),
+                                         Vector1d::Constant(footTakeOffAcceleration));
     m_heightPlanner.setFinalConditions(Vector1d::Constant(footLandingVelocity),
                                        Vector1d::Constant(footLandingAcceleration));
 

--- a/src/Planners/src/SwingFootPlanner.cpp
+++ b/src/Planners/src/SwingFootPlanner.cpp
@@ -1,63 +1,59 @@
 /**
  * @file SwingFootPlanner.cpp
  * @authors Giulio Romualdi
- * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * @copyright 2020, 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
 
-#include <BipedalLocomotion/Planners/SwingFootPlanner.h>
 #include <BipedalLocomotion/Contacts/ContactList.h>
+#include <BipedalLocomotion/Planners/SwingFootPlanner.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
 
 using namespace BipedalLocomotion::Planners;
 using namespace BipedalLocomotion::Contacts;
 
-
-using Vector1d = Eigen::Matrix<double,1,1>;
+using Vector1d = Eigen::Matrix<double, 1, 1>;
 
 bool SwingFootPlanner::initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler)
 {
+    constexpr auto logPrefix = "[SwingFootPlanner::initialize]";
     auto ptr = handler.lock();
 
     if (ptr == nullptr)
     {
-        std::cerr << "[SwingFootPlanner::initialize] The handler is not correctly initialized.";
+        log()->error("{} The handler is not correctly initialized.", logPrefix);
         return false;
     }
 
     if (!ptr->getParameter("sampling_time", m_dT))
     {
-        std::cerr << "[SwingFootPlanner::initialize] Unable to initialize the sampling time for "
-                     "the SwingFootPlanner.";
+        log()->error("{} Unable to initialize the sampling time.", logPrefix);
         return false;
     }
 
     if (!ptr->getParameter("step_height", m_stepHeight))
     {
-        std::cerr << "[SwingFootPlanner::initialize] Unable to initialize the step height for "
-                     "the SwingFootPlanner.";
+        log()->error("{} Unable to initialize the step height.", logPrefix);
         return false;
     }
 
     if (!ptr->getParameter("foot_apex_time", m_footApexTime))
     {
-        std::cerr << "[SwingFootPlanner::initialize] Unable to initialize the foot apex time for "
-                     "the SwingFootPlanner.";
+        log()->error("{} Unable to initialize the foot apex time.", logPrefix);
         return false;
     }
 
     double footLandingVelocity;
     if (!ptr->getParameter("foot_landing_velocity", footLandingVelocity))
     {
-        std::cerr << "[SwingFootPlanner::initialize] Unable to initialize the foot landing "
-                     "velocity for the SwingFootPlanner.";
+        log()->error("{} Unable to initialize the foot landing velocity.", logPrefix);
         return false;
     }
 
     double footLandingAcceleration;
     if (!ptr->getParameter("foot_landing_acceleration", footLandingAcceleration))
     {
-        std::cerr << "[SwingFootPlanner::initialize] Unable to initialize the foot landing "
-                     "acceleration for the SwingFootPlanner.";
+        log()->error("{} Unable to initialize the foot landing acceleration.", logPrefix);
         return false;
     }
 
@@ -65,10 +61,9 @@ bool SwingFootPlanner::initialize(std::weak_ptr<const ParametersHandler::IParame
     bool ok = (m_dT > 0) && ((m_footApexTime > 0) && (m_footApexTime < 1));
     if (!ok)
     {
-        std::cerr << "[SwingFootPlanner::initialize] There is a problem in the parameters used to "
-                     "configure the planner. Please remember to set a strictly positive "
-                     "sampling_time, and a foot_apex_time strictly between 0 and 1."
-                  << std::endl;
+        log()->error("{} The sampling time should be a positive number and the foot_apex_time must "
+                     "be strictly between 0 and 1.",
+                     logPrefix);
         return false;
     }
 
@@ -95,7 +90,6 @@ void SwingFootPlanner::setContactList(const ContactList& contactList)
     m_state.mixedVelocity.setZero();
     m_state.mixedAcceleration.setZero();
     m_state.isInContact = true;
-
 }
 
 bool SwingFootPlanner::isOutputValid() const
@@ -110,6 +104,8 @@ const SwingFootPlannerState& SwingFootPlanner::getOutput() const
 
 bool SwingFootPlanner::updateSE3Traj()
 {
+    constexpr auto logPrefix = "[SwingFootPlanner::updateSE3Traj]";
+
     // compute the trajectory at the current time
     const double shiftedTime = m_currentTrajectoryTime - m_currentContactPtr->deactivationTime;
 
@@ -128,8 +124,9 @@ bool SwingFootPlanner::updateSE3Traj()
     auto angularAcceleration(m_state.mixedAcceleration.asSO3());
     if (!m_SO3Planner.evaluatePoint(shiftedTime, rotation, angularVelocity, angularAcceleration))
     {
-        std::cerr << "[SwingFootPlanner::advance] Unable to get the SO(3) trajectory at time t = "
-                  << m_currentTrajectoryTime << "." << std::endl;
+        log()->error("{} Unable to get the SO(3) trajectory at time t = {}.",
+                     logPrefix,
+                     m_currentTrajectoryTime);
         return false;
     }
 
@@ -139,8 +136,9 @@ bool SwingFootPlanner::updateSE3Traj()
                                        m_state.mixedVelocity.coeffs().head<2>(),
                                        m_state.mixedAcceleration.coeffs().head<2>()))
     {
-        std::cerr << "[SwingFootPlanner::advance] Unable to get the planar trajectory at time t = "
-                  << m_currentTrajectoryTime << "." << std::endl;
+        log()->error("{} Unable to get the planar trajectory at time t = {}.",
+                     logPrefix,
+                     m_currentTrajectoryTime);
         return false;
     }
 
@@ -149,8 +147,9 @@ bool SwingFootPlanner::updateSE3Traj()
                                        m_state.mixedVelocity.coeffs().segment<1>(2),
                                        m_state.mixedAcceleration.coeffs().segment<1>(2)))
     {
-        std::cerr << "[SwingFootPlanner::advance] Unable to get the height trajectory at time t = "
-                  << m_currentTrajectoryTime << "." << std::endl;
+        log()->error("{} Unable to the height trajectory at time t = {}.",
+                     logPrefix,
+                     m_currentTrajectoryTime);
         return false;
     }
 
@@ -164,9 +163,11 @@ bool SwingFootPlanner::updateSE3Traj()
 
 bool SwingFootPlanner::advance()
 {
+    constexpr auto logPrefix = "[SwingFootPlanner::advance]";
+
     // update the time taking into account the limits
-    m_currentTrajectoryTime
-        = std::min(m_dT + m_currentTrajectoryTime, m_contactList.lastContact()->deactivationTime);
+    m_currentTrajectoryTime = std::min(m_dT + m_currentTrajectoryTime, //
+                                       m_contactList.lastContact()->deactivationTime);
 
     // here there are several case
     // 1. the link was already in contact with the environment and now it is still in contact
@@ -186,9 +187,8 @@ bool SwingFootPlanner::advance()
     // In theory this should never happen. This check is only for spotting possible bugs
     if (m_currentContactPtr == m_contactList.end())
     {
-        std::cerr << "[SwingFootPlanner::advance] During the last phase the link should be in "
-                     "contact with the environment."
-                  << std::endl;
+        log()->error("{} During the last phase the link should be in contact with the environment.",
+                     logPrefix);
         return false;
     }
 
@@ -199,11 +199,12 @@ bool SwingFootPlanner::advance()
         const auto nextContactPtr = std::next(m_currentContactPtr, 1);
         const double T = nextContactPtr->activationTime - m_currentContactPtr->deactivationTime;
 
-        if (!m_SO3Planner.setRotations(m_currentContactPtr->pose.asSO3(), nextContactPtr->pose.asSO3(), T))
+        if (!m_SO3Planner.setRotations(m_currentContactPtr->pose.asSO3(),
+                                       nextContactPtr->pose.asSO3(),
+                                       T))
         {
-            std::cerr << "[SwingFootPlanner::advance] Unable to set the initial and final "
-                         "rotations for the SO(3) planner."
-                      << std::endl;
+            log()->error("{} Unable to set the initial and final rotations for the SO(3) planner.",
+                         logPrefix);
             return false;
         }
 
@@ -212,16 +213,17 @@ bool SwingFootPlanner::advance()
                                       {m_currentContactPtr->deactivationTime,
                                        nextContactPtr->activationTime}))
         {
-            std::cerr << "[SwingFootPlanner::advance] Unable to set the knots for the planar "
-                         "planner."
-                      << std::endl;
+            log()->error("{} Unable to set the knots for the planar planner.", logPrefix);
             return false;
         }
 
-        const double footHeightViaPointPos = (m_currentContactPtr->pose.translation()(2) +
-                                              nextContactPtr->pose.translation()(2)) / 2.0 + m_stepHeight;
+        const double footHeightViaPointPos = (m_currentContactPtr->pose.translation()(2) //
+                                              + nextContactPtr->pose.translation()(2))
+                                                 / 2.0
+                                             + m_stepHeight;
 
-        const double footHeightViaPointTime = m_footApexTime * T + m_currentContactPtr->deactivationTime;
+        const double footHeightViaPointTime = m_footApexTime * T //
+                                              + m_currentContactPtr->deactivationTime;
 
         if (!m_heightPlanner.setKnots({m_currentContactPtr->pose.translation().tail<1>(),
                                        Vector1d::Constant(footHeightViaPointPos),
@@ -230,22 +232,19 @@ bool SwingFootPlanner::advance()
                                        footHeightViaPointTime,
                                        nextContactPtr->activationTime}))
         {
-            std::cerr << "[SwingFootPlanner::advance] Unable to set the knots for the height "
-                         "planner."
-                      << std::endl;
+            log()->error("{} Unable to set the knots for the knots for the height planner.",
+                         logPrefix);
             return false;
         }
 
         if (!this->updateSE3Traj())
         {
-            std::cerr << "[SwingFootPlanner::advance] Unable to update the SE(3) trajectory."
-                      << std::endl;
+            log()->error("{} Unable to update the SE(3) trajectory.", logPrefix);
             return false;
         }
 
         return true;
     }
-
 
     // This is the case (3)
     if (!m_state.isInContact && m_currentTrajectoryTime > m_currentContactPtr->deactivationTime
@@ -253,11 +252,9 @@ bool SwingFootPlanner::advance()
     {
         if (!this->updateSE3Traj())
         {
-            std::cerr << "[SwingFootPlanner::advance] Unable to update the SE(3) trajectory."
-                      << std::endl;
+            log()->error("{} Unable to update the SE(3) trajectory.", logPrefix);
             return false;
         }
-
 
         return true;
     }

--- a/src/Planners/tests/SwingFootPlannerTest.cpp
+++ b/src/Planners/tests/SwingFootPlannerTest.cpp
@@ -54,6 +54,9 @@ TEST_CASE("Swing foot planner")
     handler->setParameter("foot_apex_time", 0.5);
     handler->setParameter("foot_landing_velocity", 0.0);
     handler->setParameter("foot_landing_acceleration", 0.0);
+    handler->setParameter("foot_take_off_velocity", 0.0);
+    handler->setParameter("foot_take_off_acceleration", 0.0);
+
 
     // initialize the planner
     SwingFootPlanner planner;


### PR DESCRIPTION
This PR introduces `foot_take_off_acceleration` and `foot_take_off_velocity` parameters in the `SwingFootPlanner` class.

I also remove `std::cerr` in favour if `log()->error(...)`