### PR TITLE
conda CI: Use CasADi>=3.5.5 to avoid that an old CasADi without ipopt is picked by the conda solver

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull casadi cppad spdlog catch2 nlohmann_json
+        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull casadi>=3.5.5 cppad spdlog catch2 nlohmann_json
 
     - name: Dependencies [manif - Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull casadi>=3.5.5 cppad spdlog catch2 nlohmann_json
+        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog catch2 nlohmann_json
 
     - name: Dependencies [manif - Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Local fix for https://github.com/dic-iit/bipedal-locomotion-framework/issues/353 . I will do the proper fix at the casadi-feedstock level, but for the time being this should work fine.