### PR TITLE
Use manif provided by conda-forge in CondaForge CI

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -37,22 +37,12 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog catch2 nlohmann_json
+        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog catch2 nlohmann_json manif
 
-    - name: Dependencies [manif - Linux&macOS]
+    - name: Dependencies [tomlplusplus - Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        # manif
-        cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/artivis/manif.git
-        cd manif
-        git checkout ${manif_TAG}
-        mkdir build
-        cd build
-        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
-        cmake --build . --config ${{ matrix.build_type }} --target install
-
         # tomlplusplus
         cd ${GITHUB_WORKSPACE}
         git clone -b ${tomlplusplus_TAG} https://github.com/marzer/tomlplusplus
@@ -62,22 +52,10 @@ jobs:
         cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
-    - name: Dependencies [manif - windows]
+    - name: Dependencies [tomlplusplus - windows]
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        # manif
-        cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/artivis/manif.git
-        cd manif
-        git checkout ${manif_TAG}
-        mkdir build
-        cd build
-        cmake -G"Visual Studio 16 2019" \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library ..
-        cmake --build . --config ${{ matrix.build_type }} --target install
-
         # tomlplusplus
         cd ${GITHUB_WORKSPACE}
         git clone -b ${tomlplusplus_TAG} https://github.com/marzer/tomlplusplus


### PR DESCRIPTION
With this PR we start using manif provided by conda-forge instead of the one installed from sources.

The next step is to remove also toml-plus-plus but this is currently blocked by https://github.com/conda-forge/staged-recipes/pull/14921