### PR TITLE
Enable the Current control in RobotInterface class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Add the possibility to control a subset of coordinates in `IK::CoMTask` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/357)
 - Reduce the duplicate code in IK and TSID (https://github.com/dic-iit/bipedal-locomotion-framework/pull/364)
 - `QPFixedBaseTSID` now inherits from `QPTSID` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/366)
+- Enable the Current control in `RobotInterface` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/375)
 
 ### Fix
 

--- a/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
+++ b/src/RobotInterface/include/BipedalLocomotion/RobotInterface/IRobotControl.h
@@ -35,6 +35,7 @@ public:
         Velocity,
         Torque,
         PWM,
+        Current,
         Idle,
         Unknown
     };


### PR DESCRIPTION
This enables the possibility to set the motor current in RobotInterface class. The current is expressed in `ampere` 