### PR TITLE
Add matioCpp-based FTIMULogger example device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project are documented in this file.
 - Implement `CoMTask` in TSID (https://github.com/dic-iit/bipedal-locomotion-framework/pull/304)
 - Implement `YarpParametersHandler` bindings (https://github.com/dic-iit/bipedal-locomotion-framework/pull/309)
 - Implement `contactListMapFromJson()` and `contactListMapToJson()` methods and python bindings (https://github.com/dic-iit/bipedal-locomotion-framework/issues/316)
+- Implement a matioCpp-based strain2 sensors' FT-IMU logger example device (https://github.com/dic-iit/bipedal-locomotion-framework/pull/326)
 
 ### Changed
 - Move all the Contacts related classes in Contacts component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/204)

--- a/devices/examples/CMakeLists.txt
+++ b/devices/examples/CMakeLists.txt
@@ -3,4 +3,5 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 add_subdirectory(ROSPublisherTestDevice)
+add_subdirectory(FTIMULoggerDevice)
 

--- a/devices/examples/FTIMULoggerDevice/CMakeLists.txt
+++ b/devices/examples/FTIMULoggerDevice/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+if(FRAMEWORK_COMPILE_YarpImplementation AND FRAMEWORK_COMPILE_YarpUtilities)
+# Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
+add_bipedal_yarp_device(
+  NAME FTIMULoggerDevice
+  TYPE BipedalLocomotion::FTIMULoggerDevice
+  SOURCES src/FTIMULoggerDevice.cpp
+  PUBLIC_HEADERS include/BipedalLocomotion/FTIMULoggerDevice.h
+  PUBLIC_LINK_LIBRARIES ${YARP_LIBRARIES} BipedalLocomotion::YarpUtilities  BipedalLocomotion::ParametersHandlerYarpImplementation BipedalLocomotion::RobotInterfaceYarpImplementation BipedalLocomotion::matioCppConversions Eigen3::Eigen
+  CONFIGURE_PACKAGE_NAME ft_imu_logger_test_device)
+endif()
+

--- a/devices/examples/FTIMULoggerDevice/README.md
+++ b/devices/examples/FTIMULoggerDevice/README.md
@@ -1,0 +1,47 @@
+### iCubGenova04 strain2 FT-IMU logger
+
+A logger device based on `YarpSensorBridge` and `matioCpp` to record dataset from strain2 sensor boards mounted on the iCubGenova04 robot. 
+
+
+
+### Launching
+
+- Launch yarprobotinterface on the robot with `icub_wbd_inertials.xml`
+
+  ```
+  yarprobotinterface --config icub_wbd_inertials.xml
+  ```
+  
+- Launch the FT-IMU logger device,
+  ```
+  YARP_ROBOT_NAME=iCubGenova04 yarprobotinterface --config launch-ft-imu-logger.xml
+  ```
+
+- Press Ctrl+c to close the device, and the dataset is stored as the device is closed.
+
+ Each dataset contains,
+
+ - a `time` vector with the receive time stamps.
+ - a struct for each strain-2 sensor attached on the robot (`l_foot_ft_imu`, `r_foot_ft_imu`, `r_leg_ft_imu`, `l_leg_ft_imu`) with each struct containing the corresponding FT sensor measurement, accelerometer, gyroscope and orientation sensor measurements.
+
+Associated sensors,
+- `l_leg_ft_imu`
+    - FT: `l_leg_ft_sensor`
+    - acc: `l_upper_leg_ft_acc_3b12`
+    - gyro: `l_upper_leg_ft_gyro_3b12`
+    - orientation: `l_upper_leg_ft_eul_3b12`
+- `l_foot_ft_imu`
+    - FT: `l_foot_ft_sensor`
+    - acc: `l_foot_ft_acc_3b13`
+    - gyro: `l_foot_ft_gyro_3b13`
+    - orientation: `l_foot_ft_eul_3b13`
+- `r_leg_ft_imu`
+    - FT: `r_leg_ft_sensor`
+    - acc: `r_upper_leg_ft_acc_3b11`
+    - gyro: `r_upper_leg_ft_gyro_3b11`
+    - orientation: `r_upper_leg_ft_eul_3b11`
+- `r_foot_ft_imu`
+    - FT: `r_foot_ft_sensor`
+    - acc: `r_foot_ft_acc_3b14`
+    - gyro: `r_foot_ft_gyro_3b14`
+    - orientation: `r_foot_ft_eul_3b14`

--- a/devices/examples/FTIMULoggerDevice/README.md
+++ b/devices/examples/FTIMULoggerDevice/README.md
@@ -1,6 +1,6 @@
 ### iCubGenova04 strain2 FT-IMU logger
 
-A logger device based on `YarpSensorBridge` and `matioCpp` to record dataset from strain2 sensor boards mounted on the iCubGenova04 robot. 
+A logger device based on `YarpSensorBridge` and `matioCpp` to record dataset from strain2 sensor boards mounted on the iCubGenova04 robot.
 
 
 
@@ -11,7 +11,7 @@ A logger device based on `YarpSensorBridge` and `matioCpp` to record dataset fro
   ```
   yarprobotinterface --config icub_wbd_inertials.xml
   ```
-  
+
 - Launch the FT-IMU logger device,
   ```
   YARP_ROBOT_NAME=iCubGenova04 yarprobotinterface --config launch-ft-imu-logger.xml

--- a/devices/examples/FTIMULoggerDevice/app/CMakeLists.txt
+++ b/devices/examples/FTIMULoggerDevice/app/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+# Get list of models
+subdirlist(subdirs ${CMAKE_CURRENT_SOURCE_DIR}/robots/)
+# Install each model
+foreach (dir ${subdirs})
+  yarp_install(DIRECTORY robots/${dir} DESTINATION ${YARP_ROBOTS_INSTALL_DIR})
+endforeach ()
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/ft-imu-logger.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/ft-imu-logger.xml
@@ -17,7 +17,7 @@ GNU Lesser General Public License v2.1 or any later version. -->
         <param name="stream_forcetorque_sensors">true</param>
 
         <group name="SixAxisForceTorqueSensors">
-           <param name="sixaxis_forcetorque_sensors_list">("l_leg_ft_sensor", "l_foot_ft_sensor", "r_leg_ft_sensor", "r_foot_ft_sensor")</param> 
+           <param name="sixaxis_forcetorque_sensors_list">("l_leg_ft_sensor", "l_foot_ft_sensor", "r_leg_ft_sensor", "r_foot_ft_sensor")</param>
   <!--           <param name="sixaxis_forcetorque_sensors_list">("left_leg-eb6-j0_3-strain", "left_leg-eb7-j4_5-strain", "right_leg-eb8-j0_3-strain", "right_leg-eb9-j4_5-strain")</param>-->
         </group>
 

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/ft-imu-logger.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/ft-imu-logger.xml
@@ -1,0 +1,43 @@
+
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="ft-imu-logger" type="FTIMULoggerDevice">
+    <param name="robot">icub</param>
+    <param name="sampling_period_in_s">0.02</param>
+    <param name="port_prefix">/ft-imu-logger</param>
+
+    <group name="RobotSensorBridge">
+        <param name="check_for_nan">false</param>
+        <param name="stream_joint_states">false</param>
+        <param name="stream_inertials">true</param>
+        <param name="stream_cartesian_wrenches">false</param>
+        <param name="stream_forcetorque_sensors">true</param>
+
+        <group name="SixAxisForceTorqueSensors">
+           <param name="sixaxis_forcetorque_sensors_list">("l_leg_ft_sensor", "l_foot_ft_sensor", "r_leg_ft_sensor", "r_foot_ft_sensor")</param> 
+  <!--           <param name="sixaxis_forcetorque_sensors_list">("left_leg-eb6-j0_3-strain", "left_leg-eb7-j4_5-strain", "right_leg-eb8-j0_3-strain", "right_leg-eb9-j4_5-strain")</param>-->
+        </group>
+
+        <group name="InertialSensors">
+            <param name="accelerometers_list">("l_upper_leg_ft_acc_3b12", "l_foot_ft_acc_3b13", "r_upper_leg_ft_acc_3b11", "r_foot_ft_acc_3b14")</param>
+            <param name="gyroscopes_list">("l_upper_leg_ft_gyro_3b12", "l_foot_ft_gyro_3b13", "r_upper_leg_ft_gyro_3b11", "r_foot_ft_gyro_3b14")</param>
+            <param name="orientation_sensors_list">("l_upper_leg_ft_eul_3b12", "l_foot_ft_eul_3b13", "r_upper_leg_ft_eul_3b11", "r_foot_ft_eul_3b14")</param>
+        </group>
+
+    </group>
+
+    <!-- ATTACH -->
+    <action phase="startup" level="15" type="attach">
+        <paramlist name="networks">
+            <elem name="ft-imu-mas-remapper">ft-imu-mas-remapper</elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="2" type="detach" />
+    <!-- FINISH ATTACH-->
+
+</device>
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/ft-imu-mas-remapper.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/ft-imu-mas-remapper.xml
@@ -1,0 +1,44 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="ft-imu-mas-remapper" type="multipleanalogsensorsremapper">
+    <param name="period">10</param>
+    <param name="ThreeAxisGyroscopesNames">
+          (l_upper_leg_ft_gyro_3b12
+           l_foot_ft_gyro_3b13
+           r_upper_leg_ft_gyro_3b11
+           r_foot_ft_gyro_3b14)
+        </param>
+        <param name="ThreeAxisLinearAccelerometersNames">
+          (l_upper_leg_ft_acc_3b12
+           l_foot_ft_acc_3b13
+           r_upper_leg_ft_acc_3b11
+           r_foot_ft_acc_3b14)
+        </param>
+        <param name="OrientationSensorsNames">
+          (l_upper_leg_ft_eul_3b12 
+           l_foot_ft_eul_3b13 
+           r_upper_leg_ft_eul_3b11 
+           r_foot_ft_eul_3b14)
+        </param>
+        <param name="SixAxisForceTorqueSensorsNames">
+          (l_leg_ft_sensor
+           l_foot_ft_sensor
+           r_leg_ft_sensor
+           r_foot_ft_sensor)
+        </param>
+    <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="left-leg-ft-client">left-leg-ft-client</elem>
+                <elem name="right-leg-ft-client">right-leg-ft-client</elem>
+                <elem name="left-foot-ft-client">left-foot-ft-client</elem>
+                <elem name="right-foot-ft-client">right-foot-ft-client</elem>
+                <elem name="left-leg-inertials-client">left-leg-inertials-client</elem>
+                <elem name="right-leg-inertials-client">right-leg-inertials-client</elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="5" type="detach" />
+</device>

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/ft-imu-mas-remapper.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/ft-imu-mas-remapper.xml
@@ -18,9 +18,9 @@ GNU Lesser General Public License v2.1 or any later version. -->
            r_foot_ft_acc_3b14)
         </param>
         <param name="OrientationSensorsNames">
-          (l_upper_leg_ft_eul_3b12 
-           l_foot_ft_eul_3b13 
-           r_upper_leg_ft_eul_3b11 
+          (l_upper_leg_ft_eul_3b12
+           l_foot_ft_eul_3b13
+           r_upper_leg_ft_eul_3b11
            r_foot_ft_eul_3b14)
         </param>
         <param name="SixAxisForceTorqueSensorsNames">

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-left-foot-ft-client.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-left-foot-ft-client.xml
@@ -1,0 +1,10 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="left-foot-ft-client" type="multipleanalogsensorsclient">
+    <param name="remote">/icub/left_foot</param>
+    <param name="local">/ft_imu_logger/left_foot</param>
+</device>
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-left-leg-ft-client.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-left-leg-ft-client.xml
@@ -1,0 +1,11 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="left-leg-ft-client" type="multipleanalogsensorsclient">
+    <param name="remote">/icub/left_leg</param>
+    <param name="local">/ft_imu_logger/left_leg</param>
+</device>
+
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-left-leg-inertial-client.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-left-leg-inertial-client.xml
@@ -1,0 +1,10 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="left-leg-inertials-client" type="multipleanalogsensorsclient">
+    <param name="remote">/icub/left_leg/inertials</param>
+    <param name="local">/ft_imu_logger/left_leg/inertials</param>
+</device>
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-right-foot-ft-client.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-right-foot-ft-client.xml
@@ -1,0 +1,10 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="right-foot-ft-client" type="multipleanalogsensorsclient">
+    <param name="remote">/icub/right_foot</param>
+    <param name="local">/ft_imu_logger/right_foot</param>
+</device>
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-right-leg-ft-client.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-right-leg-ft-client.xml
@@ -1,0 +1,10 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="right-leg-ft-client" type="multipleanalogsensorsclient">
+    <param name="remote">/icub/right_leg</param>
+    <param name="local">/ft_imu_logger/right_leg</param>
+</device>
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-right-leg-inertial-client.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/interface/mas-right-leg-inertial-client.xml
@@ -1,0 +1,11 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<device  xmlns:xi="http://www.w3.org/2001/XInclude" name="right-leg-inertials-client" type="multipleanalogsensorsclient">
+    <param name="remote">/icub/right_leg/inertials</param>
+    <param name="local">/ft_imu_logger/right_leg/inertials</param>
+</device>
+
+

--- a/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/launch-ft-imu-logger.xml
+++ b/devices/examples/FTIMULoggerDevice/app/robots/iCubGenova04/launch-ft-imu-logger.xml
@@ -1,0 +1,21 @@
+<!-- Copyright (C) 2019-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+This software may be modified and distributed under the terms of the
+GNU Lesser General Public License v2.1 or any later version. -->
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGenova04" portprefix="icub" build="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <!-- interface -->
+        <xi:include href="interface/mas-left-leg-ft-client.xml" />
+        <xi:include href="interface/mas-left-foot-ft-client.xml" />
+        <xi:include href="interface/mas-right-leg-ft-client.xml" />
+        <xi:include href="interface/mas-right-foot-ft-client.xml" />
+        <xi:include href="interface/mas-left-leg-inertial-client.xml" />
+        <xi:include href="interface/mas-right-leg-inertial-client.xml" />
+        <xi:include href="interface/ft-imu-mas-remapper.xml" />
+        <xi:include href="./ft-imu-logger.xml" />
+    </devices>
+</robot>
+

--- a/devices/examples/FTIMULoggerDevice/include/BipedalLocomotion/FTIMULoggerDevice.h
+++ b/devices/examples/FTIMULoggerDevice/include/BipedalLocomotion/FTIMULoggerDevice.h
@@ -1,0 +1,70 @@
+/**
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_FRAMEWORK_FT_IMU_LOGGER_DEVICE_H
+#define BIPEDAL_LOCOMOTION_FRAMEWORK_FT_IMU_LOGGER_DEVICE_H
+
+#include <BipedalLocomotion/RobotInterface/YarpSensorBridge.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/Wrapper.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace BipedalLocomotion
+{
+    class FTIMULoggerDevice;
+}
+
+class BipedalLocomotion::FTIMULoggerDevice : public yarp::dev::DeviceDriver,
+                                             public yarp::dev::IMultipleWrapper,
+                                             public yarp::os::PeriodicThread
+{
+public:
+    explicit FTIMULoggerDevice(double period, yarp::os::ShouldUseSystemClock useSystemClock = yarp::os::ShouldUseSystemClock::No);
+    FTIMULoggerDevice();
+    ~FTIMULoggerDevice();
+
+    virtual bool open(yarp::os::Searchable& config) final;
+    virtual bool close() final;
+    virtual bool attachAll(const yarp::dev::PolyDriverList & poly) final;
+    virtual bool detachAll() final;
+    virtual void run() final;
+
+    struct FTIMUPair
+    {
+        // todo: make it a circular buffer
+        // with periodic flushing to the file
+        Eigen::MatrixXd ft;
+        Eigen::MatrixXd acc;
+        Eigen::MatrixXd gyro;
+        Eigen::MatrixXd orient;
+    };
+
+private:
+    bool setupRobotSensorBridge(yarp::os::Searchable& config);
+    bool logData();
+    std::string m_robot{"iCub"};
+    std::string m_portPrefix{"/ft_imu_logger"};
+    std::unique_ptr<BipedalLocomotion::RobotInterface::YarpSensorBridge> m_robotSensorBridge;
+    std::mutex m_deviceMutex;
+
+    std::unordered_map<std::string, FTIMUPair> m_ftimupair;
+
+    Eigen::VectorXd time;
+
+    double timeNow;
+    Eigen::Matrix<double, 3, 1> acc;
+    Eigen::Matrix<double, 3, 1> gyro;
+    Eigen::Matrix<double, 3, 1> orient;
+    Eigen::Matrix<double, 6, 1> ft;
+};
+
+
+
+#endif //BIPEDAL_LOCOMOTION_FRAMEWORK_FT_IMU_LOGGER_DEVICE_H
+

--- a/devices/examples/FTIMULoggerDevice/src/FTIMULoggerDevice.cpp
+++ b/devices/examples/FTIMULoggerDevice/src/FTIMULoggerDevice.cpp
@@ -12,6 +12,7 @@
 using namespace BipedalLocomotion::YarpUtilities;
 using namespace BipedalLocomotion::ParametersHandler;
 using namespace BipedalLocomotion::RobotInterface;
+using namespace BipedalLocomotion::Conversions;
 using namespace BipedalLocomotion;
 
 FTIMULoggerDevice::FTIMULoggerDevice(double period,
@@ -173,22 +174,10 @@ bool FTIMULoggerDevice::logData()
     auto outTime = Conversions::tomatioCpp(time, "time");
 
     // left leg ft
-    matioCpp::MultiDimensionalArray<double> outLFTLeg{"l_leg_ft_sensor",
-                                                      {static_cast<std::size_t>(m_ftimupair.at("l_leg").ft.rows()),
-                                                      static_cast<std::size_t>(m_ftimupair.at("l_leg").ft.cols())},
-                                                      m_ftimupair.at("l_leg").ft.data()};
-    matioCpp::MultiDimensionalArray<double> outLFTAccLeg{"l_leg_ft_acc",
-                                                         {static_cast<std::size_t>(m_ftimupair.at("l_leg").acc.rows()),
-                                                         static_cast<std::size_t>(m_ftimupair.at("l_leg").acc.cols())},
-                                                         m_ftimupair.at("l_leg").acc.data()};
-    matioCpp::MultiDimensionalArray<double> outLFTGyroLeg{"l_leg_ft_gyro",
-                                                          {static_cast<std::size_t>(m_ftimupair.at("l_leg").gyro.rows()),
-                                                          static_cast<std::size_t>(m_ftimupair.at("l_leg").gyro.cols())},
-                                                          m_ftimupair.at("l_leg").gyro.data()};
-    matioCpp::MultiDimensionalArray<double> outLFTOrientLeg{"l_leg_ft_orient",
-                                                            {static_cast<std::size_t>(m_ftimupair.at("l_leg").orient.rows()),
-                                                            static_cast<std::size_t>(m_ftimupair.at("l_leg").orient.cols())},
-                                                            m_ftimupair.at("l_leg").orient.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTLeg = tomatioCpp(m_ftimupair.at("l_leg").ft, "l_leg_ft_sensor");
+    matioCpp::MultiDimensionalArray<double> outLFTAccLeg = tomatioCpp(m_ftimupair.at("l_leg").acc, "l_leg_ft_acc");
+    matioCpp::MultiDimensionalArray<double> outLFTGyroLeg = tomatioCpp(m_ftimupair.at("l_leg").gyro, "l_leg_ft_gyro");
+    matioCpp::MultiDimensionalArray<double> outLFTOrientLeg = tomatioCpp(m_ftimupair.at("l_leg").orient, "l_leg_ft_orient");
 
     std::vector<matioCpp::Variable> l_leg_ftimu;
     l_leg_ftimu.emplace_back(outLFTLeg);
@@ -198,22 +187,10 @@ bool FTIMULoggerDevice::logData()
     matioCpp::Struct outLL("l_leg_ft_imu", l_leg_ftimu);
 
     // right leg ft
-    matioCpp::MultiDimensionalArray<double> outRFTLeg{"r_leg_ft_sensor",
-                                                      {static_cast<std::size_t>(m_ftimupair.at("r_leg").ft.rows()),
-                                                      static_cast<std::size_t>(m_ftimupair.at("r_leg").ft.cols())},
-                                                      m_ftimupair.at("r_leg").ft.data()};
-    matioCpp::MultiDimensionalArray<double> outRFTAccLeg{"r_leg_ft_acc",
-                                                         {static_cast<std::size_t>(m_ftimupair.at("r_leg").acc.rows()),
-                                                         static_cast<std::size_t>(m_ftimupair.at("r_leg").acc.cols())},
-                                                         m_ftimupair.at("r_leg").acc.data()};
-    matioCpp::MultiDimensionalArray<double> outRFTGyroLeg{"r_leg_ft_gyro",
-                                                          {static_cast<std::size_t>(m_ftimupair.at("r_leg").gyro.rows()),
-                                                          static_cast<std::size_t>(m_ftimupair.at("r_leg").gyro.cols())},
-                                                          m_ftimupair.at("r_leg").gyro.data()};
-    matioCpp::MultiDimensionalArray<double> outRFTOrientLeg{"r_leg_ft_orient",
-                                                            {static_cast<std::size_t>(m_ftimupair.at("r_leg").orient.rows()),
-                                                            static_cast<std::size_t>(m_ftimupair.at("r_leg").orient.cols())},
-                                                            m_ftimupair.at("r_leg").orient.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTLeg = tomatioCpp(m_ftimupair.at("r_leg").ft, "r_leg_ft_sensor");
+    matioCpp::MultiDimensionalArray<double> outRFTAccLeg = tomatioCpp(m_ftimupair.at("r_leg").acc, "r_leg_ft_acc");
+    matioCpp::MultiDimensionalArray<double> outRFTGyroLeg = tomatioCpp(m_ftimupair.at("r_leg").gyro, "r_leg_ft_gyro");
+    matioCpp::MultiDimensionalArray<double> outRFTOrientLeg = tomatioCpp(m_ftimupair.at("r_leg").orient, "r_leg_ft_orient");
 
     std::vector<matioCpp::Variable> r_leg_ftimu;
     r_leg_ftimu.emplace_back(outRFTLeg);
@@ -223,22 +200,10 @@ bool FTIMULoggerDevice::logData()
     matioCpp::Struct outRL("r_leg_ft_imu", r_leg_ftimu);
 
     // left foot ft
-    matioCpp::MultiDimensionalArray<double> outLFTFoot{"l_foot_ft_sensor",
-                                                      {static_cast<std::size_t>(m_ftimupair.at("l_foot").ft.rows()),
-                                                       static_cast<std::size_t>(m_ftimupair.at("l_foot").ft.cols())},
-                                                       m_ftimupair.at("l_foot").ft.data()};
-    matioCpp::MultiDimensionalArray<double> outLFTAccFoot{"l_leg_ft_acc",
-                                                         {static_cast<std::size_t>(m_ftimupair.at("l_foot").acc.rows()),
-                                                          static_cast<std::size_t>(m_ftimupair.at("l_foot").acc.cols())},
-                                                          m_ftimupair.at("l_foot").acc.data()};
-    matioCpp::MultiDimensionalArray<double> outLFTGyroFoot{"l_foot_ft_gyro",
-                                                          {static_cast<std::size_t>(m_ftimupair.at("l_foot").gyro.rows()),
-                                                           static_cast<std::size_t>(m_ftimupair.at("l_foot").gyro.cols())},
-                                                           m_ftimupair.at("l_foot").gyro.data()};
-    matioCpp::MultiDimensionalArray<double> outLFTOrientFoot{"l_foot_ft_orient",
-                                                            {static_cast<std::size_t>(m_ftimupair.at("l_foot").orient.rows()),
-                                                             static_cast<std::size_t>(m_ftimupair.at("l_foot").orient.cols())},
-                                                             m_ftimupair.at("l_foot").orient.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTFoot = tomatioCpp(m_ftimupair.at("l_foot").ft, "l_foot_ft_sensor");
+    matioCpp::MultiDimensionalArray<double> outLFTAccFoot = tomatioCpp(m_ftimupair.at("l_foot").acc, "l_leg_ft_acc");
+    matioCpp::MultiDimensionalArray<double> outLFTGyroFoot = tomatioCpp(m_ftimupair.at("l_foot").gyro, "l_foot_ft_gyro");
+    matioCpp::MultiDimensionalArray<double> outLFTOrientFoot = tomatioCpp(m_ftimupair.at("l_foot").orient, "l_foot_ft_orient");
 
     std::vector<matioCpp::Variable> l_foot_ftimu;
     l_foot_ftimu.emplace_back(outLFTFoot);
@@ -248,23 +213,12 @@ bool FTIMULoggerDevice::logData()
     matioCpp::Struct outLF("l_foot_ft_imu", l_foot_ftimu);
 
 
+
     // right foot ft
-    matioCpp::MultiDimensionalArray<double> outRFTFoot{"r_foot_ft_sensor",
-                                                      {static_cast<std::size_t>(m_ftimupair.at("r_foot").ft.rows()),
-                                                       static_cast<std::size_t>(m_ftimupair.at("r_foot").ft.cols())},
-                                                       m_ftimupair.at("r_foot").ft.data()};
-    matioCpp::MultiDimensionalArray<double> outRFTAccFoot{"r_leg_ft_acc",
-                                                         {static_cast<std::size_t>(m_ftimupair.at("r_foot").acc.rows()),
-                                                          static_cast<std::size_t>(m_ftimupair.at("r_foot").acc.cols())},
-                                                          m_ftimupair.at("r_foot").acc.data()};
-    matioCpp::MultiDimensionalArray<double> outRFTGyroFoot{"r_foot_ft_gyro",
-                                                          {static_cast<std::size_t>(m_ftimupair.at("r_foot").gyro.rows()),
-                                                           static_cast<std::size_t>(m_ftimupair.at("r_foot").gyro.cols())},
-                                                           m_ftimupair.at("r_foot").gyro.data()};
-    matioCpp::MultiDimensionalArray<double> outRFTOrientFoot{"r_foot_ft_orient",
-                                                            {static_cast<std::size_t>(m_ftimupair.at("r_foot").orient.rows()),
-                                                             static_cast<std::size_t>(m_ftimupair.at("r_foot").orient.cols())},
-                                                             m_ftimupair.at("r_foot").orient.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTFoot = tomatioCpp(m_ftimupair.at("r_foot").ft, "r_foot_ft_sensor");
+    matioCpp::MultiDimensionalArray<double> outRFTAccFoot = tomatioCpp(m_ftimupair.at("r_foot").acc, "r_leg_ft_acc");
+    matioCpp::MultiDimensionalArray<double> outRFTGyroFoot = tomatioCpp(m_ftimupair.at("r_foot").gyro, "r_foot_ft_gyro");
+    matioCpp::MultiDimensionalArray<double> outRFTOrientFoot = tomatioCpp(m_ftimupair.at("r_foot").orient, "r_foot_ft_orient");
 
     std::vector<matioCpp::Variable> r_foot_ftimu;
     r_foot_ftimu.emplace_back(outRFTFoot);

--- a/devices/examples/FTIMULoggerDevice/src/FTIMULoggerDevice.cpp
+++ b/devices/examples/FTIMULoggerDevice/src/FTIMULoggerDevice.cpp
@@ -2,7 +2,7 @@
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
  */
- 
+
 #include <BipedalLocomotion/FTIMULoggerDevice.h>
 #include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
 #include <BipedalLocomotion/YarpUtilities/Helper.h>

--- a/devices/examples/FTIMULoggerDevice/src/FTIMULoggerDevice.cpp
+++ b/devices/examples/FTIMULoggerDevice/src/FTIMULoggerDevice.cpp
@@ -1,0 +1,313 @@
+/**
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+ 
+#include <BipedalLocomotion/FTIMULoggerDevice.h>
+#include <BipedalLocomotion/ParametersHandler/YarpImplementation.h>
+#include <BipedalLocomotion/YarpUtilities/Helper.h>
+#include <yarp/os/LogStream.h>
+#include <BipedalLocomotion/Conversions/matioCppConversions.h>
+
+using namespace BipedalLocomotion::YarpUtilities;
+using namespace BipedalLocomotion::ParametersHandler;
+using namespace BipedalLocomotion::RobotInterface;
+using namespace BipedalLocomotion;
+
+FTIMULoggerDevice::FTIMULoggerDevice(double period,
+                                     yarp::os::ShouldUseSystemClock useSystemClock)
+: yarp::os::PeriodicThread(period, useSystemClock)
+{
+}
+
+
+FTIMULoggerDevice::FTIMULoggerDevice()
+        : yarp::os::PeriodicThread(0.01, yarp::os::ShouldUseSystemClock::No)
+{
+}
+
+FTIMULoggerDevice::~FTIMULoggerDevice()
+{
+}
+
+bool FTIMULoggerDevice::open(yarp::os::Searchable& config)
+{
+    YarpUtilities::getElementFromSearchable(config, "robot", m_robot);
+    YarpUtilities::getElementFromSearchable(config, "port_prefix", m_portPrefix);
+
+    double devicePeriod{0.01};
+
+    if (YarpUtilities::getElementFromSearchable(config, "sampling_period_in_s", devicePeriod))
+    {
+        setPeriod(devicePeriod);
+    }
+
+    if (!setupRobotSensorBridge(config))
+    {
+        return false;
+    }
+
+    m_ftimupair["r_leg"] = FTIMUPair();
+    m_ftimupair["l_leg"] = FTIMUPair();
+    m_ftimupair["l_foot"] = FTIMUPair();
+    m_ftimupair["r_foot"] = FTIMUPair();
+
+    return true;
+}
+
+bool FTIMULoggerDevice::setupRobotSensorBridge(yarp::os::Searchable& config)
+{
+    auto bridgeConfig = config.findGroup("RobotSensorBridge");
+    if (bridgeConfig.isNull())
+    {
+        yError() << "[FTIMULoggerDevice][setupRobotSensorBridge] Missing required group \"RobotSensorBridge\"";
+        return false;
+    }
+
+    std::shared_ptr<YarpImplementation> originalHandler = std::make_shared<YarpImplementation>();
+    originalHandler->set(bridgeConfig);
+
+    m_robotSensorBridge = std::make_unique<YarpSensorBridge>();
+    if (!m_robotSensorBridge->initialize(originalHandler))
+    {
+        yError() << "[FTIMULoggerDevice][setupRobotSensorBridge] Could not configure RobotSensorBridge";
+        return false;
+    }
+
+    return true;
+}
+
+
+bool FTIMULoggerDevice::attachAll(const yarp::dev::PolyDriverList & poly)
+{
+    if (!m_robotSensorBridge->setDriversList(poly))
+    {
+        yError() << "[FTIMULoggerDevice][attachAll] Could not attach drivers list to sensor bridge";
+        return false;
+    }
+
+    start();
+    return true;
+}
+
+
+void FTIMULoggerDevice::run()
+{
+    if (!m_robotSensorBridge->advance())
+    {
+        yError() << "[FTIMULoggerDevice][run] could not advance sensor bridge.";
+    }
+
+    bool ok{true};
+    auto bufferSize = time.rows();
+
+    // left leg ft
+    ok = ok && m_robotSensorBridge->getSixAxisForceTorqueMeasurement("l_leg_ft_sensor", ft, timeNow);
+    ok = ok && m_robotSensorBridge->getLinearAccelerometerMeasurement("l_upper_leg_ft_acc_3b12", acc, timeNow);
+    ok = ok && m_robotSensorBridge->getGyroscopeMeasure("l_upper_leg_ft_gyro_3b12", gyro, timeNow);
+    ok = ok && m_robotSensorBridge->getOrientationSensorMeasurement("l_upper_leg_ft_eul_3b12", orient, timeNow);
+    m_ftimupair.at("l_leg").ft.conservativeResize(bufferSize+1, 6);
+    m_ftimupair.at("l_leg").acc.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("l_leg").gyro.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("l_leg").orient.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("l_leg").ft.row(bufferSize) << ft(0), ft(1), ft(2), ft(3), ft(4), ft(5);
+    m_ftimupair.at("l_leg").acc.row(bufferSize) << acc(0), acc(1), acc(2);
+    m_ftimupair.at("l_leg").gyro.row(bufferSize) << gyro(0), gyro(1), gyro(2);
+    m_ftimupair.at("l_leg").orient.row(bufferSize) << orient(0), orient(1), orient(2);
+
+    // left foot ft
+    ok = ok && m_robotSensorBridge->getSixAxisForceTorqueMeasurement("l_foot_ft_sensor", ft, timeNow);
+    ok = ok && m_robotSensorBridge->getLinearAccelerometerMeasurement("l_foot_ft_acc_3b13", acc, timeNow);
+    ok = ok && m_robotSensorBridge->getGyroscopeMeasure("l_foot_ft_gyro_3b13", gyro, timeNow);
+    ok = ok && m_robotSensorBridge->getOrientationSensorMeasurement("l_foot_ft_eul_3b13", orient, timeNow);
+    m_ftimupair.at("l_foot").ft.conservativeResize(bufferSize+1, 6);
+    m_ftimupair.at("l_foot").acc.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("l_foot").gyro.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("l_foot").orient.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("l_foot").ft.row(bufferSize) << ft(0), ft(1), ft(2), ft(3), ft(4), ft(5);
+    m_ftimupair.at("l_foot").acc.row(bufferSize) << acc(0), acc(1), acc(2);
+    m_ftimupair.at("l_foot").gyro.row(bufferSize) << gyro(0), gyro(1), gyro(2);
+    m_ftimupair.at("l_foot").orient.row(bufferSize) << orient(0), orient(1), orient(2);
+
+    // right leg ft
+    ok = ok && m_robotSensorBridge->getSixAxisForceTorqueMeasurement("r_leg_ft_sensor", ft, timeNow);
+    ok = ok && m_robotSensorBridge->getLinearAccelerometerMeasurement("r_upper_leg_ft_acc_3b11", acc, timeNow);
+    ok = ok && m_robotSensorBridge->getGyroscopeMeasure("r_upper_leg_ft_gyro_3b11", gyro, timeNow);
+    ok = ok && m_robotSensorBridge->getOrientationSensorMeasurement("r_upper_leg_ft_eul_3b11", orient, timeNow);
+    m_ftimupair.at("r_leg").ft.conservativeResize(bufferSize+1, 6);
+    m_ftimupair.at("r_leg").acc.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("r_leg").gyro.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("r_leg").orient.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("r_leg").ft.row(bufferSize) << ft(0), ft(1), ft(2), ft(3), ft(4), ft(5);
+    m_ftimupair.at("r_leg").acc.row(bufferSize) << acc(0), acc(1), acc(2);
+    m_ftimupair.at("r_leg").gyro.row(bufferSize) << gyro(0), gyro(1), gyro(2);
+    m_ftimupair.at("r_leg").orient.row(bufferSize) << orient(0), orient(1), orient(2);
+
+    // right foot ft
+    ok = ok && m_robotSensorBridge->getSixAxisForceTorqueMeasurement("r_foot_ft_sensor", ft, timeNow);
+    ok = ok && m_robotSensorBridge->getLinearAccelerometerMeasurement("r_foot_ft_acc_3b14", acc, timeNow);
+    ok = ok && m_robotSensorBridge->getGyroscopeMeasure("r_foot_ft_gyro_3b14", gyro, timeNow);
+    ok = ok && m_robotSensorBridge->getOrientationSensorMeasurement("r_foot_ft_eul_3b14", orient, timeNow);
+    m_ftimupair.at("r_foot").ft.conservativeResize(bufferSize+1, 6);
+    m_ftimupair.at("r_foot").acc.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("r_foot").gyro.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("r_foot").orient.conservativeResize(bufferSize+1, 3);
+    m_ftimupair.at("r_foot").ft.row(bufferSize) << ft(0), ft(1), ft(2), ft(3), ft(4), ft(5);
+    m_ftimupair.at("r_foot").acc.row(bufferSize) << acc(0), acc(1), acc(2);
+    m_ftimupair.at("r_foot").gyro.row(bufferSize) << gyro(0), gyro(1), gyro(2);
+    m_ftimupair.at("r_foot").orient.row(bufferSize) << orient(0), orient(1), orient(2);
+
+    time.conservativeResize(bufferSize+1);
+    time.row(bufferSize) << timeNow;
+
+    if (!ok)
+    {
+        yError() << "[FTIMULoggerDevice][run] error reading one fo the sensors.";
+    }
+
+}
+
+bool FTIMULoggerDevice::logData()
+{
+    matioCpp::File file = matioCpp::File::Create("ftimu-out.mat");
+    auto outTime = Conversions::tomatioCpp(time, "time");
+
+    // left leg ft
+    matioCpp::MultiDimensionalArray<double> outLFTLeg{"l_leg_ft_sensor",
+                                                      {static_cast<std::size_t>(m_ftimupair.at("l_leg").ft.rows()),
+                                                      static_cast<std::size_t>(m_ftimupair.at("l_leg").ft.cols())},
+                                                      m_ftimupair.at("l_leg").ft.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTAccLeg{"l_leg_ft_acc",
+                                                         {static_cast<std::size_t>(m_ftimupair.at("l_leg").acc.rows()),
+                                                         static_cast<std::size_t>(m_ftimupair.at("l_leg").acc.cols())},
+                                                         m_ftimupair.at("l_leg").acc.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTGyroLeg{"l_leg_ft_gyro",
+                                                          {static_cast<std::size_t>(m_ftimupair.at("l_leg").gyro.rows()),
+                                                          static_cast<std::size_t>(m_ftimupair.at("l_leg").gyro.cols())},
+                                                          m_ftimupair.at("l_leg").gyro.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTOrientLeg{"l_leg_ft_orient",
+                                                            {static_cast<std::size_t>(m_ftimupair.at("l_leg").orient.rows()),
+                                                            static_cast<std::size_t>(m_ftimupair.at("l_leg").orient.cols())},
+                                                            m_ftimupair.at("l_leg").orient.data()};
+
+    std::vector<matioCpp::Variable> l_leg_ftimu;
+    l_leg_ftimu.emplace_back(outLFTLeg);
+    l_leg_ftimu.emplace_back(outLFTAccLeg);
+    l_leg_ftimu.emplace_back(outLFTGyroLeg);
+    l_leg_ftimu.emplace_back(outLFTOrientLeg);
+    matioCpp::Struct outLL("l_leg_ft_imu", l_leg_ftimu);
+
+    // right leg ft
+    matioCpp::MultiDimensionalArray<double> outRFTLeg{"r_leg_ft_sensor",
+                                                      {static_cast<std::size_t>(m_ftimupair.at("r_leg").ft.rows()),
+                                                      static_cast<std::size_t>(m_ftimupair.at("r_leg").ft.cols())},
+                                                      m_ftimupair.at("r_leg").ft.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTAccLeg{"r_leg_ft_acc",
+                                                         {static_cast<std::size_t>(m_ftimupair.at("r_leg").acc.rows()),
+                                                         static_cast<std::size_t>(m_ftimupair.at("r_leg").acc.cols())},
+                                                         m_ftimupair.at("r_leg").acc.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTGyroLeg{"r_leg_ft_gyro",
+                                                          {static_cast<std::size_t>(m_ftimupair.at("r_leg").gyro.rows()),
+                                                          static_cast<std::size_t>(m_ftimupair.at("r_leg").gyro.cols())},
+                                                          m_ftimupair.at("r_leg").gyro.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTOrientLeg{"r_leg_ft_orient",
+                                                            {static_cast<std::size_t>(m_ftimupair.at("r_leg").orient.rows()),
+                                                            static_cast<std::size_t>(m_ftimupair.at("r_leg").orient.cols())},
+                                                            m_ftimupair.at("r_leg").orient.data()};
+
+    std::vector<matioCpp::Variable> r_leg_ftimu;
+    r_leg_ftimu.emplace_back(outRFTLeg);
+    r_leg_ftimu.emplace_back(outRFTAccLeg);
+    r_leg_ftimu.emplace_back(outRFTGyroLeg);
+    r_leg_ftimu.emplace_back(outRFTOrientLeg);
+    matioCpp::Struct outRL("r_leg_ft_imu", r_leg_ftimu);
+
+    // left foot ft
+    matioCpp::MultiDimensionalArray<double> outLFTFoot{"l_foot_ft_sensor",
+                                                      {static_cast<std::size_t>(m_ftimupair.at("l_foot").ft.rows()),
+                                                       static_cast<std::size_t>(m_ftimupair.at("l_foot").ft.cols())},
+                                                       m_ftimupair.at("l_foot").ft.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTAccFoot{"l_leg_ft_acc",
+                                                         {static_cast<std::size_t>(m_ftimupair.at("l_foot").acc.rows()),
+                                                          static_cast<std::size_t>(m_ftimupair.at("l_foot").acc.cols())},
+                                                          m_ftimupair.at("l_foot").acc.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTGyroFoot{"l_foot_ft_gyro",
+                                                          {static_cast<std::size_t>(m_ftimupair.at("l_foot").gyro.rows()),
+                                                           static_cast<std::size_t>(m_ftimupair.at("l_foot").gyro.cols())},
+                                                           m_ftimupair.at("l_foot").gyro.data()};
+    matioCpp::MultiDimensionalArray<double> outLFTOrientFoot{"l_foot_ft_orient",
+                                                            {static_cast<std::size_t>(m_ftimupair.at("l_foot").orient.rows()),
+                                                             static_cast<std::size_t>(m_ftimupair.at("l_foot").orient.cols())},
+                                                             m_ftimupair.at("l_foot").orient.data()};
+
+    std::vector<matioCpp::Variable> l_foot_ftimu;
+    l_foot_ftimu.emplace_back(outLFTFoot);
+    l_foot_ftimu.emplace_back(outLFTAccFoot);
+    l_foot_ftimu.emplace_back(outLFTGyroFoot);
+    l_foot_ftimu.emplace_back(outLFTOrientFoot);
+    matioCpp::Struct outLF("l_foot_ft_imu", l_foot_ftimu);
+
+
+    // right foot ft
+    matioCpp::MultiDimensionalArray<double> outRFTFoot{"r_foot_ft_sensor",
+                                                      {static_cast<std::size_t>(m_ftimupair.at("r_foot").ft.rows()),
+                                                       static_cast<std::size_t>(m_ftimupair.at("r_foot").ft.cols())},
+                                                       m_ftimupair.at("r_foot").ft.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTAccFoot{"r_leg_ft_acc",
+                                                         {static_cast<std::size_t>(m_ftimupair.at("r_foot").acc.rows()),
+                                                          static_cast<std::size_t>(m_ftimupair.at("r_foot").acc.cols())},
+                                                          m_ftimupair.at("r_foot").acc.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTGyroFoot{"r_foot_ft_gyro",
+                                                          {static_cast<std::size_t>(m_ftimupair.at("r_foot").gyro.rows()),
+                                                           static_cast<std::size_t>(m_ftimupair.at("r_foot").gyro.cols())},
+                                                           m_ftimupair.at("r_foot").gyro.data()};
+    matioCpp::MultiDimensionalArray<double> outRFTOrientFoot{"r_foot_ft_orient",
+                                                            {static_cast<std::size_t>(m_ftimupair.at("r_foot").orient.rows()),
+                                                             static_cast<std::size_t>(m_ftimupair.at("r_foot").orient.cols())},
+                                                             m_ftimupair.at("r_foot").orient.data()};
+
+    std::vector<matioCpp::Variable> r_foot_ftimu;
+    r_foot_ftimu.emplace_back(outRFTFoot);
+    r_foot_ftimu.emplace_back(outRFTAccFoot);
+    r_foot_ftimu.emplace_back(outRFTGyroFoot);
+    r_foot_ftimu.emplace_back(outRFTOrientFoot);
+    matioCpp::Struct outRF("r_foot_ft_imu", r_foot_ftimu);
+
+    bool write_ok{true};
+    write_ok = write_ok && file.write(outLL);
+    write_ok = write_ok && file.write(outRL);
+    write_ok = write_ok && file.write(outLF);
+    write_ok = write_ok && file.write(outRF);
+    write_ok = write_ok && file.write(outTime);
+
+    if (!write_ok)
+    {
+        yError() <<  "[FTIMULoggerDevice][logData] Could not write to file." ;
+        return false;
+    }
+
+    return true;
+}
+
+bool FTIMULoggerDevice::detachAll()
+{
+    std::lock_guard<std::mutex> guard(m_deviceMutex);
+    if (isRunning())
+    {
+        stop();
+    }
+
+    return true;
+}
+
+
+bool FTIMULoggerDevice::close()
+{
+    std::lock_guard<std::mutex> guard(m_deviceMutex);
+    if (!logData())
+    {
+        yError() << "[FTIMULoggerDevice][close] Failed to log data.";
+    }
+
+    return true;
+}


### PR DESCRIPTION
This PR adds,
- an example device that access the strain2 sensor based FT-IMU pairs available on `iCubGenova04` through the `YarpSensorBridge` and logs the foot IMU and  FT sensor measurements using a naive Eigen+matioCpp based implementation.


P.S. for a scalable implementation, it is recommended to use the `yarp-telemetry` based logging. 