### PR TITLE
Implement Contact wrench Cone in math component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 ### Added
 - Implement `CubicSpline` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/344)
 - Implement `PWM` control in RobotControl class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/346)
+- Implement `ContactWrenchCone` class in Math component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/352)
+- Implement `skew` function in Math component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/352)
 
 ### Changed
 ### Fix

--- a/src/Math/CMakeLists.txt
+++ b/src/Math/CMakeLists.txt
@@ -8,9 +8,12 @@ if(FRAMEWORK_COMPILE_Math)
 
   add_bipedal_locomotion_library(
     NAME                  Math
-    PUBLIC_HEADERS        ${H_PREFIX}/CARE.h ${H_PREFIX}/Constants.h ${H_PREFIX}/LinearizedFrictionCone.h ${H_PREFIX}/Wrench.h
-    SOURCES               src/CARE.cpp  src/LinearizedFrictionCone.cpp
-    PUBLIC_LINK_LIBRARIES Eigen3::Eigen BipedalLocomotion::ParametersHandler BipedalLocomotion::TextLogging MANIF::manif
+    PUBLIC_HEADERS        ${H_PREFIX}/CARE.h ${H_PREFIX}/Constants.h
+                          ${H_PREFIX}/LinearizedFrictionCone.h ${H_PREFIX}/ContactWrenchCone.h
+                          ${H_PREFIX}/Wrench.h
+    SOURCES               src/CARE.cpp  src/LinearizedFrictionCone.cpp src/ContactWrenchCone.cpp
+    PUBLIC_LINK_LIBRARIES Eigen3::Eigen BipedalLocomotion::ParametersHandler
+                          BipedalLocomotion::TextLogging MANIF::manif
     SUBDIRECTORIES        tests)
 
 endif()

--- a/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
+++ b/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
@@ -67,7 +67,7 @@ class ContactWrenchCone
 public:
 
     /**
-     * Initialize the continuous algebraic riccati equation solver.
+     * Initialize the Contact Wrench Cone class.
      * @param handler pointer to the parameter handler.
      * @note The following parameters are required:
      * |         Parameter Name        |       Type       |                               Description                               | Mandatory |

--- a/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
+++ b/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
@@ -1,0 +1,83 @@
+/**
+ * @file ContactWrenchCone.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_MATH_CONTACT_WRENCH_CONE_H
+#define BIPEDAL_LOCOMOTION_MATH_CONTACT_WRENCH_CONE_H
+
+#include <memory>
+
+#include <Eigen/Dense>
+
+#include <BipedalLocomotion/ParametersHandler/IParametersHandler.h>
+
+
+namespace BipedalLocomotion
+{
+namespace Math
+{
+
+/**
+ * ContactWrenchCone computes the polyhedral approximation of the contact wrench friction cone.
+ * A surface remains fixed with respect the environment if the contact wrench lies in a cone
+ * described by
+ * \f[
+ * f ^c \cdot n > 0 \quad | f ^t | \le \mu f^c \cdot n
+ * \f]
+ *  where \f$ f^c \f$ is the
+ * contact force, \f$ n \f$ is the vector normal to the contact surface. \f$ f^t \f$ is the
+ * tangential force to the contact surface and \f$ \mu \f$ is the friction parameter. In addition we
+ * require CoP inside the support area and a bounded yaw torque. The ContactWrenchCone aims to
+ * compute the polyhedral approximation of \f$ | f ^t | \le \mu f^c \cdot n \f$ by spitting the base
+ * of the cone into slices while considering the contact torque constraints. The class implements
+ * the equations presented in [_Stability of Surface Contacts for Humanoid Robots: Closed-Form
+ * Formulae of the Contact Wrench Cone for Rectangular Support Areas_
+ * paper](https://ieeexplore.ieee.org/document/7139910). However differently from the original
+ * work, the origin of the frame attached to the contact surface is not required to be in the
+ * center of the surface.
+ * @note If you want to specify only the constraints related to the contact force please take a look
+ * at LinearizedFrictionCone class.
+ */
+class ContactWrenchCone
+{
+    Eigen::MatrixXd m_A;
+    Eigen::VectorXd m_b;
+
+    bool m_isIntialized{false}; /**< True if the class has been correctly initialize */
+
+public:
+
+    /**
+     * Initialize the continuous algebraic riccati equation solver.
+     * @param handler pointer to the parameter handler.
+     * @note The following parameters are required:
+     * |         Parameter Name        |       Type       |                               Description                               | Mandatory |
+     * |:-----------------------------:|:----------------:|:-----------------------------------------------------------------------:|:---------:|
+     * |       `number_of_slices`      |       `int`      |                  Number of slices used to split 90 deg.                 |    Yes    |
+     * | `static_friction_coefficient` |     `double`     |                       Static friction coefficient.                      |    Yes    |
+     * |        `foot_limits_x`        | `vector<double>` | x coordinate of the foot limits w.r.t the frame attached to the surface |    Yes    |
+     * |        `foot_limits_y`        | `vector<double>` | y coordinate of the foot limits w.r.t the frame attached to the surface |    Yes    |
+     * @return true in case of success/false otherwise.
+     */
+    bool initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler);
+
+    /**
+     * Get the matrix A.
+     * @return the matrix A.
+     */
+    Eigen::Ref<const Eigen::MatrixXd> getA() const;
+
+    /**
+     * Get the vector B.
+     * @return the matrix B..
+     */
+    Eigen::Ref<const Eigen::VectorXd> getB() const;
+};
+
+} // namespace Math
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_MATH_CONTACT_WRENCH_CONE_H

--- a/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
+++ b/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
@@ -22,7 +22,7 @@ namespace Math
 
 /**
  * ContactWrenchCone computes the polyhedral approximation of the contact wrench friction cone.
- * A surface remains fixed with respect the environment if the contact wrench lies in a cone
+ * A surface remains fixed with respect to the environment if the contact wrench lies in a cone
  * described by
  * \f[
  * f ^c \cdot n > 0 \quad | f ^t | \le \mu f^c \cdot n
@@ -31,14 +31,14 @@ namespace Math
  * contact force, \f$ n \f$ is the vector normal to the contact surface. \f$ f^t \f$ is the
  * tangential force to the contact surface and \f$ \mu \f$ is the friction parameter. In addition we
  * require CoP inside the support area and a bounded yaw torque. The ContactWrenchCone aims to
- * compute the polyhedral approximation of \f$ | f ^t | \le \mu f^c \cdot n \f$ by spitting the base
+ * compute the polyhedral approximation of \f$ | f ^t | \le \mu f^c \cdot n \f$ by splitting the base
  * of the cone into slices while considering the contact torque constraints. The class implements
  * the equations presented in [_Stability of Surface Contacts for Humanoid Robots: Closed-Form
  * Formulae of the Contact Wrench Cone for Rectangular Support Areas_
  * paper](https://ieeexplore.ieee.org/document/7139910). However differently from the original
  * work, the origin of the frame attached to the contact surface is not required to be in the
  * center of the surface.
- * @note The ContactWrenchCone class express the constraints in body representation (so called right
+ * @note The ContactWrenchCone class express the constraints in body representation (so called left
  * trivialization). Please check
  * [here](https://pure.tue.nl/ws/files/25753352/Traversaro_en_Saccon_DC_2016.064.pdf) for further
  * details. If you want to express the constraint in mixed representation please remember to

--- a/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
+++ b/src/Math/include/BipedalLocomotion/Math/ContactWrenchCone.h
@@ -38,8 +38,24 @@ namespace Math
  * paper](https://ieeexplore.ieee.org/document/7139910). However differently from the original
  * work, the origin of the frame attached to the contact surface is not required to be in the
  * center of the surface.
+ * @note The ContactWrenchCone class express the constraints in body representation (so called right
+ * trivialization). Please check
+ * [here](https://pure.tue.nl/ws/files/25753352/Traversaro_en_Saccon_DC_2016.064.pdf) for further
+ * details. If you want to express the constraint in mixed representation please remember to
+ * postmultiply the matrix A for the corresponding adjoint matrix. Namely:
+ * \f[
+ * A_{\text{mixed}} = A
+ * \begin{bmatrix}
+ * {}^I R _ B ^\top & 0 \\
+ * 0 & {}^I R _ B^\top
+ * \end{bmatrix}
+ * \f]
+ * where \f$I\f$ and \f$B\f$ are the inertial and the frame attached to the contact surface
+ * respectively.
  * @note If you want to specify only the constraints related to the contact force please take a look
  * at LinearizedFrictionCone class.
+ * @warning ContactWrenchCone class does not consider the unilaterally constraint of the normal
+ * force.
  */
 class ContactWrenchCone
 {

--- a/src/Math/src/ContactWrenchCone.cpp
+++ b/src/Math/src/ContactWrenchCone.cpp
@@ -1,0 +1,144 @@
+/**
+ * @file ContactWrenchCone.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <cmath>
+#include <numeric>
+
+#include <BipedalLocomotion/Math/ContactWrenchCone.h>
+#include <BipedalLocomotion/Math/LinearizedFrictionCone.h>
+#include <BipedalLocomotion/Math/Wrench.h>
+#include <BipedalLocomotion/TextLogging/Logger.h>
+
+using namespace BipedalLocomotion::Math;
+
+bool ContactWrenchCone::initialize(std::weak_ptr<ParametersHandler::IParametersHandler> handler)
+{
+    constexpr auto errorPrefix = "[ContactWrenchCone::initialize]";
+    LinearizedFrictionCone forceCone;
+
+    auto ptr = handler.lock();
+    if (ptr == nullptr)
+    {
+        log()->error("{} Invalid parameter handler.", errorPrefix);
+        return false;
+    }
+
+    double staticFrictionCoefficient = -1;
+    bool ok =  ptr->getParameter("static_friction_coefficient", staticFrictionCoefficient);
+    ok = ok && staticFrictionCoefficient > 0;
+
+    std::vector<double> limitsX;
+    ok = ok && ptr->getParameter("foot_limits_x", limitsX);
+    std::vector<double> limitsY;
+    ok = ok && ptr->getParameter("foot_limits_y", limitsY);
+    ok = ok && (limitsX.size() == limitsY.size()) && (limitsX.size() == 2);
+
+    if (!ok)
+    {
+        log()->error("{} Unable to retrieve all the parameters.", errorPrefix);
+        return false;
+    }
+
+    if(!forceCone.initialize(handler))
+    {
+        log()->error("{} Unable to initialize the force friction cone.", errorPrefix);
+        return false;
+    }
+
+    const double centerX = std::accumulate(limitsX.begin(), limitsX.end(), 0.0) / limitsX.size();
+    const double centerY = std::accumulate(limitsY.begin(), limitsY.end(), 0.0) / limitsY.size();
+
+    const double halfRectangleLength = (std::abs(limitsX[0]) + std::abs(limitsX[1])) / 2.0;
+    const double halfRectangleWidth = (std::abs(limitsY[0]) + std::abs(limitsY[1])) / 2.0;
+
+    constexpr std::size_t copConstraints = 2;
+    constexpr std::size_t yawTorqueConstraints = 8;
+    constexpr std::size_t torqueConstraints = 2 * copConstraints + yawTorqueConstraints;
+    m_A.resize(forceCone.getB().size() + torqueConstraints, Wrench<double>::SizeAtCompileTime);
+    m_A.setZero();
+    m_A.topLeftCorner(forceCone.getA().rows(), forceCone.getA().cols()) = forceCone.getA();
+
+    // take the lower part of the matrix A
+    // this should simplify
+    Eigen::Ref<Eigen::MatrixXd> ACoP = m_A.middleRows(forceCone.getB().size(), 2 * copConstraints);
+    ACoP(0, 2) = limitsY[0];
+    ACoP(1, 2) = -limitsY[1];
+    ACoP(0, 3) = -1;
+    ACoP(1, 3) = 1;
+    ACoP(2, 2) = limitsX[0];
+    ACoP(3, 2) = -limitsX[1];
+    ACoP(2, 4) = 1;
+    ACoP(3, 4) = -1;
+
+    // please refer to the last 8 rows of the matrix U presented in
+    // https://scaron.info/publications/icra-2015.html
+    Eigen::Ref<Eigen::MatrixXd> AYawTorque = m_A.bottomRows(yawTorqueConstraints);
+    AYawTorque.row(0) << -halfRectangleWidth - centerY, -halfRectangleLength + centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        staticFrictionCoefficient, staticFrictionCoefficient, -1;
+
+    AYawTorque.row(1) << -halfRectangleWidth - centerY, halfRectangleLength + centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        staticFrictionCoefficient, -staticFrictionCoefficient, -1;
+
+    AYawTorque.row(2) << halfRectangleWidth - centerY, -halfRectangleLength + centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        -staticFrictionCoefficient, staticFrictionCoefficient, -1;
+
+    AYawTorque.row(3) << halfRectangleWidth - centerY, halfRectangleLength + centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        -staticFrictionCoefficient, -staticFrictionCoefficient, -1;
+
+    AYawTorque.row(4) << halfRectangleWidth + centerY, halfRectangleLength - centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        staticFrictionCoefficient, staticFrictionCoefficient, 1;
+
+    AYawTorque.row(5) << halfRectangleWidth + centerY, -halfRectangleLength - centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        staticFrictionCoefficient, -staticFrictionCoefficient, 1;
+
+    AYawTorque.row(6) << -halfRectangleWidth + centerY, halfRectangleLength - centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        -staticFrictionCoefficient, staticFrictionCoefficient, 1;
+
+    AYawTorque.row(7) << -halfRectangleWidth + centerY, -halfRectangleLength - centerX,
+        -(halfRectangleWidth + halfRectangleLength) * staticFrictionCoefficient,
+        -staticFrictionCoefficient, -staticFrictionCoefficient, 1;
+
+    m_b.resize(m_A.rows());
+    m_b.head(forceCone.getB().size()) = forceCone.getB();
+    m_b.tail(torqueConstraints).setZero();
+
+    m_isIntialized = true;
+
+    return true;
+}
+
+Eigen::Ref<const Eigen::MatrixXd> ContactWrenchCone::getA() const
+{
+    constexpr auto error = "[ContactWrenchCone::getA] Please initialize the class before.";
+
+    if (!m_isIntialized)
+    {
+        log()->warn(error);
+        assert(m_isIntialized && error);
+    }
+
+    return m_A;
+}
+
+Eigen::Ref<const Eigen::VectorXd> ContactWrenchCone::getB() const
+{
+    constexpr auto error = "[ContactWrenchCone::getB] Please initialize the class before.";
+    if (!m_isIntialized)
+    {
+        log()->warn(error);
+        assert(m_isIntialized && error);
+    }
+
+    return m_b;
+}

--- a/src/Math/src/ContactWrenchCone.cpp
+++ b/src/Math/src/ContactWrenchCone.cpp
@@ -115,7 +115,7 @@ bool ContactWrenchCone::initialize(std::weak_ptr<ParametersHandler::IParametersH
         -staticFrictionCoefficient, -staticFrictionCoefficient, 1;
 
     // AYawTorque expects a wrench expressed in the center of the contact surface. The following
-    // adjoin transform brings the wrench expressed in the frame attached to the contact surface in
+    // adjoint transform brings the wrench expressed in the frame attached to the contact surface in
     // the center of the surface. The orientation of the two frames is identical and the translation
     // is given by the 3d vector named center.
     Eigen::Matrix<double, wrenchSize, wrenchSize> adjointTransform

--- a/src/Math/tests/CMakeLists.txt
+++ b/src/Math/tests/CMakeLists.txt
@@ -9,8 +9,8 @@ add_bipedal_test(
   LINKS BipedalLocomotion::Math)
 
 add_bipedal_test(
-  NAME LinearizedFrictionConeTest
-  SOURCES LinearizedFrictionConeTest.cpp
+  NAME FrictionCones
+  SOURCES FrictionConesTest.cpp
   LINKS BipedalLocomotion::Math)
 
 add_bipedal_test(

--- a/src/Math/tests/FrictionConesTest.cpp
+++ b/src/Math/tests/FrictionConesTest.cpp
@@ -8,8 +8,9 @@
 // Catch2
 #include <catch2/catch.hpp>
 
-#include <BipedalLocomotion/Math/LinearizedFrictionCone.h>
 #include <BipedalLocomotion/Math/ContactWrenchCone.h>
+#include <BipedalLocomotion/Math/LinearizedFrictionCone.h>
+#include <BipedalLocomotion/Math/Wrench.h>
 #include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
 
 using namespace BipedalLocomotion::Math;
@@ -54,41 +55,94 @@ TEST_CASE("Contact wrench Cone")
     ContactWrenchCone cone;
     REQUIRE(cone.initialize(params));
 
-    // test the solution
-    REQUIRE(cone.getB().isApprox(Eigen::VectorXd::Zero(8 + 12)));
+    SECTION("Check matrix and vector")
+    {
+        // test the solution
+        REQUIRE(cone.getB().isApprox(Eigen::VectorXd::Zero(8 + 12)));
 
+        Eigen::MatrixXd forceConstraintSolution(8, 3);
+        forceConstraintSolution << 2.4142,  1.0000, -0.7243,
+                                   0.4142,  1.0000, -0.3000,
+                                  -0.4142,  1.0000, -0.3000,
+                                  -2.4142,  1.0000, -0.7243,
+                                  -2.4142, -1.0000, -0.7243,
+                                  -0.4142, -1.0000, -0.3000,
+                                   0.4142, -1.0000, -0.3000,
+                                   2.4142, -1.0000, -0.7243;
 
-    Eigen::MatrixXd forceConstraintSolution(8, 3);
-    forceConstraintSolution << 2.4142,  1.0000, -0.7243,
-                               0.4142,  1.0000, -0.3000,
-                              -0.4142,  1.0000, -0.3000,
-                              -2.4142,  1.0000, -0.7243,
-                              -2.4142, -1.0000, -0.7243,
-                              -0.4142, -1.0000, -0.3000,
-                               0.4142, -1.0000, -0.3000,
-                               2.4142, -1.0000, -0.7243;
+        constexpr double tolerance = 1e-4;
+        REQUIRE(forceConstraintSolution.isApprox(cone.getA().topLeftCorner<8, 3>(), tolerance));
+        REQUIRE(cone.getA().topRightCorner<8, 3>().isZero(tolerance));
 
-    constexpr double tolerance = 1e-4;
-    REQUIRE(forceConstraintSolution.isApprox(cone.getA().topLeftCorner<8, 3>(), tolerance));
-    REQUIRE(cone.getA().topRightCorner<8, 3>().isZero(tolerance));
+        Eigen::MatrixXd frictionConeConstraint(4, 6);
+        frictionConeConstraint << 0, 0,  limitsY[0], -1,  0, 0,
+                                  0, 0, -limitsY[1],  1,  0, 0,
+                                  0, 0,  limitsX[0],  0,  1, 0,
+                                  0, 0, -limitsX[1],  0, -1, 0;
 
-    Eigen::MatrixXd frictionConeConstraint(4, 6);
-    frictionConeConstraint << 0, 0,  limitsY[0], -1,  0, 0,
-                              0, 0, -limitsY[1],  1,  0, 0,
-                              0, 0,  limitsX[0],  0,  1, 0,
-                              0, 0, -limitsX[1],  0, -1, 0;
+        REQUIRE(cone.getA().middleRows(8, 4).isApprox(frictionConeConstraint, tolerance));
 
-    REQUIRE(cone.getA().middleRows(8, 4).isApprox(frictionConeConstraint, tolerance));
+        Eigen::MatrixXd yawTorqueConstriantMatlab(8,6);
+        yawTorqueConstriantMatlab << -0.01, -0.05, -0.018,  0.300,  0.300, -1.0000,
+                                     -0.01,  0.10, -0.033,  0.300, -0.300, -1.0000,
+                                      0.02, -0.05, -0.021, -0.300,  0.300, -1.0000,
+                                      0.02,  0.10, -0.036, -0.300, -0.300, -1.0000,
+                                      0.01,  0.05, -0.018,  0.300,  0.300,  1.0000,
+                                      0.01, -0.10, -0.033,  0.300, -0.300,  1.0000,
+                                     -0.02,  0.05, -0.021, -0.300,  0.300,  1.0000,
+                                     -0.02, -0.10, -0.036, -0.300, -0.300,  1.0000;
 
-    Eigen::MatrixXd yawTorqueConstriantMatlab(8,6);
-    yawTorqueConstriantMatlab << -0.01, -0.05, -0.018,  0.300,  0.300, -1.0000,
-                                 -0.01,  0.10, -0.033,  0.300, -0.300, -1.0000,
-                                  0.02, -0.05, -0.021, -0.300,  0.300, -1.0000,
-                                  0.02,  0.10, -0.036, -0.300, -0.300, -1.0000,
-                                  0.01,  0.05, -0.018,  0.300,  0.300,  1.0000,
-                                  0.01, -0.10, -0.033,  0.300, -0.300,  1.0000,
-                                 -0.02,  0.05, -0.021, -0.300,  0.300,  1.0000,
-                                 -0.02, -0.10, -0.036, -0.300, -0.300,  1.0000;
+        REQUIRE(cone.getA().bottomRows(8).isApprox(yawTorqueConstriantMatlab, tolerance));
+    }
 
-    REQUIRE(cone.getA().bottomRows(8).isApprox(yawTorqueConstriantMatlab, tolerance));
+    SECTION("Feasible wrench")
+    {
+        constexpr double forceZ = 100; // normal force in Newton
+
+        // the CoP is feasible since it is inside the rectangular foot.
+        Eigen::Vector2d CoP;
+        CoP << 0.01, -0.01;
+        constexpr double scalingTangentialForce = 0.01;
+
+        const double forceX = forceZ * scalingTangentialForce;
+        const double forceY = -forceZ * scalingTangentialForce;
+        const double torqueX = forceZ * CoP(1);
+        const double torqueY = -forceZ * CoP(0);
+        const double torqueZ = 0;
+
+        BipedalLocomotion::Math::Wrenchd wrench;
+        wrench << forceX, forceY, forceZ, torqueX, torqueY, torqueZ;
+
+        // Check feasibility
+        // Ax - b <= 0
+        Eigen::VectorXd constraintValue = -cone.getB();
+        constraintValue.noalias() += cone.getA() * wrench;
+        REQUIRE((constraintValue.array() < 0.0).all());
+    }
+
+    SECTION("Unfeasible wrench")
+    {
+        constexpr double forceZ = 100; // normal force in Newton
+
+        // The following CoP is outside the rectangular foot. So it is unfeasible.
+        Eigen::Vector2d CoP;
+        CoP << 0.2, -0.4;
+
+        // The following
+        constexpr double scalingTangentialForce = 0.4;
+        const double forceX = forceZ * scalingTangentialForce;
+        const double forceY = -forceZ * scalingTangentialForce;
+        const double torqueX = forceZ * CoP(1);
+        const double torqueY = -forceZ * CoP(0);
+        const double torqueZ = 0;
+
+        BipedalLocomotion::Math::Wrenchd wrench;
+        wrench << forceX, forceY, forceZ, torqueX, torqueY, torqueZ;
+
+        // Check unfeasibility
+        // Ax - b > 0
+        Eigen::VectorXd constraintValue = -cone.getB();
+        constraintValue.noalias() += cone.getA() * wrench;
+        REQUIRE((constraintValue.array() > 0.0).any());
+    }
 }

--- a/src/Math/tests/FrictionConesTest.cpp
+++ b/src/Math/tests/FrictionConesTest.cpp
@@ -1,5 +1,5 @@
 /**
- * @file LinearizedFrictionConeTest.cpp
+ * @file FrictionConesTest.cpp
  * @authors Giulio Romualdi
  * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
  * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.

--- a/src/Math/tests/FrictionConesTest.cpp
+++ b/src/Math/tests/FrictionConesTest.cpp
@@ -44,18 +44,18 @@ TEST_CASE("Linearized Friction Cone")
 TEST_CASE("Contact wrench Cone")
 {
     auto params = std::make_shared<StdImplementation>();
+    std::vector<double>limitsX{-0.05, 0.1};
+    std::vector<double>limitsY{-0.02, 0.01};
     params->setParameter("number_of_slices", 2);
     params->setParameter("static_friction_coefficient", 0.3);
-    params->setParameter("foot_limits_x", std::vector<double>{-0.05, 0.1});
-    params->setParameter("foot_limits_y", std::vector<double>{-0.05, 0.05});
+    params->setParameter("foot_limits_x", limitsX);
+    params->setParameter("foot_limits_y", limitsY);
 
     ContactWrenchCone cone;
     REQUIRE(cone.initialize(params));
 
     // test the solution
     REQUIRE(cone.getB().isApprox(Eigen::VectorXd::Zero(8 + 12)));
-
-    std::cerr << cone.getA() << std::endl;
 
 
     Eigen::MatrixXd forceConstraintSolution(8, 3);
@@ -71,4 +71,24 @@ TEST_CASE("Contact wrench Cone")
     constexpr double tolerance = 1e-4;
     REQUIRE(forceConstraintSolution.isApprox(cone.getA().topLeftCorner<8, 3>(), tolerance));
     REQUIRE(cone.getA().topRightCorner<8, 3>().isZero(tolerance));
+
+    Eigen::MatrixXd frictionConeConstraint(4, 6);
+    frictionConeConstraint << 0, 0,  limitsY[0], -1,  0, 0,
+                              0, 0, -limitsY[1],  1,  0, 0,
+                              0, 0,  limitsX[0],  0,  1, 0,
+                              0, 0, -limitsX[1],  0, -1, 0;
+
+    REQUIRE(cone.getA().middleRows(8, 4).isApprox(frictionConeConstraint, tolerance));
+
+    Eigen::MatrixXd yawTorqueConstriantMatlab(8,6);
+    yawTorqueConstriantMatlab << -0.01, -0.05, -0.018,  0.300,  0.300, -1.0000,
+                                 -0.01,  0.10, -0.033,  0.300, -0.300, -1.0000,
+                                  0.02, -0.05, -0.021, -0.300,  0.300, -1.0000,
+                                  0.02,  0.10, -0.036, -0.300, -0.300, -1.0000,
+                                  0.01,  0.05, -0.018,  0.300,  0.300,  1.0000,
+                                  0.01, -0.10, -0.033,  0.300, -0.300,  1.0000,
+                                 -0.02,  0.05, -0.021, -0.300,  0.300,  1.0000,
+                                 -0.02, -0.10, -0.036, -0.300, -0.300,  1.0000;
+
+    REQUIRE(cone.getA().bottomRows(8).isApprox(yawTorqueConstriantMatlab, tolerance));
 }

--- a/src/Math/tests/FrictionConesTest.cpp
+++ b/src/Math/tests/FrictionConesTest.cpp
@@ -9,6 +9,7 @@
 #include <catch2/catch.hpp>
 
 #include <BipedalLocomotion/Math/LinearizedFrictionCone.h>
+#include <BipedalLocomotion/Math/ContactWrenchCone.h>
 #include <BipedalLocomotion/ParametersHandler/StdImplementation.h>
 
 using namespace BipedalLocomotion::Math;
@@ -37,4 +38,37 @@ TEST_CASE("Linearized Friction Cone")
 
     constexpr double tolerance = 1e-4;
     REQUIRE(matlabSolution.isApprox(cone.getA(), tolerance));
+}
+
+
+TEST_CASE("Contact wrench Cone")
+{
+    auto params = std::make_shared<StdImplementation>();
+    params->setParameter("number_of_slices", 2);
+    params->setParameter("static_friction_coefficient", 0.3);
+    params->setParameter("foot_limits_x", std::vector<double>{-0.05, 0.1});
+    params->setParameter("foot_limits_y", std::vector<double>{-0.05, 0.05});
+
+    ContactWrenchCone cone;
+    REQUIRE(cone.initialize(params));
+
+    // test the solution
+    REQUIRE(cone.getB().isApprox(Eigen::VectorXd::Zero(8 + 12)));
+
+    std::cerr << cone.getA() << std::endl;
+
+
+    Eigen::MatrixXd forceConstraintSolution(8, 3);
+    forceConstraintSolution << 2.4142,  1.0000, -0.7243,
+                               0.4142,  1.0000, -0.3000,
+                              -0.4142,  1.0000, -0.3000,
+                              -2.4142,  1.0000, -0.7243,
+                              -2.4142, -1.0000, -0.7243,
+                              -0.4142, -1.0000, -0.3000,
+                               0.4142, -1.0000, -0.3000,
+                               2.4142, -1.0000, -0.7243;
+
+    constexpr double tolerance = 1e-4;
+    REQUIRE(forceConstraintSolution.isApprox(cone.getA().topLeftCorner<8, 3>(), tolerance));
+    REQUIRE(cone.getA().topRightCorner<8, 3>().isZero(tolerance));
 }


### PR DESCRIPTION
The math is taken from [Stability of surface contacts for humanoid robots: Closed-form formulae of the Contact Wrench Cone for rectangular support areas](https://ieeexplore.ieee.org/document/7139910)

The PR is required to implement the Feasibility wrench constraint in TSID

cc @Giulero 