### PR TITLE
Enable Python bindings in conda-forge CI and fix Python bindings compilation and tests on MSVC

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -9,7 +9,6 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  manif_TAG: 0.0.4
   tomlplusplus_TAG: v2.4.0
 
 jobs:
@@ -37,7 +36,14 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog catch2 nlohmann_json manif
+        mamba install -c robotology idyntree yarp libmatio matio-cpp lie-group-controllers eigen qhull "casadi>=3.5.5" cppad spdlog catch2 nlohmann_json manif manifpy pybind11 numpy pytest scipy
+
+    - name: Windows-only Dependencies [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        # Compilation related dependencies
+        mamba install vs2019_win-64
 
     - name: Dependencies [tomlplusplus - Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -74,25 +80,40 @@ jobs:
         mkdir -p build
         cd build
         cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_IK:BOOL=OFF \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+              -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
-    - name: Configure [Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
-      run: |
-        mkdir -p build
-        cd build
-        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_IK:BOOL=OFF \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-
-    - name: Build
+    - name: Build [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         cd build
         cmake --build . --config ${{ matrix.build_type }}
 
-    - name: Test
+    - name: Test [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
+      run: |
+        cd build
+        ctest --output-on-failure -C ${{ matrix.build_type }}
+
+    - name: Configure [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: cmd /C call {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DFRAMEWORK_COMPILE_IK:BOOL=OFF -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+
+    - name: Build [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: cmd /C call {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Test [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: cmd /C call {0}
       run: |
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project are documented in this file.
 
 ### Fix
 - Fixed the crashing of `YarpSensorBridge` while trying to access unconfigured control board sensors data by adding some checks (https://github.com/dic-iit/bipedal-locomotion-framework/pull/378)
+- Fixed the compilation of Python bindings (enabled by the `FRAMEWORK_COMPILE_PYTHON_BINDINGS` CMake option) when compiling with Visual Studio (https://github.com/dic-iit/bipedal-locomotion-framework/pull/380).
 
 ## [0.2.0] - 2021-06-15
 ### Added

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -43,6 +43,15 @@ set_target_properties(pybind11_blf PROPERTIES
 
 if(FRAMEWORK_TEST_PYTHON_BINDINGS)
     add_subdirectory(tests)
+
+    # For testing on Windows we copy the blf .dll in the same
+    # directory of the bindings
+    if(WIN32)
+        add_custom_command(TARGET pybind11_blf POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            $<TARGET_FILE_DIR:BipedalLocomotion::Math>
+            $<TARGET_FILE_DIR:pybind11_blf>)
+    endif()
 endif()
 
 # Output package is:
@@ -56,3 +65,4 @@ install(TARGETS pybind11_blf DESTINATION ${PYTHON_INSTDIR})
 # Install the __init__.py file
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/all.py"
   DESTINATION ${PYTHON_INSTDIR})
+

--- a/bindings/python/FloatingBaseEstimators/src/LeggedOdometry.cpp
+++ b/bindings/python/FloatingBaseEstimators/src/LeggedOdometry.cpp
@@ -58,13 +58,13 @@ void CreateLeggedOdometry(pybind11::module& module)
              py::arg("encoder_speeds"))
         .def("advance", &LeggedOdometry::advance)
         .def("reset_estimator",
-             py::overload_cast<const InternalState&>(&LeggedOdometry::resetEstimator),
+             py::overload_cast<const InternalState&>(&FloatingBaseEstimator::resetEstimator),
              py::arg("new_state"))
         .def("reset_estimator",
              py::overload_cast<const Eigen::Quaterniond&, const Eigen::Vector3d&>(
-                 &LeggedOdometry::resetEstimator),
-             py::arg("new_imu_orientation"),
-             py::arg("new_imu_position"))
+                 &FloatingBaseEstimator::resetEstimator),
+             py::arg("new_base_orientation"),
+             py::arg("new_base_position"))
         .def("reset_estimator", py::overload_cast<>(&LeggedOdometry::resetEstimator))
         .def("reset_estimator",
              py::overload_cast<const std::string&, const Eigen::Quaterniond&, const Eigen::Vector3d&>(


### PR DESCRIPTION
* Fixed compilation of Python bindings on Windows on MSVC. The problem was that the pybind11 bindings for LeggedOdometry references some `LeggedOdometry::resetEstimator` overloads that actually belonged to the parent class  `FloatingBaseEstimator`.
* Fixed loading of tests on MSVC by copying the BLF dll to the directory in which the Python binding dll is found, to avoid problem in loading blf dll as on Windows there is no RPATH
* Switch GitHub Actions conda CI to use Ninja as a generator on Windows, to workaround  https://github.com/dic-iit/bipedal-locomotion-framework/issues/382 . As the ninja MSVC generator only works on Command Prompt, we also switched the relevant steps to run on Command Prompt as well.