### PR TITLE
Stream motor state, joint torques and PID state in SensorBridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Implement `ContactWrenchCone` class in Math component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/352)
 - Implement `skew` function in Math component (https://github.com/dic-iit/bipedal-locomotion-framework/pull/352)
 - Implement `QPTSID` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/366)
+- Implement motor pwm, motor encoders, wbd joint torque estimates, pid reading in `YarpSensorBridge`(https://github.com/dic-iit/bipedal-locomotion-framework/pull/359).
 
 ### Changed
 - Add common Python files to gitignore (https://github.com/dic-iit/bipedal-locomotion-framework/pull/338)

--- a/bindings/python/RobotInterface/src/SensorBridge.cpp
+++ b/bindings/python/RobotInterface/src/SensorBridge.cpp
@@ -32,7 +32,7 @@ void CreateISensorBridge(pybind11::module& module)
 
     py::class_<SensorBridgeOptions>(module, "SensorBridgeOptions")
         .def(py::init())
-        .def_readwrite("is_kinematics_enabled", &SensorBridgeOptions::isKinematicsEnabled)
+        .def_readwrite("is_kinematics_enabled", &SensorBridgeOptions::isJointSensorsEnabled)
         .def_readwrite("is_imu_enabled", &SensorBridgeOptions::isIMUEnabled)
         .def_readwrite("is_linear_accelerometer_enabled",
                        &SensorBridgeOptions::isLinearAccelerometerEnabled)

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -212,11 +212,9 @@ public:
      * Get all joints' positions in radians
      * @param[out] parameter all joints' position in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "jointPositions" to this method
-     *
      * @return true/false in case of success/failure
      */
     bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
@@ -237,11 +235,9 @@ public:
      * Get all joints' velocities in rad/s
      * @param[out] parameter all joints' velocities in radians per second
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "jointVelocties" to this method
-     *
      * @return true/false in case of success/failure
      */
     bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
@@ -356,11 +352,9 @@ public:
      * Get all motors' currents in ampere
      * @param[out] motorCurrents all motors' current in ampere
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "motorCurrents" to this method
-     *
      * @return true/false in case of success/failure
      */
     bool getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
@@ -381,20 +375,18 @@ public:
      * Get all motors' PWMs
      * @param[out] motorPWMs all motors' PWM in ampere
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
-     * This means that the user must pass a resized argument "motorPWMs" to this method
-     *
+     * This means that the user must pass a resized argument "motorPWMs" to this methodW
      * @return true/false in case of success/failure
      */
     bool getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,
                            OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
-     * Get motor torque in NewtonMeter
+     * Get motor torque in Nm
      * @param[in] jointName name of the joint
-     * @param[out] jointTorque motor torque in NewtonMeter
+     * @param[out] jointTorque motor torque in Nm
      * @param[out] receiveTimeInSeconds time at which the measurement was received
      * @return true/false in case of success/failure
      */
@@ -403,14 +395,12 @@ public:
                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
-     * Get all motors' torques in NewtonMeter
-     * @param[out] jointTorques all motors' torque in NewtonMeter
-     * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
+     * Get all motors' torques in Nm
+     * @param[out] jointTorques all motors' torque in Nm
+     * @param[out] receiveTimeInSeconds time at which the measurement was receivedW
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "jointTorques" to this method
-     *
      * @return true/false in case of success/failure
      */
     bool getJointTorques(Eigen::Ref<Eigen::VectorXd> jointTorques,
@@ -431,11 +421,9 @@ public:
      * Get all pid positions in rad
      * @param[out] pidPositions all pid positions in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
-     * This means that the user must pass a resized argument "pidPositions" to this method
-     *
+     * This means that the user must pass a resized argument "pidPositions" to this methodW
      * @return true/false in case of success/failure
      */
     virtual bool getPidPositions(Eigen::Ref<Eigen::VectorXd> pidPositions,
@@ -456,11 +444,9 @@ public:
      * Get all pid position errors in rad
      * @param[out] pidPositionErrors all pid position errors in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "pidPositionErrors" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getPidPositionErrors(Eigen::Ref<Eigen::VectorXd> pidPositionErrors,
@@ -481,11 +467,9 @@ public:
      * Get all motors' positions in rad
      * @param[out] parameter all motors' position in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "motorPositions" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getMotorPositions(Eigen::Ref<Eigen::VectorXd> motorPositions,
@@ -506,11 +490,9 @@ public:
      * Get all motors' velocities in rad/s
      * @param[out] parameter all motors' velocities in radians per second
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "motorVelocties" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getMotorVelocities(Eigen::Ref<Eigen::VectorXd> motorVelocties,

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -375,7 +375,7 @@ public:
      * @param[out] receiveTimeInSeconds time at which the measurement was received
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
-     * This means that the user must pass a resized argument "motorPWMs" to this methodW
+     * This means that the user must pass a resized argument "motorPWMs" to this method
      * @return true/false in case of success/failure
      */
     bool getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -361,6 +361,31 @@ public:
     bool getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
                            OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
+    /**
+     * Get motor torque in NewtonMeter
+     * @param[in] jointName name of the joint
+     * @param[out] motorTorque motor current in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getMotorTorque(const std::string& jointName,
+                          double& motorTorque,
+                          OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get all motors' torques in NewtonMeter
+     * @param[out] motorTorques all motors' torque in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "motorTorques" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getMotorTorques(Eigen::Ref<Eigen::VectorXd> motorTorques,
+                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
 private:
     /** Private implementation */
     struct Impl;

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -60,8 +60,6 @@ namespace RobotInterface
  * |                            |stream_pids                      | boolean           |Flag to activate the attachment to remapped control boards for pids reading      |
  * |                            |stream_motor_states              | boolean           |Flag to activate the attachment to remapped control boards for motor states reading      |
  * |                            |stream_motor_PWM                 | boolean           |Flag to activate the attachment to remapped control boards for PWM reading      |
- * |                            |stream_joint_torques             | boolean           |Flag to activate the attachment to remapped control boards for joint torques reading      |
- * |                            |stream_current_sensors           | boolean           |Flag to activate the attachment to remapped control boards for current sensors reading      |
  * |RemoteControlBoardRemapper  |                                 |                   |Expects only one remapped remotecontrolboard device attached to it, if there multiple remote control boards, then  use a remapper to create a single remotecontrolboard |
  * |                            |joints_list                      | vector of strings |This parameter is **optional**. The joints list used to open the remote control board remapper. If the list is not passed, the order of the joint stored in the PolyDriver is used       |
  * |InertialSensors             |                                 |                   |Expects IMU to be opened as genericSensorClient devices communicating through the inertial server and other inertials as a part multiple analog sensors remapper ("multipleanalogsensorsremapper") |

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridge.h
@@ -52,11 +52,16 @@ namespace RobotInterface
  * |     Group                  |         Parameter               | Type              |                   Description                   |
  * |:--------------------------:|:-------------------------------:|:-----------------:|:---------------------------------------------- :|
  * |                            |check_for_nan                    | boolean           |flag to activate checking for NANs in the incoming measurement buffers, not applicable for images|
- * |                            |stream_joint_states              | boolean           |Flag to activate the attachment to IMU sensor devices       |
+ * |                            |stream_joint_states              | boolean           |Flag to activate the attachment to remapped control boards for joint states reading     |
  * |                            |stream_inertials                 | boolean           |Flag to activate the attachment to IMU sensor devices       |
  * |                            |stream_cartesian_wrenches        | boolean           |Flag to activate the attachment to Cartesian wrench related devices       |
  * |                            |stream_forcetorque_sensors       | boolean           |Flag to activate the attachment to six axis FT sensor devices       |
  * |                            |stream_cameras                   | boolean           |Flag to activate the attachment to Cameras devices       |
+ * |                            |stream_pids                      | boolean           |Flag to activate the attachment to remapped control boards for pids reading      |
+ * |                            |stream_motor_states              | boolean           |Flag to activate the attachment to remapped control boards for motor states reading      |
+ * |                            |stream_motor_PWM                 | boolean           |Flag to activate the attachment to remapped control boards for PWM reading      |
+ * |                            |stream_joint_torques             | boolean           |Flag to activate the attachment to remapped control boards for joint torques reading      |
+ * |                            |stream_current_sensors           | boolean           |Flag to activate the attachment to remapped control boards for current sensors reading      |
  * |RemoteControlBoardRemapper  |                                 |                   |Expects only one remapped remotecontrolboard device attached to it, if there multiple remote control boards, then  use a remapper to create a single remotecontrolboard |
  * |                            |joints_list                      | vector of strings |This parameter is **optional**. The joints list used to open the remote control board remapper. If the list is not passed, the order of the joint stored in the PolyDriver is used       |
  * |InertialSensors             |                                 |                   |Expects IMU to be opened as genericSensorClient devices communicating through the inertial server and other inertials as a part multiple analog sensors remapper ("multipleanalogsensorsremapper") |
@@ -362,29 +367,154 @@ public:
                            OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
-     * Get motor torque in NewtonMeter
+     * Get motor PWM
      * @param[in] jointName name of the joint
-     * @param[out] motorTorque motor current in NewtonMeter
+     * @param[out] motorPWM motor PWM
      * @param[out] receiveTimeInSeconds time at which the measurement was received
      * @return true/false in case of success/failure
      */
-    bool getMotorTorque(const std::string& jointName,
-                          double& motorTorque,
+    bool getMotorPWM(const std::string& jointName,
+                          double& motorPWM,
                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
     /**
-     * Get all motors' torques in NewtonMeter
-     * @param[out] motorTorques all motors' torque in NewtonMeter
+     * Get all motors' PWMs
+     * @param[out] motorPWMs all motors' PWM in ampere
      * @param[out] receiveTimeInSeconds time at which the measurement was received
      *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
-     * This means that the user must pass a resized argument "motorTorques" to this method
+     * This means that the user must pass a resized argument "motorPWMs" to this method
      *
      * @return true/false in case of success/failure
      */
-    bool getMotorTorques(Eigen::Ref<Eigen::VectorXd> motorTorques,
+    bool getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,
                            OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get motor torque in NewtonMeter
+     * @param[in] jointName name of the joint
+     * @param[out] jointTorque motor torque in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    bool getJointTorque(const std::string& jointName,
+                          double& jointTorque,
+                          OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get all motors' torques in NewtonMeter
+     * @param[out] jointTorques all motors' torque in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "jointTorques" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    bool getJointTorques(Eigen::Ref<Eigen::VectorXd> jointTorques,
+                           OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get pid position in rad
+     * @param[in] jointName name of the joint
+     * @param[out] pidPosition pid position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPosition(const std::string& jointName,
+                                  double& pidPosition,
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get all pid positions in rad
+     * @param[out] pidPositions all pid positions in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "pidPositions" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPositions(Eigen::Ref<Eigen::VectorXd> pidPositions,
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get pid position error in rad
+     * @param[in] jointName name of the joint
+     * @param[out] pidPositionError pid position error in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPositionError(const std::string& jointName,
+                                  double& pidPositionError,
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get all pid position errors in rad
+     * @param[out] pidPositionErrors all pid position errors in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "pidPositionErrors" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPositionErrors(Eigen::Ref<Eigen::VectorXd> pidPositionErrors,
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get motor position in rad
+     * @param[in] jointName name of the joint
+     * @param[out] motorPosition motor position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorPosition(const std::string& jointName,
+                                  double& motorPosition,
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get all motors' positions in rad
+     * @param[out] parameter all motors' position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "motorPositions" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorPositions(Eigen::Ref<Eigen::VectorXd> motorPositions,
+                                   OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get motor velocity in rad/s
+     * @param[in] jointName name of the joint
+     * @param[out] motorVelocity motor velocity in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorVelocity(const std::string& jointName,
+                                  double& motorVelocity,
+                                  OptionalDoubleRef receiveTimeInSeconds = {}) final;
+
+    /**
+     * Get all motors' velocities in rad/s
+     * @param[out] parameter all motors' velocities in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "motorVelocties" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorVelocities(Eigen::Ref<Eigen::VectorXd> motorVelocties,
+                                    OptionalDoubleRef receiveTimeInSeconds = {}) final;
 
 private:
     /** Private implementation */

--- a/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
+++ b/src/RobotInterface/YarpImplementation/include/BipedalLocomotion/RobotInterface/YarpSensorBridgeImpl.h
@@ -871,11 +871,21 @@ struct YarpSensorBridge::Impl
         {
             ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.axis);
             ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.encoders);
-            ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.currsensors);
-            ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.amp);
-            ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.motorEncoders);
             ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.torques);
-            ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.pids);
+            if (metaData.bridgeOptions.isPWMControlEnabled)
+            {
+                ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.amp);
+            }
+            if (metaData.bridgeOptions.isMotorSensorsEnabled)
+            {
+                ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.motorEncoders);
+                ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.currsensors);
+            }
+            if (metaData.bridgeOptions.isPIDsEnabled)
+            {
+                ok = ok && devList[devIdx]->poly->view(controlBoardRemapperInterfaces.pids);
+            }
+
             if (ok)
             {
                 break;
@@ -904,6 +914,7 @@ struct YarpSensorBridge::Impl
      */
     void resetControlBoardBuffers()
     {
+        // default joint variables
         // firstly resize all the controlboard data buffers
         controlBoardRemapperMeasures.remappedJointPermutationMatrix.resize(
             metaData.bridgeOptions.nrJoints);
@@ -911,40 +922,64 @@ struct YarpSensorBridge::Impl
 
         controlBoardRemapperMeasures.jointPositions.resize(metaData.bridgeOptions.nrJoints);
         controlBoardRemapperMeasures.jointVelocities.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorCurrents.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorPWMs.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorPositions.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorVelocities.resize(metaData.bridgeOptions.nrJoints);
         controlBoardRemapperMeasures.jointTorques.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.pidPositions.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.pidPositionErrors.resize(metaData.bridgeOptions.nrJoints);
 
         controlBoardRemapperMeasures.jointPositionsUnordered.resize(
             metaData.bridgeOptions.nrJoints);
         controlBoardRemapperMeasures.jointVelocitiesUnordered.resize(
             metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorCurrentsUnordered.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorPWMsUnordered.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorPositionsUnordered.resize(
-            metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.motorVelocitiesUnordered.resize(
-            metaData.bridgeOptions.nrJoints);
         controlBoardRemapperMeasures.jointTorquesUnordered.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.pidPositionsUnordered.resize(metaData.bridgeOptions.nrJoints);
-        controlBoardRemapperMeasures.pidPositionErrorsUnordered.resize(
-            metaData.bridgeOptions.nrJoints);
 
         // zero buffers
         controlBoardRemapperMeasures.remappedJointPermutationMatrix.setIdentity();
         controlBoardRemapperMeasures.jointPositions.setZero();
         controlBoardRemapperMeasures.jointVelocities.setZero();
-        controlBoardRemapperMeasures.motorCurrents.setZero();
-        controlBoardRemapperMeasures.motorPWMs.setZero();
-        controlBoardRemapperMeasures.motorPositions.setZero();
-        controlBoardRemapperMeasures.motorVelocities.setZero();
         controlBoardRemapperMeasures.jointTorques.setZero();
-        controlBoardRemapperMeasures.pidPositions.setZero();
-        controlBoardRemapperMeasures.pidPositionErrors.setZero();
+
+        if (metaData.bridgeOptions.isPWMControlEnabled)
+        {
+            // firstly resize all the controlboard data buffers
+            controlBoardRemapperMeasures.motorPWMs.resize(metaData.bridgeOptions.nrJoints);
+
+            controlBoardRemapperMeasures.motorPWMsUnordered.resize(metaData.bridgeOptions.nrJoints);
+
+            // zero buffers
+            controlBoardRemapperMeasures.motorPWMs.setZero();
+        }
+
+        if (metaData.bridgeOptions.isMotorSensorsEnabled)
+        {
+            // firstly resize all the controlboard data buffers
+            controlBoardRemapperMeasures.motorPositions.resize(metaData.bridgeOptions.nrJoints);
+            controlBoardRemapperMeasures.motorVelocities.resize(metaData.bridgeOptions.nrJoints);
+            controlBoardRemapperMeasures.motorCurrents.resize(metaData.bridgeOptions.nrJoints);
+
+            controlBoardRemapperMeasures.motorPositionsUnordered.resize(
+                metaData.bridgeOptions.nrJoints);
+            controlBoardRemapperMeasures.motorVelocitiesUnordered.resize(
+                metaData.bridgeOptions.nrJoints);
+            controlBoardRemapperMeasures.motorCurrentsUnordered.resize(metaData.bridgeOptions.nrJoints);
+
+            // zero buffers
+            controlBoardRemapperMeasures.motorPositions.setZero();
+            controlBoardRemapperMeasures.motorVelocities.setZero();
+            controlBoardRemapperMeasures.motorCurrents.setZero();
+        }
+
+        if (metaData.bridgeOptions.isPIDsEnabled)
+        {
+            // firstly resize all the controlboard data buffers
+            controlBoardRemapperMeasures.pidPositions.resize(metaData.bridgeOptions.nrJoints);
+            controlBoardRemapperMeasures.pidPositionErrors.resize(metaData.bridgeOptions.nrJoints);
+
+            controlBoardRemapperMeasures.pidPositionsUnordered.resize(metaData.bridgeOptions.nrJoints);
+            controlBoardRemapperMeasures.pidPositionErrorsUnordered.resize(
+                metaData.bridgeOptions.nrJoints);
+
+            // zero buffers
+            controlBoardRemapperMeasures.pidPositions.setZero();
+            controlBoardRemapperMeasures.pidPositionErrors.setZero();
+        }
     }
 
     /**
@@ -1315,8 +1350,9 @@ struct YarpSensorBridge::Impl
              && controlBoardRemapperInterfaces.encoders->getEncoderSpeeds(
                  controlBoardRemapperMeasures.jointVelocitiesUnordered.data());
         ok = ok
-             && controlBoardRemapperInterfaces.currsensors->getCurrents(
-                 controlBoardRemapperMeasures.motorCurrentsUnordered.data());
+             && controlBoardRemapperInterfaces.torques->getTorques(
+                 controlBoardRemapperMeasures.jointTorquesUnordered.data());
+
         if (!ok)
         {
             log()->error("{} Unable to read from encoders interface, use previous measurement.",
@@ -1340,9 +1376,9 @@ struct YarpSensorBridge::Impl
                 return false;
             }
 
-            if (nanExistsInVec(controlBoardRemapperMeasures.motorCurrentsUnordered,
+            if (nanExistsInVec(controlBoardRemapperMeasures.jointTorquesUnordered,
                                logPrefix,
-                               "current sensors"))
+                               "WBDJointTorques"))
             {
                 return false;
             }
@@ -1357,52 +1393,9 @@ struct YarpSensorBridge::Impl
             = controlBoardRemapperMeasures.remappedJointPermutationMatrix
               * controlBoardRemapperMeasures.jointVelocitiesUnordered * M_PI / 180;
 
-        controlBoardRemapperMeasures.motorCurrents.noalias()
+        controlBoardRemapperMeasures.jointTorques.noalias()
             = controlBoardRemapperMeasures.remappedJointPermutationMatrix
-              * controlBoardRemapperMeasures.motorCurrentsUnordered;
-
-        controlBoardRemapperMeasures.receivedTimeInSeconds = yarp::os::Time::now();
-
-        return true;
-    }
-
-    /**
-     * Read current sensor measurements
-     */
-    bool readAllCurrentSensors(bool checkForNan = false)
-    {
-        if (!metaData.bridgeOptions.isCurrentSensorsEnabled
-            || !metaData.bridgeOptions.isKinematicsEnabled)
-        {
-            // do nothing
-            return true;
-        }
-
-        constexpr auto logPrefix = "[YarpSensorBridge::Impl::readAllCurrentSensors]";
-        bool ok;
-        ok = controlBoardRemapperInterfaces.currsensors->getCurrents(
-            controlBoardRemapperMeasures.motorCurrentsUnordered.data());
-
-        if (!ok)
-        {
-            log()->error("{} Unable to read from currentsensors, use previous measurement.",
-                         logPrefix);
-            return false;
-        }
-
-        if (checkForNan)
-        {
-            if (nanExistsInVec(controlBoardRemapperMeasures.motorCurrentsUnordered,
-                               logPrefix,
-                               "CurrentSensors"))
-            {
-                return false;
-            }
-        }
-
-        controlBoardRemapperMeasures.motorCurrents.noalias()
-            = controlBoardRemapperMeasures.remappedJointPermutationMatrix
-              * controlBoardRemapperMeasures.motorCurrentsUnordered;
+              * controlBoardRemapperMeasures.jointTorquesUnordered;
 
         controlBoardRemapperMeasures.receivedTimeInSeconds = yarp::os::Time::now();
 
@@ -1412,16 +1405,16 @@ struct YarpSensorBridge::Impl
     /**
      * Read motor encoders measurements
      */
-    bool readAllMotorEncoders(bool checkForNan = false)
+    bool readAllMotorSensors(bool checkForNan = false)
     {
-        if (!metaData.bridgeOptions.isMotorEncodersEnabled
+        if (!metaData.bridgeOptions.isMotorSensorsEnabled
             || !metaData.bridgeOptions.isKinematicsEnabled)
         {
             // do nothing
             return true;
         }
 
-        constexpr auto logPrefix = "[YarpSensorBridge::Impl::readAllMotorEncoders]";
+        constexpr auto logPrefix = "[YarpSensorBridge::Impl::readAllMotorSensors]";
         bool ok{true};
         ok = ok
              && controlBoardRemapperInterfaces.motorEncoders->getMotorEncoders(
@@ -1429,6 +1422,9 @@ struct YarpSensorBridge::Impl
         ok = ok
              && controlBoardRemapperInterfaces.motorEncoders->getMotorEncoderSpeeds(
                  controlBoardRemapperMeasures.motorVelocitiesUnordered.data());
+        ok = ok
+             && controlBoardRemapperInterfaces.currsensors->getCurrents(
+            controlBoardRemapperMeasures.motorCurrentsUnordered.data());
 
         if (!ok)
         {
@@ -1439,9 +1435,23 @@ struct YarpSensorBridge::Impl
 
         if (checkForNan)
         {
+            if (nanExistsInVec(controlBoardRemapperMeasures.motorPositionsUnordered,
+                               logPrefix,
+                               "MotorEncodersPos"))
+            {
+                return false;
+            }
+
+            if (nanExistsInVec(controlBoardRemapperMeasures.motorVelocitiesUnordered,
+                               logPrefix,
+                               "MotorEncodersVel"))
+            {
+                return false;
+            }
+
             if (nanExistsInVec(controlBoardRemapperMeasures.motorCurrentsUnordered,
                                logPrefix,
-                               "MotorEncoders"))
+                               "CurrentSensors"))
             {
                 return false;
             }
@@ -1453,6 +1463,9 @@ struct YarpSensorBridge::Impl
         controlBoardRemapperMeasures.motorVelocities.noalias()
             = controlBoardRemapperMeasures.remappedJointPermutationMatrix
               * controlBoardRemapperMeasures.motorVelocitiesUnordered;
+        controlBoardRemapperMeasures.motorCurrents.noalias()
+            = controlBoardRemapperMeasures.remappedJointPermutationMatrix
+              * controlBoardRemapperMeasures.motorCurrentsUnordered;
 
         controlBoardRemapperMeasures.receivedTimeInSeconds = yarp::os::Time::now();
 
@@ -1498,49 +1511,6 @@ struct YarpSensorBridge::Impl
         controlBoardRemapperMeasures.motorPWMs.noalias()
             = controlBoardRemapperMeasures.remappedJointPermutationMatrix
               * controlBoardRemapperMeasures.motorPWMsUnordered;
-
-        controlBoardRemapperMeasures.receivedTimeInSeconds = yarp::os::Time::now();
-
-        return true;
-    }
-
-    /**
-     * Read joint torque estimates
-     */
-    bool readAllWBDJointTorques(bool checkForNan = false)
-    {
-        if (!metaData.bridgeOptions.isWBDEstimatesEnabled
-            || !metaData.bridgeOptions.isKinematicsEnabled)
-        {
-            // do nothing
-            return true;
-        }
-
-        constexpr auto logPrefix = "[YarpSensorBridge::Impl::readAllWBDJointTorques]";
-        bool ok;
-        ok = controlBoardRemapperInterfaces.torques->getTorques(
-            controlBoardRemapperMeasures.jointTorquesUnordered.data());
-
-        if (!ok)
-        {
-            log()->error("{} Unable to read from wholebodydynamics, use previous measurement.",
-                         logPrefix);
-            return false;
-        }
-
-        if (checkForNan)
-        {
-            if (nanExistsInVec(controlBoardRemapperMeasures.jointTorquesUnordered,
-                               logPrefix,
-                               "WBDJointTorques"))
-            {
-                return false;
-            }
-        }
-
-        controlBoardRemapperMeasures.jointTorques.noalias()
-            = controlBoardRemapperMeasures.remappedJointPermutationMatrix
-              * controlBoardRemapperMeasures.jointTorquesUnordered;
 
         controlBoardRemapperMeasures.receivedTimeInSeconds = yarp::os::Time::now();
 
@@ -1798,20 +1768,6 @@ struct YarpSensorBridge::Impl
                                         failedReads.end());
         }
 
-        if (!readAllCurrentSensors(checkForNAN))
-        {
-            failedReadAllSensors.insert(failedReadAllSensors.end(),
-                                        failedReads.begin(),
-                                        failedReads.end());
-        }
-
-        if (!readAllWBDJointTorques(checkForNAN))
-        {
-            failedReadAllSensors.insert(failedReadAllSensors.end(),
-                                        failedReads.begin(),
-                                        failedReads.end());
-        }
-
         if (!readAllPIDs(checkForNAN))
         {
             failedReadAllSensors.insert(failedReadAllSensors.end(),
@@ -1819,7 +1775,7 @@ struct YarpSensorBridge::Impl
                                         failedReads.end());
         }
 
-        if (!readAllMotorEncoders(checkForNAN))
+        if (!readAllMotorSensors(checkForNAN))
         {
             failedReadAllSensors.insert(failedReadAllSensors.end(),
                                         failedReads.begin(),

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -71,7 +71,7 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    &YarpSensorBridge::Impl::configureRemoteControlBoardRemapper,
                                    handler,
                                    m_pimpl->metaData,
-                                   m_pimpl->metaData.bridgeOptions.isMotorEncodersEnabled);
+                                   m_pimpl->metaData.bridgeOptions.isMotorSensorsEnabled);
     if (!ret)
     {
         log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
@@ -86,34 +86,6 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    handler,
                                    m_pimpl->metaData,
                                    m_pimpl->metaData.bridgeOptions.isPWMControlEnabled);
-    if (!ret)
-    {
-        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
-                    "YarpSensorBridge "
-                    "will not stream relevant measures.",
-                    logPrefix);
-    }
-
-    ret = m_pimpl->subConfigLoader("stream_joint_torques",
-                                   "WBDEstimates",
-                                   &YarpSensorBridge::Impl::configureRemoteControlBoardRemapper,
-                                   handler,
-                                   m_pimpl->metaData,
-                                   m_pimpl->metaData.bridgeOptions.isWBDEstimatesEnabled);
-    if (!ret)
-    {
-        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
-                    "YarpSensorBridge "
-                    "will not stream relevant measures.",
-                    logPrefix);
-    }
-
-    ret = m_pimpl->subConfigLoader("stream_current_sensors",
-                                   "Currents",
-                                   &YarpSensorBridge::Impl::configureRemoteControlBoardRemapper,
-                                   handler,
-                                   m_pimpl->metaData,
-                                   m_pimpl->metaData.bridgeOptions.isCurrentSensorsEnabled);
     if (!ret)
     {
         log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -475,3 +475,38 @@ bool YarpSensorBridge::getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrent
 
     return true;
 }
+
+bool YarpSensorBridge::getMotorTorque(const std::string& jointName,
+                                       double& motorTorque,
+                                       OptionalDoubleRef receiveTimeInSeconds)
+{
+    int idx;
+    if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
+    {
+        log()->error("[YarpSensorBridge::getMotorTorque] {} could not be found in the configured "
+                     "list of joints.",
+                     jointName);
+        return false;
+    }
+
+    motorTorque = m_pimpl->controlBoardRemapperMeasures.motorTorques[idx];
+
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    return true;
+}
+
+bool YarpSensorBridge::getMotorTorques(Eigen::Ref<Eigen::VectorXd> motorTorques,
+                                        OptionalDoubleRef receiveTimeInSeconds)
+{
+
+    motorTorques = m_pimpl->controlBoardRemapperMeasures.motorTorques;
+
+    if (receiveTimeInSeconds)
+        receiveTimeInSeconds.value().get()
+            = m_pimpl->controlBoardRemapperMeasures.receivedTimeInSeconds;
+
+    return true;
+}

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -60,7 +60,8 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    m_pimpl->metaData.bridgeOptions.isPIDsEnabled);
     if (!ret)
     {
-        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. YarpSensorBridge "
+        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
+                    "YarpSensorBridge "
                     "will not stream relevant measures.",
                     logPrefix);
     }
@@ -73,7 +74,8 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    m_pimpl->metaData.bridgeOptions.isMotorEncodersEnabled);
     if (!ret)
     {
-        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. YarpSensorBridge "
+        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
+                    "YarpSensorBridge "
                     "will not stream relevant measures.",
                     logPrefix);
     }
@@ -86,7 +88,8 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    m_pimpl->metaData.bridgeOptions.isPWMControlEnabled);
     if (!ret)
     {
-        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. YarpSensorBridge "
+        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
+                    "YarpSensorBridge "
                     "will not stream relevant measures.",
                     logPrefix);
     }
@@ -99,7 +102,8 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    m_pimpl->metaData.bridgeOptions.isWBDEstimatesEnabled);
     if (!ret)
     {
-        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. YarpSensorBridge "
+        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
+                    "YarpSensorBridge "
                     "will not stream relevant measures.",
                     logPrefix);
     }
@@ -112,7 +116,8 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    m_pimpl->metaData.bridgeOptions.isCurrentSensorsEnabled);
     if (!ret)
     {
-        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. YarpSensorBridge "
+        log()->info("{} Skipping the configuration of configureRemoteControlBoardRemapper. "
+                    "YarpSensorBridge "
                     "will not stream relevant measures.",
                     logPrefix);
     }
@@ -131,12 +136,13 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                     logPrefix);
     }
 
-    ret = m_pimpl->subConfigLoader("stream_forcetorque_sensors", //
-                                   "SixAxisForceTorqueSensors",
-                                   &YarpSensorBridge::Impl::configureSixAxisForceTorqueSensors,
-                                   handler,
-                                   m_pimpl->metaData,
-                                   m_pimpl->metaData.bridgeOptions.isSixAxisForceTorqueSensorEnabled);
+    ret = m_pimpl
+              ->subConfigLoader("stream_forcetorque_sensors", //
+                                "SixAxisForceTorqueSensors",
+                                &YarpSensorBridge::Impl::configureSixAxisForceTorqueSensors,
+                                handler,
+                                m_pimpl->metaData,
+                                m_pimpl->metaData.bridgeOptions.isSixAxisForceTorqueSensorEnabled);
     if (!ret)
     {
         log()->info("{} Skipping the configuration of SixAxisForceTorqueSensors. YarpSensorBridge "
@@ -174,11 +180,6 @@ bool YarpSensorBridge::setDriversList(const yarp::dev::PolyDriverList& deviceDri
 
     bool ret{true};
     ret = ret && m_pimpl->attachRemappedRemoteControlBoard(deviceDriversList);
-    ret = ret && m_pimpl->attachWBDJointTorqueEstimates(deviceDriversList);
-    ret = ret && m_pimpl->attachPIDsRemappedControlBoard(deviceDriversList);
-    ret = ret && m_pimpl->attachMotorEncoders(deviceDriversList);
-    ret = ret && m_pimpl->attachMotorPWMs(deviceDriversList);
-    ret = ret && m_pimpl->attachCurrentSensors(deviceDriversList);
     ret = ret && m_pimpl->attachAllInertials(deviceDriversList);
     ret = ret && m_pimpl->attachAllSixAxisForceTorqueSensors(deviceDriversList);
     ret = ret && m_pimpl->attachCartesianWrenchInterface(deviceDriversList);
@@ -328,7 +329,6 @@ bool YarpSensorBridge::getJointPosition(const std::string& jointName,
 bool YarpSensorBridge::getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
                                          OptionalDoubleRef receiveTimeInSeconds)
 {
-
     jointPositions = m_pimpl->controlBoardRemapperMeasures.jointPositions;
     if (receiveTimeInSeconds)
         receiveTimeInSeconds.value().get()
@@ -536,7 +536,6 @@ bool YarpSensorBridge::getMotorCurrent(const std::string& jointName,
 bool YarpSensorBridge::getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
                                         OptionalDoubleRef receiveTimeInSeconds)
 {
-
     motorCurrents = m_pimpl->controlBoardRemapperMeasures.motorCurrents;
 
     if (receiveTimeInSeconds)
@@ -547,8 +546,8 @@ bool YarpSensorBridge::getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrent
 }
 
 bool YarpSensorBridge::getMotorPWM(const std::string& jointName,
-                                       double& motorPWM,
-                                       OptionalDoubleRef receiveTimeInSeconds)
+                                   double& motorPWM,
+                                   OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
     if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
@@ -569,9 +568,8 @@ bool YarpSensorBridge::getMotorPWM(const std::string& jointName,
 }
 
 bool YarpSensorBridge::getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,
-                                        OptionalDoubleRef receiveTimeInSeconds)
+                                    OptionalDoubleRef receiveTimeInSeconds)
 {
-
     motorPWMs = m_pimpl->controlBoardRemapperMeasures.motorPWMs;
 
     if (receiveTimeInSeconds)
@@ -582,8 +580,8 @@ bool YarpSensorBridge::getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,
 }
 
 bool YarpSensorBridge::getJointTorque(const std::string& jointName,
-                                       double& jointTorque,
-                                       OptionalDoubleRef receiveTimeInSeconds)
+                                      double& jointTorque,
+                                      OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
     if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
@@ -604,9 +602,8 @@ bool YarpSensorBridge::getJointTorque(const std::string& jointName,
 }
 
 bool YarpSensorBridge::getJointTorques(Eigen::Ref<Eigen::VectorXd> jointTorques,
-                                        OptionalDoubleRef receiveTimeInSeconds)
+                                       OptionalDoubleRef receiveTimeInSeconds)
 {
-
     jointTorques = m_pimpl->controlBoardRemapperMeasures.jointTorques;
 
     if (receiveTimeInSeconds)
@@ -616,8 +613,8 @@ bool YarpSensorBridge::getJointTorques(Eigen::Ref<Eigen::VectorXd> jointTorques,
     return true;
 }
 
-bool YarpSensorBridge::getPidPosition(const std::string &jointName,
-                                      double &pidPosition,
+bool YarpSensorBridge::getPidPosition(const std::string& jointName,
+                                      double& pidPosition,
                                       OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
@@ -641,7 +638,6 @@ bool YarpSensorBridge::getPidPosition(const std::string &jointName,
 bool YarpSensorBridge::getPidPositions(Eigen::Ref<Eigen::VectorXd> pidPositions,
                                        OptionalDoubleRef receiveTimeInSeconds)
 {
-
     pidPositions = m_pimpl->controlBoardRemapperMeasures.pidPositions;
 
     if (receiveTimeInSeconds)
@@ -651,14 +647,15 @@ bool YarpSensorBridge::getPidPositions(Eigen::Ref<Eigen::VectorXd> pidPositions,
     return true;
 }
 
-bool YarpSensorBridge::getPidPositionError(const std::string &jointName,
-                                           double &pidPositionError,
+bool YarpSensorBridge::getPidPositionError(const std::string& jointName,
+                                           double& pidPositionError,
                                            OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
     if (!m_pimpl->getIndexFromVector(m_pimpl->metaData.sensorsList.jointsList, jointName, idx))
     {
-        log()->error("[YarpSensorBridge::getPidPositionError] {} could not be found in the configured "
+        log()->error("[YarpSensorBridge::getPidPositionError] {} could not be found in the "
+                     "configured "
                      "list of motors.",
                      jointName);
         return false;
@@ -676,7 +673,6 @@ bool YarpSensorBridge::getPidPositionError(const std::string &jointName,
 bool YarpSensorBridge::getPidPositionErrors(Eigen::Ref<Eigen::VectorXd> pidPositionErrors,
                                             OptionalDoubleRef receiveTimeInSeconds)
 {
-
     pidPositionErrors = m_pimpl->controlBoardRemapperMeasures.pidPositionErrors;
 
     if (receiveTimeInSeconds)
@@ -686,8 +682,8 @@ bool YarpSensorBridge::getPidPositionErrors(Eigen::Ref<Eigen::VectorXd> pidPosit
     return true;
 }
 
-bool YarpSensorBridge::getMotorPosition(const std::string &jointName,
-                                        double &motorPosition,
+bool YarpSensorBridge::getMotorPosition(const std::string& jointName,
+                                        double& motorPosition,
                                         OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
@@ -711,7 +707,6 @@ bool YarpSensorBridge::getMotorPosition(const std::string &jointName,
 bool YarpSensorBridge::getMotorPositions(Eigen::Ref<Eigen::VectorXd> motorPositions,
                                          OptionalDoubleRef receiveTimeInSeconds)
 {
-
     motorPositions = m_pimpl->controlBoardRemapperMeasures.motorPositions;
 
     if (receiveTimeInSeconds)
@@ -721,8 +716,8 @@ bool YarpSensorBridge::getMotorPositions(Eigen::Ref<Eigen::VectorXd> motorPositi
     return true;
 }
 
-bool YarpSensorBridge::getMotorVelocity(const std::string &jointName,
-                                        double &motorVelocity,
+bool YarpSensorBridge::getMotorVelocity(const std::string& jointName,
+                                        double& motorVelocity,
                                         OptionalDoubleRef receiveTimeInSeconds)
 {
     int idx;
@@ -746,7 +741,6 @@ bool YarpSensorBridge::getMotorVelocity(const std::string &jointName,
 bool YarpSensorBridge::getMotorVelocities(Eigen::Ref<Eigen::VectorXd> motorVelocties,
                                           OptionalDoubleRef receiveTimeInSeconds)
 {
-
     motorVelocties = m_pimpl->controlBoardRemapperMeasures.motorVelocities;
 
     if (receiveTimeInSeconds)

--- a/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
+++ b/src/RobotInterface/YarpImplementation/src/YarpSensorBridge.cpp
@@ -44,7 +44,7 @@ bool YarpSensorBridge::initialize(std::weak_ptr<const IParametersHandler> handle
                                    &YarpSensorBridge::Impl::configureRemoteControlBoardRemapper,
                                    handler,
                                    m_pimpl->metaData,
-                                   m_pimpl->metaData.bridgeOptions.isKinematicsEnabled);
+                                   m_pimpl->metaData.bridgeOptions.isJointSensorsEnabled);
     if (!ret)
     {
         log()->info("{} Skipping the configuration of RemoteControlBoardRemapper. YarpSensorBridge "

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -38,6 +38,11 @@ struct SensorBridgeOptions
     bool isSixAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
     bool isThreeAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
     bool isCartesianWrenchEnabled{false}; /**< flag to connect cartesian wrench measurement sources */
+    bool isPIDsEnabled{ false }; /** flag to connect pid position measurement sources */
+    bool isMotorEncodersEnabled{ false }; /** flag to connect motor measurement sources */
+    bool isPWMControlEnabled{ false }; /** flag to connect PWM measurement sources */
+    bool isWBDEstimatesEnabled{ false }; /** flag to connect WBD estimates sources */
+    bool isCurrentSensorsEnabled{ false }; /** flag to connect current measurement sources */
 
     size_t nrJoints{0}; /**< number of joints available through Kinematics stream, to be configured at initialization */
 };
@@ -367,32 +372,187 @@ protected:
     };
 
     /**
-     * Get motor torques in NewtonMeter
+     * Get motor PWM
      * @param[in] jointName name of the joint
-     * @param[out] motorTorque motor current in NewtonMeter
+     * @param[out] motorPWM motor PWM
      * @param[out] receiveTimeInSeconds time at which the measurement was received
      * @return true/false in case of success/failure
      */
-    virtual bool getMotorTorque(const std::string& jointName,
-                                  double& motorTorque,
+    virtual bool getMotorPWM(const std::string& jointName,
+                                  double& motorPWM,
                                   OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
 
     /**
-     * Get all motors' torque in NewtonMeter
-     * @param[out] motorTorques all motors' torque in NewtonMeter
+     * Get all motors' PWM
+     * @param[out] motorPWMs all motors' PWM
      * @param[out] receiveTimeInSeconds time at which the measurement was received
      *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
-     * This means that the user must pass a resized argument "motorTorques" to this method
+     * This means that the user must pass a resized argument "motorPWMs" to this method
      *
      * @return true/false in case of success/failure
      */
-    virtual bool getMotorTorques(Eigen::Ref<Eigen::VectorXd> motorTorques,
+    virtual bool getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,
                                   OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get joint torques in NewtonMeter
+     * @param[in] jointName name of the joint
+     * @param[out] jointTorque motor torque in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getJointTorque(const std::string& jointName,
+                                  double& jointTorque,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get all joints' torque in NewtonMeter
+     * @param[out] jointTorques all motors' torque in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "jointTorques" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getJointTorques(Eigen::Ref<Eigen::VectorXd> jointTorques,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get pid position in rad
+     * @param[in] jointName name of the joint
+     * @param[out] pidPosition pid position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPosition(const std::string& jointName,
+                                  double& pidPosition,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get all pid positions in rad
+     * @param[out] pidPositions all pid positions in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "pidPositions" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPositions(Eigen::Ref<Eigen::VectorXd> pidPositions,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get pid position error in rad
+     * @param[in] jointName name of the joint
+     * @param[out] pidPositionError pid position error in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPositionError(const std::string& jointName,
+                                  double& pidPositionError,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get all pid position errors in rad
+     * @param[out] pidPositionErrors all pid position errors in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "pidPositionErrors" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getPidPositionErrors(Eigen::Ref<Eigen::VectorXd> pidPositionErrors,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get motor position in rad
+     * @param[in] jointName name of the joint
+     * @param[out] motorPosition motor position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorPosition(const std::string& jointName,
+                                  double& motorPosition,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get all motors' positions in rad
+     * @param[out] parameter all motors' position in radians
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "motorPositions" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorPositions(Eigen::Ref<Eigen::VectorXd> motorPositions,
+                                   OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get motor velocity in rad/s
+     * @param[in] jointName name of the joint
+     * @param[out] motorVelocity motor velocity in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorVelocity(const std::string& jointName,
+                                  double& motorVelocity,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get all motors' velocities in rad/s
+     * @param[out] parameter all motors' velocities in radians per second
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "motorVelocties" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorVelocities(Eigen::Ref<Eigen::VectorXd> motorVelocties,
+                                    OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -43,10 +43,8 @@ struct SensorBridgeOptions
     bool isCartesianWrenchEnabled{false}; /**< flag to connect cartesian wrench measurement sources
                                            */
     bool isPIDsEnabled{false}; /** flag to connect pid position measurement sources */
-    bool isMotorEncodersEnabled{false}; /** flag to connect motor measurement sources */
+    bool isMotorSensorsEnabled{false}; /** flag to connect motor measurement sources */
     bool isPWMControlEnabled{false}; /** flag to connect PWM measurement sources */
-    bool isWBDEstimatesEnabled{false}; /** flag to connect WBD estimates sources */
-    bool isCurrentSensorsEnabled{false}; /** flag to connect current measurement sources */
 
     size_t nrJoints{0}; /**< number of joints available through Kinematics stream, to be configured
                            at initialization */

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -31,20 +31,25 @@ struct SensorBridgeOptions
 {
     bool isKinematicsEnabled{false}; /**< flag to connect kinematics measurement sources */
     bool isIMUEnabled{false}; /**< flag to connect IMU measurement sources */
-    bool isLinearAccelerometerEnabled{false}; /**< flag to connect linear accelerometer measurement sources */
+    bool isLinearAccelerometerEnabled{false}; /**< flag to connect linear accelerometer measurement
+                                                 sources */
     bool isGyroscopeEnabled{false}; /**< flag to connect gyroscope measurement sources */
     bool isOrientationSensorEnabled{false}; /**< flag to connect gyroscope measurement sources */
     bool isMagnetometerEnabled{false}; /**< flag to connect magnetometer measurement sources */
-    bool isSixAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
-    bool isThreeAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque measurement sources */
-    bool isCartesianWrenchEnabled{false}; /**< flag to connect cartesian wrench measurement sources */
-    bool isPIDsEnabled{ false }; /** flag to connect pid position measurement sources */
-    bool isMotorEncodersEnabled{ false }; /** flag to connect motor measurement sources */
-    bool isPWMControlEnabled{ false }; /** flag to connect PWM measurement sources */
-    bool isWBDEstimatesEnabled{ false }; /** flag to connect WBD estimates sources */
-    bool isCurrentSensorsEnabled{ false }; /** flag to connect current measurement sources */
+    bool isSixAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque
+                                                      measurement sources */
+    bool isThreeAxisForceTorqueSensorEnabled{false}; /**< flag to connect six axis force torque
+                                                        measurement sources */
+    bool isCartesianWrenchEnabled{false}; /**< flag to connect cartesian wrench measurement sources
+                                           */
+    bool isPIDsEnabled{false}; /** flag to connect pid position measurement sources */
+    bool isMotorEncodersEnabled{false}; /** flag to connect motor measurement sources */
+    bool isPWMControlEnabled{false}; /** flag to connect PWM measurement sources */
+    bool isWBDEstimatesEnabled{false}; /** flag to connect WBD estimates sources */
+    bool isCurrentSensorsEnabled{false}; /** flag to connect current measurement sources */
 
-    size_t nrJoints{0}; /**< number of joints available through Kinematics stream, to be configured at initialization */
+    size_t nrJoints{0}; /**< number of joints available through Kinematics stream, to be configured
+                           at initialization */
 };
 
 /**
@@ -53,16 +58,20 @@ struct SensorBridgeOptions
 struct SensorLists
 {
     std::vector<std::string> jointsList; /**< list of joints attached to the bridge */
-    std::vector<std::string> IMUsList;   /**< list of IMUs attached to the bridge */
-    std::vector<std::string> linearAccelerometersList; /**< list of linear accelerometers attached to the bridge */
+    std::vector<std::string> IMUsList; /**< list of IMUs attached to the bridge */
+    std::vector<std::string> linearAccelerometersList; /**< list of linear accelerometers attached
+                                                          to the bridge */
     std::vector<std::string> gyroscopesList; /**< list of gyroscopes attached to the bridge */
-    std::vector<std::string> orientationSensorsList; /**< list of orientation sensors attached to the bridge */
+    std::vector<std::string> orientationSensorsList; /**< list of orientation sensors attached to
+                                                        the bridge */
     std::vector<std::string> magnetometersList; /**< list of magnetometers attached to the bridge */
-    std::vector<std::string> sixAxisForceTorqueSensorsList; /**< list of six axis force torque sensors attached to the bridge */
-    std::vector<std::string> threeAxisForceTorqueSensorsList; /**< list of three axis force torque sensors attached to the bridge */
-    std::vector<std::string> cartesianWrenchesList; /**< list of cartesian wrench streams attached to the bridge */
+    std::vector<std::string> sixAxisForceTorqueSensorsList; /**< list of six axis force torque
+                                                               sensors attached to the bridge */
+    std::vector<std::string> threeAxisForceTorqueSensorsList; /**< list of three axis force torque
+                                                                 sensors attached to the bridge */
+    std::vector<std::string> cartesianWrenchesList; /**< list of cartesian wrench streams attached
+                                                       to the bridge */
 };
-
 
 /**
  * Meta data struct to hold list of sensors and configured options
@@ -70,8 +79,8 @@ struct SensorLists
  */
 struct SensorBridgeMetaData
 {
-  SensorLists sensorsList;
-  SensorBridgeOptions bridgeOptions;
+    SensorLists sensorsList;
+    SensorBridgeOptions bridgeOptions;
 };
 
 /**
@@ -96,63 +105,94 @@ public:
      * @param[out] jointsList list of joints attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getJointsList(std::vector<std::string>& jointsList) { return false; };
+    virtual bool getJointsList(std::vector<std::string>& jointsList)
+    {
+        return false;
+    };
 
     /**
      * Get imu sensors
      * @param[out] IMUsList list of IMUs attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getIMUsList(std::vector<std::string>& IMUsList) { return false; };
+    virtual bool getIMUsList(std::vector<std::string>& IMUsList)
+    {
+        return false;
+    };
 
     /**
      * Get linear accelerometers
      * @param[out] linearAccelerometersList list of linear accelerometers attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList) { return false; };
+    virtual bool getLinearAccelerometersList(std::vector<std::string>& linearAccelerometersList)
+    {
+        return false;
+    };
 
     /**
      * Get gyroscopes
      * @param[out] gyroscopesList list of gyroscopes attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getGyroscopesList(std::vector<std::string>& gyroscopesList) { return false; };
+    virtual bool getGyroscopesList(std::vector<std::string>& gyroscopesList)
+    {
+        return false;
+    };
 
     /**
      * Get orientation sensors
      * @param[out] orientationSensorsList list of orientation sensors attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getOrientationSensorsList(std::vector<std::string>& orientationSensorsList) { return false; };
+    virtual bool getOrientationSensorsList(std::vector<std::string>& orientationSensorsList)
+    {
+        return false;
+    };
 
     /**
      * Get magnetometers sensors
      * @param[out] magnetometersList list of magnetometers attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getMagnetometersList(std::vector<std::string>& magnetometersList) { return false; };
+    virtual bool getMagnetometersList(std::vector<std::string>& magnetometersList)
+    {
+        return false;
+    };
 
     /**
      * Get 6 axis FT sensors
-     * @param[out] sixAxisForceTorqueSensorsList list of 6 axis force torque sensors attached to the bridge
+     * @param[out] sixAxisForceTorqueSensorsList list of 6 axis force torque sensors attached to the
+     * bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList) { return false; };
+    virtual bool
+    getSixAxisForceTorqueSensorsList(std::vector<std::string>& sixAxisForceTorqueSensorsList)
+    {
+        return false;
+    };
 
     /**
      * Get 6 axis FT sensors
-     * @param[out] threeAxisForceTorqueSensorsList list of 3 axis force torque sensors attached to the bridge
+     * @param[out] threeAxisForceTorqueSensorsList list of 3 axis force torque sensors attached to
+     * the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList) { return false; };
+    virtual bool
+    getThreeAxisForceTorqueSensorsList(std::vector<std::string>& threeAxisForceTorqueSensorsList)
+    {
+        return false;
+    };
 
-   /**
+    /**
      * Get cartesian wrenches
      * @param[out] cartesianWrenchesList list of cartesian wrenches attached to the bridge
      * @return  true/false in case of success/failure
      */
-    virtual bool getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList) { return false; };
+    virtual bool getCartesianWrenchesList(std::vector<std::string>& cartesianWrenchesList)
+    {
+        return false;
+    };
 
     /**
      * Get joint position  in radians
@@ -163,21 +203,25 @@ public:
      */
     virtual bool getJointPosition(const std::string& jointName,
                                   double& jointPosition,
-                                  OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Get all joints' positions in radians
      * @param[out] parameter all joints' position in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "jointPositions" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getJointPositions(Eigen::Ref<Eigen::VectorXd> jointPositions,
-                                   OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                   OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Get joint velocity in rad/s
@@ -188,21 +232,25 @@ public:
      */
     virtual bool getJointVelocity(const std::string& jointName,
                                   double& jointVelocity,
-                                  OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Get all joints' velocities in rad/s
      * @param[out] parameter all joints' velocities in radians per second
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "jointVelocties" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getJointVelocities(Eigen::Ref<Eigen::VectorXd> jointVelocties,
-                                    OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                    OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Get IMU measurement
@@ -219,7 +267,10 @@ public:
      */
     virtual bool getIMUMeasurement(const std::string& imuName,
                                    Eigen::Ref<Vector12d> imuMeasurement,
-                                   OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                   OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Get linear accelerometer measurement in m/s^2
@@ -230,7 +281,10 @@ public:
      */
     virtual bool getLinearAccelerometerMeasurement(const std::string& accName,
                                                    Eigen::Ref<Eigen::Vector3d> accMeasurement,
-                                                   OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                                   OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Get gyroscope measurement in rad/s
@@ -241,9 +295,12 @@ public:
      */
     virtual bool getGyroscopeMeasure(const std::string& gyroName,
                                      Eigen::Ref<Eigen::Vector3d> gyroMeasurement,
-                                     OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                     OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
-   /**
+    /**
      * Get orientation sensor measurement in radians as roll pitch yaw Euler angles
      * @param[in] rpyName name of the orientation sensor
      * @param[out] rpyMeasurement rpy measurements of size 3
@@ -252,9 +309,12 @@ public:
      */
     virtual bool getOrientationSensorMeasurement(const std::string& rpyName,
                                                  Eigen::Ref<Eigen::Vector3d> rpyMeasurement,
-                                                 OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                                 OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
-   /**
+    /**
      * Get magentometer measurement in tesla
      * @param[in] magName name of the magnetometer
      * @param[out] magMeasurement magnetometer measurements of size 3
@@ -263,7 +323,10 @@ public:
      */
     virtual bool getMagnetometerMeasurement(const std::string& magName,
                                             Eigen::Ref<Eigen::Vector3d> magMeasurement,
-                                            OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                            OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Get six axis force torque measurement
@@ -274,10 +337,14 @@ public:
      */
     virtual bool getSixAxisForceTorqueMeasurement(const std::string& ftName,
                                                   Eigen::Ref<Vector6d> ftMeasurement,
-                                                  OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
-     * Get three axis force-torque measurement containing normal force (N) and tangential moments (Nm)
+     * Get three axis force-torque measurement containing normal force (N) and tangential moments
+     * (Nm)
      * @param[in] ftName name of the FT sensor
      * @param[out] ftMeasurement FT measurements of size 3 containing tau_x tau_y and fz
      * @param[out] receiveTimeInSeconds time at which the measurement was received
@@ -285,9 +352,12 @@ public:
      */
     virtual bool getThreeAxisForceTorqueMeasurement(const std::string& ftName,
                                                     Eigen::Ref<Eigen::Vector3d> ftMeasurement,
-                                                    OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                                    OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
-   /**
+    /**
      * Get 6D end effector wrenches in N and Nm for forces and torques respectively
      * @param[in] cartesianWrenchName name of the end effector wrench
      * @param[out] cartesianWrenchMeasurement end effector wrench measurement of size 6
@@ -296,7 +366,10 @@ public:
      */
     virtual bool getCartesianWrench(const std::string& cartesianWrenchName,
                                     Eigen::Ref<Vector6d> cartesianWrenchMeasurement,
-                                    OptionalDoubleRef receiveTimeInSeconds = {}) { return false; };
+                                    OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 
     /**
      * Destructor
@@ -305,40 +378,56 @@ public:
 
 protected:
     /**
-     * Helper method to maintain SensorBridgeOptions struct by populating it from the configuration parameters
-     * @note the user may choose to use/not use this method depending on their requirements for the implementation
-     * if the user chooses to not use the method, the implementation must simply contain "return true;"
-     *
+     * Helper method to maintain SensorBridgeOptions struct by populating it from the configuration
+     * parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the
+     * implementation if the user chooses to not use the method, the implementation must simply
+     * contain "return true;"
      * @param[in] handler  Parameters handler
-     * @param[in] sensorBridgeOptions SensorBridgeOptions to hold the bridge options for streaming sensor measurements
+     * @param[in] sensorBridgeOptions SensorBridgeOptions to hold the bridge options for streaming
+     * sensor measurements
      */
-    virtual bool populateSensorBridgeOptionsFromConfig(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
-                                                      SensorBridgeOptions& sensorBridgeOptions) { return true; };
+    virtual bool populateSensorBridgeOptionsFromConfig(
+        std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+        SensorBridgeOptions& sensorBridgeOptions)
+    {
+        return true;
+    };
 
     /**
-     * Helper method to maintain SensorLists struct by populating it from the configuration parameters
-     * @note the user may choose to use/not use this method depending on their requirements for the implementation
-     * if the user chooses to not use the method, the implementation must simply contain "return true;"
-     *
+     * Helper method to maintain SensorLists struct by populating it from the configuration
+     * parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the
+     * implementation if the user chooses to not use the method, the implementation must simply
+     * contain "return true;"
      * @param[in] handler  Parameters handler
      * @param[in] sensorBridgeOptions configured object of SensorBridgeOptions
      * @param[in] sensorLists SensorLists object holding list of connected sensor devices
      */
-    virtual bool populateSensorListsFromConfig(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
-                                               const SensorBridgeOptions& sensorBridgeOptions,
-                                               SensorLists& sensorLists) { return true; };
+    virtual bool
+    populateSensorListsFromConfig(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+                                  const SensorBridgeOptions& sensorBridgeOptions,
+                                  SensorLists& sensorLists)
+    {
+        return true;
+    };
 
     /**
-     * Helper method to maintain SensorBridgeMetaData struct by populating it from the configuration parameters
-     * @note the user may choose to use/not use this method depending on their requirements for the implementation
-     * if the user chooses to not use the method, the implementation must simply contain "return true;"
-     *
+     * Helper method to maintain SensorBridgeMetaData struct by populating it from the configuration
+     * parameters
+     * @note the user may choose to use/not use this method depending on their requirements for the
+     * implementation if the user chooses to not use the method, the implementation must simply
+     * contain "return true;"
      * @param[in] handler  Parameters handler
      * @param[in] sensorBridgeMetaData configured object of SensorBridgeMetadata
      * @param[in] sensorLists SensorLists object holding list of connected sensor devices
      */
-    virtual bool populateSensorBridgeMetaDataFromConfig(std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
-                                                        SensorBridgeMetaData& sensorBridgeMetaData) { return true; };
+    virtual bool populateSensorBridgeMetaDataFromConfig(
+        std::weak_ptr<const ParametersHandler::IParametersHandler> handler,
+        SensorBridgeMetaData& sensorBridgeMetaData)
+    {
+        return true;
+    };
 
     /**
      * Get motor currents in ampere
@@ -348,8 +437,8 @@ protected:
      * @return true/false in case of success/failure
      */
     virtual bool getMotorCurrent(const std::string& jointName,
-                                  double& motorCurrent,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                                 double& motorCurrent,
+                                 OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -358,11 +447,9 @@ protected:
      * Get all motors' current in ampere
      * @param[out] motorCurrents all motors' current in ampere
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "motorCurrents" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getMotorCurrents(Eigen::Ref<Eigen::VectorXd> motorCurrents,
@@ -379,8 +466,8 @@ protected:
      * @return true/false in case of success/failure
      */
     virtual bool getMotorPWM(const std::string& jointName,
-                                  double& motorPWM,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                             double& motorPWM,
+                             OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -389,46 +476,42 @@ protected:
      * Get all motors' PWM
      * @param[out] motorPWMs all motors' PWM
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "motorPWMs" to this method
-     *
      * @return true/false in case of success/failure
      */
-    virtual bool getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    virtual bool
+    getMotorPWMs(Eigen::Ref<Eigen::VectorXd> motorPWMs, OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
 
     /**
-     * Get joint torques in NewtonMeter
+     * Get joint torques in Nm
      * @param[in] jointName name of the joint
-     * @param[out] jointTorque motor torque in NewtonMeter
+     * @param[out] jointTorque motor torque in Nm
      * @param[out] receiveTimeInSeconds time at which the measurement was received
      * @return true/false in case of success/failure
      */
     virtual bool getJointTorque(const std::string& jointName,
-                                  double& jointTorque,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                                double& jointTorque,
+                                OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
 
     /**
-     * Get all joints' torque in NewtonMeter
-     * @param[out] jointTorques all motors' torque in NewtonMeter
+     * Get all joints' torque in Nm
+     * @param[out] jointTorques all motors' torque in Nm
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "jointTorques" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getJointTorques(Eigen::Ref<Eigen::VectorXd> jointTorques,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                                 OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -441,8 +524,8 @@ protected:
      * @return true/false in case of success/failure
      */
     virtual bool getPidPosition(const std::string& jointName,
-                                  double& pidPosition,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                                double& pidPosition,
+                                OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -451,15 +534,13 @@ protected:
      * Get all pid positions in rad
      * @param[out] pidPositions all pid positions in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "pidPositions" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getPidPositions(Eigen::Ref<Eigen::VectorXd> pidPositions,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                                 OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -472,8 +553,8 @@ protected:
      * @return true/false in case of success/failure
      */
     virtual bool getPidPositionError(const std::string& jointName,
-                                  double& pidPositionError,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                                     double& pidPositionError,
+                                     OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -482,15 +563,13 @@ protected:
      * Get all pid position errors in rad
      * @param[out] pidPositionErrors all pid position errors in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "pidPositionErrors" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getPidPositionErrors(Eigen::Ref<Eigen::VectorXd> pidPositionErrors,
-                                  OptionalDoubleRef receiveTimeInSeconds = {})
+                                      OptionalDoubleRef receiveTimeInSeconds = {})
     {
         return false;
     };
@@ -513,11 +592,9 @@ protected:
      * Get all motors' positions in rad
      * @param[out] parameter all motors' position in radians
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "motorPositions" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getMotorPositions(Eigen::Ref<Eigen::VectorXd> motorPositions,
@@ -544,11 +621,9 @@ protected:
      * Get all motors' velocities in rad/s
      * @param[out] parameter all motors' velocities in radians per second
      * @param[out] receiveTimeInSeconds time at which the measurement was received
-     *
      * @warning the size is decided at the configuration and remains fixed,
      * and internal checks must be done at the implementation level by the Derived class.
      * This means that the user must pass a resized argument "motorVelocties" to this method
-     *
      * @return true/false in case of success/failure
      */
     virtual bool getMotorVelocities(Eigen::Ref<Eigen::VectorXd> motorVelocties,

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -29,7 +29,7 @@ namespace RobotInterface
  */
 struct SensorBridgeOptions
 {
-    bool isKinematicsEnabled{false}; /**< flag to connect kinematics measurement sources */
+    bool isJointSensorsEnabled{false}; /**< flag to connect joint measurement sources */
     bool isIMUEnabled{false}; /**< flag to connect IMU measurement sources */
     bool isLinearAccelerometerEnabled{false}; /**< flag to connect linear accelerometer measurement
                                                  sources */

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/ISensorBridge.h
@@ -365,6 +365,37 @@ protected:
     {
         return false;
     };
+
+    /**
+     * Get motor torques in NewtonMeter
+     * @param[in] jointName name of the joint
+     * @param[out] motorTorque motor current in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorTorque(const std::string& jointName,
+                                  double& motorTorque,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
+
+    /**
+     * Get all motors' torque in NewtonMeter
+     * @param[out] motorTorques all motors' torque in NewtonMeter
+     * @param[out] receiveTimeInSeconds time at which the measurement was received
+     *
+     * @warning the size is decided at the configuration and remains fixed,
+     * and internal checks must be done at the implementation level by the Derived class.
+     * This means that the user must pass a resized argument "motorTorques" to this method
+     *
+     * @return true/false in case of success/failure
+     */
+    virtual bool getMotorTorques(Eigen::Ref<Eigen::VectorXd> motorTorques,
+                                  OptionalDoubleRef receiveTimeInSeconds = {})
+    {
+        return false;
+    };
 };
 } // namespace RobotInterface
 } // namespace BipedalLocomotion

--- a/utilities/joint-trajectory-player/config/robots/iCubGazeboV3/blf-joint-trajectory-player-options.ini
+++ b/utilities/joint-trajectory-player/config/robots/iCubGazeboV3/blf-joint-trajectory-player-options.ini
@@ -14,5 +14,5 @@ position_direct_max_admissible_error             0.1
 [SENSOR_BRIDGE]
 check_for_nan                                    false
 stream_joint_states                              true
-stream_current_sensors                           true
+stream_motor_states                              true
 

--- a/utilities/joint-trajectory-player/config/robots/iCubGazeboV3/blf-joint-trajectory-player-options.ini
+++ b/utilities/joint-trajectory-player/config/robots/iCubGazeboV3/blf-joint-trajectory-player-options.ini
@@ -14,4 +14,5 @@ position_direct_max_admissible_error             0.1
 [SENSOR_BRIDGE]
 check_for_nan                                    false
 stream_joint_states                              true
+stream_current_sensors                           true
 


### PR DESCRIPTION
This PR is meant to add the possibility to log motor encoders, current sensors, WBD torque estimates, motor PWMs, PID references.