### PR TITLE
Restore backward compatibility of SwingFootPlanner parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project are documented in this file.
 - Fix `YarpImplementation::setParameterPrivate()` when a boolean or a vector of boolean is passed (https://github.com/dic-iit/bipedal-locomotion-framework/pull/311)
 - Add `foot_take_off_acceleration` and `foot_take_off_velocity` parameters in the `SwingFootPlanner` class (https://github.com/dic-iit/bipedal-locomotion-framework/issues/323)
 - Change the parameters handler verbosity (https://github.com/dic-iit/bipedal-locomotion-framework/pull/330)
+- Restore backward compatibility of SwingFootPlanner parameters (https://github.com/dic-iit/bipedal-locomotion-framework/pull/334)
 
 ### Fixed
 - Fix missing implementation of `YarpSensorBridge::getFailedSensorReads()`. (https://github.com/dic-iit/bipedal-locomotion-framework/pull/202)

--- a/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
@@ -75,10 +75,10 @@ public:
      * |        `sampling_time`       | `double` |                                        Sampling time of the planner in seconds                                       |    Yes    |
      * |         `step_height`        | `double` | Height of the swing foot. It is not the maximum height of the foot. If apex time is 0.5 `step_height` is the maximum |    Yes    |
      * |        `foot_apex_time`      | `double` |   Number between 0 and 1 representing the foot apex instant. If 0 the apex happens at take off if 1 at touch down    |    Yes    |
-     * |    `foot_landing_velocity`   | `double` |                                               Landing vertical velocity                                              |    Yes    |
-     * |  `foot_landing_acceleration` | `double` |                                             Landing vertical acceleration                                            |    Yes    |
-     * |   `foot_take_off_velocity`   | `double` |                                              Take-off vertical velocity                                              |    Yes    |
-     * | `foot_take_off_acceleration` | `double` |                                            Take-off vertical acceleration                                            |    Yes    |
+     * |    `foot_landing_velocity`   | `double` |                                               Landing vertical velocity                                              |    No    |
+     * |  `foot_landing_acceleration` | `double` |                                             Landing vertical acceleration                                            |    No    |
+     * |   `foot_take_off_velocity`   | `double` |                                              Take-off vertical velocity                                              |    No    |
+     * | `foot_take_off_acceleration` | `double` |                                            Take-off vertical acceleration                                            |    No    |
      * @return True in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) final;

--- a/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
+++ b/src/Planners/include/BipedalLocomotion/Planners/SwingFootPlanner.h
@@ -75,10 +75,10 @@ public:
      * |        `sampling_time`       | `double` |                                        Sampling time of the planner in seconds                                       |    Yes    |
      * |         `step_height`        | `double` | Height of the swing foot. It is not the maximum height of the foot. If apex time is 0.5 `step_height` is the maximum |    Yes    |
      * |        `foot_apex_time`      | `double` |   Number between 0 and 1 representing the foot apex instant. If 0 the apex happens at take off if 1 at touch down    |    Yes    |
-     * |    `foot_landing_velocity`   | `double` |                                               Landing vertical velocity                                              |    No    |
-     * |  `foot_landing_acceleration` | `double` |                                             Landing vertical acceleration                                            |    No    |
-     * |   `foot_take_off_velocity`   | `double` |                                              Take-off vertical velocity                                              |    No    |
-     * | `foot_take_off_acceleration` | `double` |                                            Take-off vertical acceleration                                            |    No    |
+     * |    `foot_landing_velocity`   | `double` |                                     Landing vertical velocity (default value 0.0)                                    |    No    |
+     * |  `foot_landing_acceleration` | `double` |                                   Landing vertical acceleration (default value 0.0)                                  |    No    |
+     * |   `foot_take_off_velocity`   | `double` |                                    Take-off vertical velocity (default value 0.0)                                    |    No    |
+     * | `foot_take_off_acceleration` | `double` |                                  Take-off vertical acceleration (default value 0.0)                                  |    No    |
      * @return True in case of success/false otherwise.
      */
     bool initialize(std::weak_ptr<const ParametersHandler::IParametersHandler> handler) final;

--- a/src/Planners/src/SwingFootPlanner.cpp
+++ b/src/Planners/src/SwingFootPlanner.cpp
@@ -43,32 +43,32 @@ bool SwingFootPlanner::initialize(std::weak_ptr<const ParametersHandler::IParame
         return false;
     }
 
-    double footTakeOffVelocity;
+    double footTakeOffVelocity = 0.0;
     if (!ptr->getParameter("foot_take_off_velocity", footTakeOffVelocity))
     {
-        log()->error("{} Unable to initialize the foot take-off velocity.", logPrefix);
-        return false;
+        log()->info("{} Using default foot_take_off_velocity={}.", logPrefix, footTakeOffVelocity);
     }
 
-    double footTakeOffAcceleration;
+    double footTakeOffAcceleration = 0.0;
     if (!ptr->getParameter("foot_take_off_acceleration", footTakeOffAcceleration))
     {
-        log()->error("{} Unable to initialize the foot take-off acceleration.", logPrefix);
-        return false;
+        log()->info("{} Using default foot_take_off_acceleration={}.",
+                    logPrefix,
+                    footTakeOffAcceleration);
     }
 
-    double footLandingVelocity;
+    double footLandingVelocity = 0.0;
     if (!ptr->getParameter("foot_landing_velocity", footLandingVelocity))
     {
-        log()->error("{} Unable to initialize the foot landing velocity.", logPrefix);
-        return false;
+        log()->info("{} Using default foot_landing_velocity={}.", logPrefix, footLandingVelocity);
     }
 
-    double footLandingAcceleration;
+    double footLandingAcceleration = 0.0;
     if (!ptr->getParameter("foot_landing_acceleration", footLandingAcceleration))
     {
-        log()->error("{} Unable to initialize the foot landing acceleration.", logPrefix);
-        return false;
+        log()->info("{} Using default foot_landing_acceleration={}.",
+                    logPrefix,
+                    footLandingAcceleration);
     }
 
     // check the parameters passed to the planner


### PR DESCRIPTION
Refer to https://github.com/dic-iit/bipedal-locomotion-framework/pull/323#issuecomment-859498629. #323 introduced new mandatory parameters. Since they can be easily defaulted to `0.0`, this PR makes them optional so that the existing code that does not include the new parameters in its handler keeps working as before. 