### PR TITLE
Fix the `TOML` and `YARP` implementation of the parameters handler when a `std::vector<bool>` is passed to the `setParameter()` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   LieGroupControllers_TAG: v0.1.1
   osqp_TAG: v0.6.2
   OsqpEigen_TAG: v0.6.3
-  tomlplusplus_TAG: v2.4.0
+  tomlplusplus_TAG: 4f21332bdd7555bbf9add1aafe82909a2f8aa52b~
 
   # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg
   VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg
@@ -278,8 +278,9 @@ jobs:
 
         # Tomlplusplus
         cd ${GITHUB_WORKSPACE}
-        git clone -b ${tomlplusplus_TAG} https://github.com/marzer/tomlplusplus
+        git clone https://github.com/marzer/tomlplusplus
         cd tomlplusplus
+        git checkout ${tomlplusplus_TAG}
         mkdir -p build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented in this file.
 ### Fix
 - Fixed the crashing of `YarpSensorBridge` while trying to access unconfigured control board sensors data by adding some checks (https://github.com/dic-iit/bipedal-locomotion-framework/pull/378)
 - Fixed the compilation of Python bindings (enabled by the `FRAMEWORK_COMPILE_PYTHON_BINDINGS` CMake option) when compiling with Visual Studio (https://github.com/dic-iit/bipedal-locomotion-framework/pull/380).
+- Fixed the `TOML` and `YARP` implementation of the parameters handler when a `std::vector<bool>` is passed to the `setParameter()` method (https://github.com/dic-iit/bipedal-locomotion-framework/pull/390).
 
 ## [0.2.0] - 2021-06-15
 ### Added

--- a/src/ParametersHandler/TomlImplementation/include/BipedalLocomotion/ParametersHandler/TomlImplementation.h
+++ b/src/ParametersHandler/TomlImplementation/include/BipedalLocomotion/ParametersHandler/TomlImplementation.h
@@ -259,6 +259,16 @@ public:
     ~TomlImplementation() = default;
 };
 
+/**
+ * Private implementation of setParameter
+ * @param parameterName name of the parameter
+ * @param parameter parameter
+ * @note The specialization is required because std::vector<bool> is not a container and the
+ * operator[] does not return a bool&
+ */
+template <>
+void TomlImplementation::setParameterPrivate<std::vector<bool>>(const std::string& parameterName,
+                                                                const std::vector<bool>& parameter);
 } // namespace ParametersHandler
 } // namespace BipedalLocomotion
 

--- a/src/ParametersHandler/TomlImplementation/src/TomlImplementation.cpp
+++ b/src/ParametersHandler/TomlImplementation/src/TomlImplementation.cpp
@@ -12,6 +12,20 @@
 
 using namespace BipedalLocomotion::ParametersHandler;
 
+template <>
+void TomlImplementation::setParameterPrivate<std::vector<bool>>(const std::string& parameterName,
+                                                                const std::vector<bool>& parameter)
+{
+    // vector<bool> is (usually) specialized explicitly to store each bool in a single bit,
+    // The range loop using reference leads to a compilation error.
+    // https://stackoverflow.com/questions/34079390/range-for-loops-and-stdvectorbool
+    m_container.insert_or_assign(parameterName, toml::array());
+    for (bool element : parameter)
+    {
+        m_container[parameterName].as_array()->push_back(element);
+    }
+}
+
 bool TomlImplementation::getParameter(const std::string& parameterName, int& parameter) const
 {
     return getParameterPrivate(parameterName, parameter);
@@ -93,6 +107,7 @@ void TomlImplementation::setParameter(const std::string& parameterName,
 {
     return setParameterPrivate(parameterName, parameter);
 }
+
 void TomlImplementation::setParameter(
     const std::string& parameterName,
     const GenericContainer::Vector<const std::string>::Ref parameter)

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -26,7 +26,7 @@ void YarpImplementation::setParameterPrivate<std::vector<bool>>(const std::strin
     yarp::os::Value yarpNewList;
     auto newList = yarpNewList.asList();
 
-    for (const auto& element : parameter)
+    for (bool element : parameter)
     {
         // if the parameter is a boolean we cannot use the usual way to add the new parameter
         // Please check https://github.com/robotology/yarp/issues/2584#issuecomment-847778679

--- a/src/ParametersHandler/tests/ParametersHandlerTomlTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerTomlTest.cpp
@@ -82,6 +82,15 @@ TEST_CASE("Get parameters")
         REQUIRE(element == fibonacciNumbers);
     }
 
+    SECTION("Set bool Vector")
+    {
+        std::vector<bool> element;
+        const std::vector<bool> newFlags{false, true, false, true, true, true, false};
+        parameterHandler->setParameter("new_flags", newFlags);
+        REQUIRE(parameterHandler->getParameter("new_flags", element));
+        REQUIRE(element == newFlags);
+    }
+
     SECTION("Get bool Vector")
     {
         std::vector<bool> element;


### PR DESCRIPTION
This fixes the problem spotted by @traversaro in #381. 
It implements what is explained in https://github.com/dic-iit/bipedal-locomotion-framework/pull/381#issuecomment-896756059


- [x] Enable TOMLPlusPlus in CI 