### PR TITLE
Add a synchronization mechanism for the AdvanceableRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Implement `AdvanceableRunner::isRunning()` method (https://github.com/dic-iit/bipedal-locomotion-framework/pull/395)
 - Implement `ContactPhaseList::getPresentPhase()` method (https://github.com/dic-iit/bipedal-locomotion-framework/pull/396)
+- Add a synchronization mechanism for the `AdvanceableRunner` class (https://github.com/dic-iit/bipedal-locomotion-framework/pull/403)
 
 ### Changed
 

--- a/src/System/CMakeLists.txt
+++ b/src/System/CMakeLists.txt
@@ -15,8 +15,9 @@ if(FRAMEWORK_COMPILE_System)
                            ${H_PREFIX}/IClock.h ${H_PREFIX}/StdClock.h ${H_PREFIX}/Clock.h
                            ${H_PREFIX}/SharedResource.h ${H_PREFIX}/AdvanceableRunner.h
                            ${H_PREFIX}/QuitHandler.h
+                           ${H_PREFIX}/Barrier.h
     SOURCES                src/VariablesHandler.cpp src/LinearTask.cpp
-                           src/StdClock.cpp src/Clock.cpp src/QuitHandler.cpp
+                           src/StdClock.cpp src/Clock.cpp src/QuitHandler.cpp src/Barrier.cpp
     PUBLIC_LINK_LIBRARIES  BipedalLocomotion::ParametersHandler Eigen3::Eigen
     SUBDIRECTORIES         tests YarpImplementation
     )

--- a/src/System/include/BipedalLocomotion/System/Barrier.h
+++ b/src/System/include/BipedalLocomotion/System/Barrier.h
@@ -1,0 +1,47 @@
+/**
+ * @file Barrier.h
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef BIPEDAL_LOCOMOTION_SYSTEM_BARRIER_H
+#define BIPEDAL_LOCOMOTION_SYSTEM_BARRIER_H
+
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+
+namespace BipedalLocomotion
+{
+namespace System
+{
+/**
+ * Barrier provides a thread-coordination mechanism that allows an expected number of threads to
+ * block until the expected number of threads arrive at the barrier.
+ */
+class Barrier
+{
+public:
+    /**
+     * Constructor.
+     * @param counter initial value of the expected counter
+     */
+    explicit Barrier(const std::size_t counter);
+
+    /**
+     * Blocks this thread at the phase synchronization point until its phase completion step is run
+     */
+    void wait();
+
+private:
+    std::mutex m_mutex;
+    std::condition_variable m_cond;
+    std::size_t m_initialCount;
+    std::size_t m_count;
+    std::size_t m_generation;
+};
+} // namespace System
+} // namespace BipedalLocomotion
+
+#endif // BIPEDAL_LOCOMOTION_SYSTEM_BARRIER_H

--- a/src/System/src/Barrier.cpp
+++ b/src/System/src/Barrier.cpp
@@ -1,0 +1,40 @@
+/**
+ * @file Barrier.cpp
+ * @authors Giulio Romualdi
+ * @copyright 2021 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include <mutex>
+
+#include <BipedalLocomotion/System/Barrier.h>
+
+using namespace BipedalLocomotion::System;
+
+Barrier::Barrier(const std::size_t counter)
+    : m_initialCount(counter)
+    , m_count(counter)
+    , m_generation(0)
+{
+}
+
+void Barrier::wait()
+{
+    std::unique_lock lock{m_mutex};
+    const auto tempGeneration = m_generation;
+    if ((--m_count) == 1)
+    {
+        // all threads reached the barrier, so we can consider them synchronized
+        m_generation++;
+
+        // reset the counter
+        m_count = m_initialCount;
+
+        // notify the other threads
+        m_cond.notify_all();
+    } else
+    {
+        // waiting for the other threads
+        m_cond.wait(lock, [this, tempGeneration] { return tempGeneration != m_generation; });
+    }
+}


### PR DESCRIPTION
This PR introduces a synchronization mechanism for the `AdvanceableRunner` class.  The `Barrier` class has been developed,  the code was taken from [here](https://stackoverflow.com/questions/24465533/implementing-boostbarrier-in-c11).

c++20 introduces the barrier class however since this repo is based on c++17, the implementation of this new class was required. `Barrier` is then used in the `run` method of the advanceable runner to synchronize the startup of all the threads.