### PR TITLE
Add the possibility to use manif objects in the ForwardEuler integrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 - `QPFixedBaseTSID` now inherits from `QPTSID` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/366)
 - Enable the Current control in `RobotInterface` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/375)
 - Add the possibility to disable and enable the PD controllers in `IK::SE3Task` (https://github.com/dic-iit/bipedal-locomotion-framework/pull/373).
+- Add the possibility to use manif objects in the ForwardEuler integrator (https://github.com/dic-iit/bipedal-locomotion-framework/pull/379).
 
 ### Fix
 - Fixed the crashing of `YarpSensorBridge` while trying to access unconfigured control board sensors data by adding some checks (https://github.com/dic-iit/bipedal-locomotion-framework/pull/378)

--- a/src/IK/tests/QPInverseKinematicsTest.cpp
+++ b/src/IK/tests/QPInverseKinematicsTest.cpp
@@ -196,7 +196,7 @@ System getSystem(std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
 
     out.dynamics = std::make_shared<FloatingBaseSystemKinematics>();
     out.dynamics->setState({basePose.topRightCorner<3, 1>(),
-                            basePose.topLeftCorner<3, 3>(),
+                            toManifRot(basePose.topLeftCorner<3, 3>()),
                             jointPositions});
 
     out.integrator = std::make_shared<ForwardEuler<FloatingBaseSystemKinematics>>();
@@ -266,7 +266,7 @@ TEST_CASE("QP-IK")
                     = system.integrator->getSolution();
 
                 // update the KinDynComputations object
-                baseTransform.topLeftCorner<3, 3>() = baseRotation;
+                baseTransform.topLeftCorner<3, 3>() = baseRotation.rotation();
                 baseTransform.topRightCorner<3, 1>() = basePosition;
                 REQUIRE(kinDyn->setRobotState(baseTransform,
                                               jointPosition,


### PR DESCRIPTION
This PR introduces the possibility to use ForwardEuler integrator with manif objects. Thanks to this I removed the  Baumgarte stabilization in FloatingBaseSystemKinematics class
